### PR TITLE
Feat: Add spinner component for loading state

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,5 @@
 export { default as Brand } from './brand/brand';
 export { default as ErrorFallback } from './error-fallback/error-fallback';
 export { default as OTPInput } from './otp-input/otp-input';
+export { default as Spinner } from './spinner/spinner';
+export { default as FullScreenSpinner } from './spinner/full-screen-spinner';

--- a/src/components/spinner/full-screen-spinner.tsx
+++ b/src/components/spinner/full-screen-spinner.tsx
@@ -1,21 +1,13 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 
 import Spinner from './spinner';
+import { styles } from './spinner.styles';
 
 const FullScreenSpinner: React.FC = () => (
-  <View style={styles.container}>
+  <View style={styles.fullScreenContainer}>
     <Spinner size="large" />
   </View>
 );
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    width: '100%',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});
 
 export default FullScreenSpinner;

--- a/src/components/spinner/full-screen-spinner.tsx
+++ b/src/components/spinner/full-screen-spinner.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+import Spinner from './spinner';
+
+const FullScreenSpinner: React.FC = () => (
+  <View style={styles.container}>
+    <Spinner size="large" />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default FullScreenSpinner;

--- a/src/components/spinner/spinner.styles.ts
+++ b/src/components/spinner/spinner.styles.ts
@@ -1,0 +1,14 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  fullScreenContainer: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { ActivityIndicator, View } from 'react-native';
 
+import { styles } from './spinner.styles';
 interface SpinnerProps {
-  size: 'small' | 'large';
+  size?: 'small' | 'large';
 }
 
 const Spinner: React.FC<SpinnerProps> = ({ size = 'small' }) => (
@@ -11,11 +12,8 @@ const Spinner: React.FC<SpinnerProps> = ({ size = 'small' }) => (
   </View>
 );
 
-const styles = StyleSheet.create({
-  container: {
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});
+Spinner.defaultProps = {
+  size: 'small',
+};
 
 export default Spinner;

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { ActivityIndicator, View, StyleSheet } from 'react-native';
 
-const Spinner: React.FC = () => (
+interface SpinnerProps {
+  size: 'small' | 'large';
+}
+
+const Spinner: React.FC<SpinnerProps> = ({ size = 'small' }) => (
   <View style={styles.container}>
-    <ActivityIndicator size="small" color="#000" />
+    <ActivityIndicator size={size} color="#000" />
   </View>
 );
 

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
+
+const Spinner: React.FC = () => (
+  <View style={styles.container}>
+    <ActivityIndicator size="small" color="#000" />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default Spinner;


### PR DESCRIPTION
### ✨ Add Spinner Component (React Native)

This PR introduces a reusable `Spinner` component for React Native, inspired by the [MERN boilerplate Spinner components](https://github.com/jalantechnologies/boilerplate-mern/tree/4b02697716aa3cadf0c272a40875383afa62ff85/src/apps/frontend/components/spinner).

#### 🛠 Features

- Uses React Native’s built-in `ActivityIndicator`.
- Accepts a `size` prop (`'small'` | `'large'`) to control the loader size.
- Default styling centers the spinner within its container.
- Simple and reusable loading indicator for various UI states.

#### 📦 Component API

```tsx
<Spinner size="large" />
<FullScreenSpinner/>
```

[Spinner Demo](https://www.loom.com/share/a838a5c418654da38dbe10970a479dbc)
