### PR TITLE
Feat: Add Button component

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -74,19 +74,16 @@ export const useKindStyles = () => {
     }),
     [ButtonKind.SECONDARY]: StyleSheet.create({
       base: {
-        backgroundColor: appTheme.colors.secondary as unknown as string,
         borderRadius: appTheme.radii.md,
+        borderColor: appTheme.colors.primary as unknown as string,
       },
       enabled: { opacity: 1 },
       disabled: { opacity: 0.5 },
-      text: { color: appTheme.colors.lightText },
+      text: { color: appTheme.colors.primary as unknown as string },
     }),
     [ButtonKind.TERTIARY]: StyleSheet.create({
       base: {
-        backgroundColor: appTheme.colors.tertiary as unknown as string,
-        borderRadius: appTheme.radii.md,
-        borderWidth: 1,
-        borderColor: appTheme.colors.primary as unknown as string,
+        borderWidth: 0,
       },
       enabled: { opacity: 1 },
       disabled: { opacity: 0.5 },

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -1,0 +1,55 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 40,
+    borderWidth: 1,
+    borderRadius: 8,
+    width: '100%',
+    gap: 8,
+  },
+  horizontalStack: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  enhancer: {
+    minWidth: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  activityIndicator: {
+    marginHorizontal: 4,
+  },
+  primary: {
+    backgroundColor: '#007bff',
+    borderColor: '#007bff',
+  },
+  secondary: {
+    backgroundColor: '#e0e0e0',
+    borderColor: '#e0e0e0',
+  },
+  tertiary: {
+    backgroundColor: 'transparent',
+    borderColor: 'transparent',
+  },
+  danger: {
+    backgroundColor: '#dc3545',
+    borderColor: '#dc3545',
+  },
+  compact: {
+    padding: 8,
+  },
+  default: {
+    padding: 10,
+  },
+  large: {
+    padding: 14,
+  },
+  mini: {
+    padding: 6,
+  },
+});

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -1,56 +1,121 @@
-import appTheme from 'boilerplate-react-native/src/app-theme';
-import { StyleSheet } from 'react-native';
+import { ButtonKind, ButtonSize } from 'boilerplate-react-native/src/types/button';
+import { useTheme } from 'native-base';
+import { StyleSheet, TextStyle, ViewStyle } from 'react-native';
 
-export const styles = StyleSheet.create({
-  activityIndicator: {
-    marginHorizontal: appTheme.space['1'],
-  },
-  button: {
-    alignItems: 'center',
-    borderRadius: appTheme.radii.md,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: appTheme.space['2'],
-    justifyContent: 'center',
-    minHeight: 40,
-    width: '100%',
-  },
-  compact: {
-    padding: appTheme.space['2'],
-  },
-  danger: {
-    backgroundColor: appTheme.colors.danger[600],
-    borderColor: appTheme.colors.danger[600],
-  },
-  default: {
-    padding: appTheme.space['3'],
-  },
-  enhancer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    minWidth: 24,
-  },
-  horizontalStack: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: appTheme.space['2'],
-  },
-  large: {
-    padding: appTheme.space['4'],
-  },
-  mini: {
-    padding: appTheme.space['1'],
-  },
-  primary: {
-    backgroundColor: appTheme.colors.primary,
-    borderColor: appTheme.colors.primary,
-  },
-  secondary: {
-    backgroundColor: appTheme.colors.secondary,
-    borderColor: appTheme.colors.secondary,
-  },
-  tertiary: {
-    backgroundColor: appTheme.colors.tertiary,
-    borderColor: appTheme.colors.tertiary,
-  },
-});
+export const useButtonStyles = () => {
+  const theme = useTheme();
+
+  return StyleSheet.create({
+    activityIndicator: {
+      marginHorizontal: theme.space['1'],
+    },
+    button: {
+      alignItems: 'center',
+      borderRadius: theme.radii.md,
+      borderWidth: 1,
+      flexDirection: 'row',
+      gap: theme.space['2'],
+      justifyContent: 'center',
+      minHeight: 40,
+      width: '100%',
+    },
+    compact: {
+      padding: theme.space['2'],
+    },
+    danger: {
+      backgroundColor: theme.colors.danger['900'],
+      borderColor: theme.colors.danger['600'],
+    },
+    default: {
+      padding: theme.space['3'],
+    },
+    enhancer: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      minWidth: 24,
+    },
+    horizontalStack: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: theme.space['2'],
+    },
+    large: {
+      padding: theme.space['4'],
+    },
+    mini: {
+      padding: theme.space['1'],
+    },
+    primary: {
+      backgroundColor: theme.colors.primary['900'],
+      borderColor: theme.colors.primary['600'],
+    },
+    secondary: {
+      backgroundColor: theme.colors.secondary['900'],
+      borderColor: theme.colors.secondary['600'],
+    },
+    tertiary: {
+      backgroundColor: theme.colors.tertiary['900'],
+      borderColor: theme.colors.tertiary['600'],
+    },
+  });
+};
+
+export const useKindStyles = () => {
+  const appTheme = useTheme();
+  return {
+    [ButtonKind.PRIMARY]: StyleSheet.create({
+      base: { backgroundColor: appTheme.colors.primary['900'], borderRadius: appTheme.radii.md },
+      enabled: { opacity: 1 },
+      disabled: { opacity: 0.5 },
+      text: { color: appTheme.colors.lightText['900'] },
+    }),
+    [ButtonKind.SECONDARY]: StyleSheet.create({
+      base: { backgroundColor: appTheme.colors.secondary['900'], borderRadius: appTheme.radii.md },
+      enabled: { opacity: 1 },
+      disabled: { opacity: 0.5 },
+      text: { color: appTheme.colors.lightText['900'] },
+    }),
+    [ButtonKind.TERTIARY]: StyleSheet.create({
+      base: {
+        backgroundColor: appTheme.colors.tertiary['900'],
+        borderRadius: appTheme.radii.md,
+        borderWidth: 1,
+        borderColor: appTheme.colors.primary['900'],
+      },
+      enabled: { opacity: 1 },
+      disabled: { opacity: 0.5 },
+      text: { color: appTheme.colors.primary['900'] },
+    }),
+    [ButtonKind.DANGER]: StyleSheet.create({
+      base: { backgroundColor: appTheme.colors.danger['900'], borderRadius: 8 },
+      enabled: { opacity: 1 },
+      disabled: { opacity: 0.5 },
+      text: { color: appTheme.colors.lightText['900'] },
+    }),
+  } as Record<
+    ButtonKind,
+    { base: ViewStyle; disabled: ViewStyle; enabled: ViewStyle; text: TextStyle }
+  >;
+};
+
+export const useSizeStyles = () => {
+  const appTheme = useTheme();
+  return {
+    [ButtonSize.COMPACT]: StyleSheet.create({
+      container: { padding: appTheme.space[1] },
+      text: { fontSize: appTheme.fontSizes.sm },
+    }),
+    [ButtonSize.DEFAULT]: StyleSheet.create({
+      container: { padding: appTheme.space[2] },
+      text: { fontSize: appTheme.fontSizes.md },
+    }),
+    [ButtonSize.LARGE]: StyleSheet.create({
+      container: { padding: appTheme.space[3] },
+      text: { fontSize: appTheme.fontSizes.lg },
+    }),
+    [ButtonSize.MINI]: StyleSheet.create({
+      container: { padding: appTheme.space['0.5'] },
+      text: { fontSize: appTheme.fontSizes.xs },
+    }),
+  } as Record<ButtonSize, { container: ViewStyle; text: TextStyle }>;
+};

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -2,28 +2,44 @@ import appTheme from 'boilerplate-react-native/src/app-theme';
 import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
+  activityIndicator: {
+    marginHorizontal: appTheme.space['1'],
+  },
   button: {
-    flexDirection: 'row',
     alignItems: 'center',
+    borderRadius: appTheme.radii.md,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: appTheme.space['2'],
     justifyContent: 'center',
     minHeight: 40,
-    borderWidth: 1,
-    borderRadius: appTheme.radii?.md || 8,
     width: '100%',
-    gap: appTheme.space?.['2'] || 8,
   },
-  horizontalStack: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: appTheme.space?.['2'] || 8,
+  compact: {
+    padding: appTheme.space['2'],
+  },
+  danger: {
+    backgroundColor: appTheme.colors.danger[600],
+    borderColor: appTheme.colors.danger[600],
+  },
+  default: {
+    padding: appTheme.space['3'],
   },
   enhancer: {
-    minWidth: 24,
     alignItems: 'center',
     justifyContent: 'center',
+    minWidth: 24,
   },
-  activityIndicator: {
-    marginHorizontal: appTheme.space?.['1'] || 4,
+  horizontalStack: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: appTheme.space['2'],
+  },
+  large: {
+    padding: appTheme.space['4'],
+  },
+  mini: {
+    padding: appTheme.space['1'],
   },
   primary: {
     backgroundColor: appTheme.colors.primary,
@@ -36,21 +52,5 @@ export const styles = StyleSheet.create({
   tertiary: {
     backgroundColor: appTheme.colors.tertiary,
     borderColor: appTheme.colors.tertiary,
-  },
-  danger: {
-    backgroundColor: appTheme.colors.danger?.[600] || '#dc3545',
-    borderColor: appTheme.colors.danger?.[600] || '#dc3545',
-  },
-  compact: {
-    padding: appTheme.space?.['2'] || 8,
-  },
-  default: {
-    padding: appTheme.space?.['3'] || 10,
-  },
-  large: {
-    padding: appTheme.space?.['4'] || 14,
-  },
-  mini: {
-    padding: appTheme.space?.['1'] || 6,
   },
 });

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -1,3 +1,4 @@
+import appTheme from 'boilerplate-react-native/src/app-theme';
 import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
@@ -7,14 +8,14 @@ export const styles = StyleSheet.create({
     justifyContent: 'center',
     minHeight: 40,
     borderWidth: 1,
-    borderRadius: 8,
+    borderRadius: appTheme.radii?.md || 8,
     width: '100%',
-    gap: 8,
+    gap: appTheme.space?.['2'] || 8,
   },
   horizontalStack: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: appTheme.space?.['2'] || 8,
   },
   enhancer: {
     minWidth: 24,
@@ -22,34 +23,34 @@ export const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   activityIndicator: {
-    marginHorizontal: 4,
+    marginHorizontal: appTheme.space?.['1'] || 4,
   },
   primary: {
-    backgroundColor: '#007bff',
-    borderColor: '#007bff',
+    backgroundColor: appTheme.colors.primary,
+    borderColor: appTheme.colors.primary,
   },
   secondary: {
-    backgroundColor: '#e0e0e0',
-    borderColor: '#e0e0e0',
+    backgroundColor: appTheme.colors.secondary,
+    borderColor: appTheme.colors.secondary,
   },
   tertiary: {
-    backgroundColor: 'transparent',
-    borderColor: 'transparent',
+    backgroundColor: appTheme.colors.tertiary,
+    borderColor: appTheme.colors.tertiary,
   },
   danger: {
-    backgroundColor: '#dc3545',
-    borderColor: '#dc3545',
+    backgroundColor: appTheme.colors.danger?.[600] || '#dc3545',
+    borderColor: appTheme.colors.danger?.[600] || '#dc3545',
   },
   compact: {
-    padding: 8,
+    padding: appTheme.space?.['2'] || 8,
   },
   default: {
-    padding: 10,
+    padding: appTheme.space?.['3'] || 10,
   },
   large: {
-    padding: 14,
+    padding: appTheme.space?.['4'] || 14,
   },
   mini: {
-    padding: 6,
+    padding: appTheme.space?.['1'] || 6,
   },
 });

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -46,16 +46,16 @@ export const useButtonStyles = () => {
       padding: theme.space['1'],
     },
     primary: {
-      backgroundColor: theme.colors.primary['900'],
-      borderColor: theme.colors.primary['600'],
+      backgroundColor: theme.colors.primary as unknown as string,
+      borderColor: theme.colors.primary as unknown as string,
     },
     secondary: {
-      backgroundColor: theme.colors.secondary['900'],
-      borderColor: theme.colors.secondary['600'],
+      backgroundColor: theme.colors.secondary as unknown as string,
+      borderColor: theme.colors.secondary as unknown as string,
     },
     tertiary: {
-      backgroundColor: theme.colors.tertiary['900'],
-      borderColor: theme.colors.tertiary['600'],
+      backgroundColor: theme.colors.tertiary as unknown as string,
+      borderColor: theme.colors.tertiary as unknown as string,
     },
   });
 };
@@ -64,33 +64,39 @@ export const useKindStyles = () => {
   const appTheme = useTheme();
   return {
     [ButtonKind.PRIMARY]: StyleSheet.create({
-      base: { backgroundColor: appTheme.colors.primary['900'], borderRadius: appTheme.radii.md },
-      enabled: { opacity: 1 },
-      disabled: { opacity: 0.5 },
-      text: { color: appTheme.colors.lightText['900'] },
-    }),
-    [ButtonKind.SECONDARY]: StyleSheet.create({
-      base: { backgroundColor: appTheme.colors.secondary['900'], borderRadius: appTheme.radii.md },
-      enabled: { opacity: 1 },
-      disabled: { opacity: 0.5 },
-      text: { color: appTheme.colors.lightText['900'] },
-    }),
-    [ButtonKind.TERTIARY]: StyleSheet.create({
       base: {
-        backgroundColor: appTheme.colors.tertiary['900'],
+        backgroundColor: appTheme.colors.primary as unknown as string,
         borderRadius: appTheme.radii.md,
-        borderWidth: 1,
-        borderColor: appTheme.colors.primary['900'],
       },
       enabled: { opacity: 1 },
       disabled: { opacity: 0.5 },
-      text: { color: appTheme.colors.primary['900'] },
+      text: { color: appTheme.colors.lightText },
+    }),
+    [ButtonKind.SECONDARY]: StyleSheet.create({
+      base: {
+        backgroundColor: appTheme.colors.secondary as unknown as string,
+        borderRadius: appTheme.radii.md,
+      },
+      enabled: { opacity: 1 },
+      disabled: { opacity: 0.5 },
+      text: { color: appTheme.colors.lightText },
+    }),
+    [ButtonKind.TERTIARY]: StyleSheet.create({
+      base: {
+        backgroundColor: appTheme.colors.tertiary as unknown as string,
+        borderRadius: appTheme.radii.md,
+        borderWidth: 1,
+        borderColor: appTheme.colors.primary as unknown as string,
+      },
+      enabled: { opacity: 1 },
+      disabled: { opacity: 0.5 },
+      text: { color: appTheme.colors.primary as unknown as string },
     }),
     [ButtonKind.DANGER]: StyleSheet.create({
       base: { backgroundColor: appTheme.colors.danger['900'], borderRadius: 8 },
       enabled: { opacity: 1 },
       disabled: { opacity: 0.5 },
-      text: { color: appTheme.colors.lightText['900'] },
+      text: { color: appTheme.colors.lightText },
     }),
   } as Record<
     ButtonKind,

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -60,7 +60,7 @@ const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
           </View>
         ) : null}
         <Text style={[kindStyle.text, sizeStyle.text]}>{children}</Text>
-        {isLoading && kind === ButtonKind.PRIMARY ? (
+        {isLoading ? (
           <ActivityIndicator color={kindStyle.text.color} style={styles.activityIndicator} />
         ) : null}
         {endEnhancer ? (

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,3 +1,4 @@
+import appTheme from 'boilerplate-react-native/src/app-theme';
 import { ButtonKind, ButtonSize } from 'boilerplate-react-native/src/types/button';
 import React from 'react';
 import {
@@ -11,7 +12,6 @@ import {
 } from 'react-native';
 
 import { styles } from './button.styles';
-
 interface ButtonProps {
   disabled?: boolean;
   endEnhancer?: React.ReactElement | string;
@@ -28,25 +28,30 @@ const kindStyles: Record<
   { base: ViewStyle; disabled: ViewStyle; enabled: ViewStyle; text: TextStyle }
 > = {
   [ButtonKind.PRIMARY]: {
-    base: { backgroundColor: '#007bff', borderRadius: 6 },
+    base: { backgroundColor: appTheme.colors.primary, borderRadius: 8 },
     enabled: { opacity: 1 },
     disabled: { opacity: 0.5 },
     text: { color: '#fff' },
   },
   [ButtonKind.SECONDARY]: {
-    base: { backgroundColor: '#e0e0e0', borderRadius: 6 },
+    base: { backgroundColor: appTheme.colors.secondary, borderRadius: 8 },
     enabled: { opacity: 1 },
     disabled: { opacity: 0.5 },
-    text: { color: '#333' },
+    text: { color: '#fff' },
   },
   [ButtonKind.TERTIARY]: {
-    base: { backgroundColor: 'transparent', borderRadius: 6 },
+    base: {
+      backgroundColor: appTheme.colors.background,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: appTheme.colors.primary,
+    },
     enabled: { opacity: 1 },
     disabled: { opacity: 0.5 },
-    text: { color: '#007bff' },
+    text: { color: appTheme.colors.primary },
   },
   [ButtonKind.DANGER]: {
-    base: { backgroundColor: '#dc3545', borderRadius: 6 },
+    base: { backgroundColor: appTheme.components.Button.variants.danger.bg, borderRadius: 8 },
     enabled: { opacity: 1 },
     disabled: { opacity: 0.5 },
     text: { color: '#fff' },

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,5 +1,5 @@
 import { ButtonKind, ButtonSize } from 'boilerplate-react-native/src/types/button';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import {
   TouchableOpacity,
   Text,
@@ -17,10 +17,9 @@ interface ButtonProps {
   onClick?: (event: GestureResponderEvent) => void;
   size?: ButtonSize;
   startEnhancer?: React.ReactElement | string;
-  children: React.ReactNode;
 }
 
-const Button: React.FC<ButtonProps> = ({
+const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
   children,
   disabled = false,
   endEnhancer = undefined,
@@ -37,8 +36,6 @@ const Button: React.FC<ButtonProps> = ({
   const sizeStyle = sizeStyles[size];
 
   const styles = useButtonStyles();
-
-  console.log(`Kind styles: ${JSON.stringify(kindStyle)}, kind: ${kind}`);
 
   return (
     <TouchableOpacity

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -107,11 +107,10 @@ const Button: React.FC<ButtonProps> = ({
             )}
           </View>
         ) : null}
+        <Text style={[kindStyle.text, sizeStyle.text]}>{children}</Text>
         {isLoading && kind === ButtonKind.PRIMARY ? (
           <ActivityIndicator color={kindStyle.text.color} style={styles.activityIndicator} />
-        ) : (
-          <Text style={[kindStyle.text, sizeStyle.text]}>{children}</Text>
-        )}
+        ) : null}
         {endEnhancer ? (
           <View style={styles.enhancer}>
             {typeof endEnhancer === 'string' ? (

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,139 @@
+import { ButtonKind, ButtonSize } from 'boilerplate-react-native/src/types/button';
+import React from 'react';
+import {
+  TouchableOpacity,
+  Text,
+  ActivityIndicator,
+  View,
+  GestureResponderEvent,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+
+import { styles } from './button.styles';
+
+interface ButtonProps {
+  disabled?: boolean;
+  endEnhancer?: React.ReactElement | string;
+  isLoading?: boolean;
+  kind?: ButtonKind;
+  onClick?: (event: GestureResponderEvent) => void;
+  size?: ButtonSize;
+  startEnhancer?: React.ReactElement | string;
+  children: React.ReactNode;
+}
+
+const kindStyles: Record<
+  ButtonKind,
+  { base: ViewStyle; disabled: ViewStyle; enabled: ViewStyle; text: TextStyle }
+> = {
+  [ButtonKind.PRIMARY]: {
+    base: { backgroundColor: '#007bff', borderRadius: 6 },
+    enabled: { opacity: 1 },
+    disabled: { opacity: 0.5 },
+    text: { color: '#fff' },
+  },
+  [ButtonKind.SECONDARY]: {
+    base: { backgroundColor: '#e0e0e0', borderRadius: 6 },
+    enabled: { opacity: 1 },
+    disabled: { opacity: 0.5 },
+    text: { color: '#333' },
+  },
+  [ButtonKind.TERTIARY]: {
+    base: { backgroundColor: 'transparent', borderRadius: 6 },
+    enabled: { opacity: 1 },
+    disabled: { opacity: 0.5 },
+    text: { color: '#007bff' },
+  },
+  [ButtonKind.DANGER]: {
+    base: { backgroundColor: '#dc3545', borderRadius: 6 },
+    enabled: { opacity: 1 },
+    disabled: { opacity: 0.5 },
+    text: { color: '#fff' },
+  },
+};
+
+const sizeStyles: Record<ButtonSize, { container: ViewStyle; text: TextStyle }> = {
+  [ButtonSize.COMPACT]: {
+    container: { padding: 8 },
+    text: { fontSize: 14 },
+  },
+  [ButtonSize.DEFAULT]: {
+    container: { padding: 10 },
+    text: { fontSize: 16 },
+  },
+  [ButtonSize.LARGE]: {
+    container: { padding: 14 },
+    text: { fontSize: 18 },
+  },
+  [ButtonSize.MINI]: {
+    container: { padding: 6 },
+    text: { fontSize: 12 },
+  },
+};
+
+const Button: React.FC<ButtonProps> = ({
+  children,
+  disabled = false,
+  endEnhancer = undefined,
+  isLoading = false,
+  kind = ButtonKind.PRIMARY,
+  onClick = undefined,
+  size = ButtonSize.DEFAULT,
+  startEnhancer = undefined,
+}) => {
+  const kindStyle = kindStyles[kind];
+  const sizeStyle = sizeStyles[size];
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.button,
+        kindStyle.base,
+        disabled || isLoading ? kindStyle.disabled : kindStyle.enabled,
+        sizeStyle.container,
+      ]}
+      disabled={disabled || isLoading}
+      onPress={onClick}
+      accessibilityRole="button"
+    >
+      <View style={styles.horizontalStack}>
+        {startEnhancer ? (
+          <View style={styles.enhancer}>
+            {typeof startEnhancer === 'string' ? (
+              <Text style={[kindStyle.text, sizeStyle.text]}>{startEnhancer}</Text>
+            ) : (
+              startEnhancer
+            )}
+          </View>
+        ) : null}
+        {isLoading && kind === ButtonKind.PRIMARY ? (
+          <ActivityIndicator color={kindStyle.text.color} style={styles.activityIndicator} />
+        ) : (
+          <Text style={[kindStyle.text, sizeStyle.text]}>{children}</Text>
+        )}
+        {endEnhancer ? (
+          <View style={styles.enhancer}>
+            {typeof endEnhancer === 'string' ? (
+              <Text style={[kindStyle.text, sizeStyle.text]}>{endEnhancer}</Text>
+            ) : (
+              endEnhancer
+            )}
+          </View>
+        ) : null}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+Button.defaultProps = {
+  disabled: false,
+  endEnhancer: undefined,
+  isLoading: false,
+  kind: ButtonKind.PRIMARY,
+  onClick: undefined,
+  size: ButtonSize.DEFAULT,
+  startEnhancer: undefined,
+};
+
+export default Button;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,4 +1,3 @@
-import appTheme from 'boilerplate-react-native/src/app-theme';
 import { ButtonKind, ButtonSize } from 'boilerplate-react-native/src/types/button';
 import React from 'react';
 import {
@@ -7,11 +6,9 @@ import {
   ActivityIndicator,
   View,
   GestureResponderEvent,
-  ViewStyle,
-  TextStyle,
 } from 'react-native';
 
-import { styles } from './button.styles';
+import { useButtonStyles, useKindStyles, useSizeStyles } from './button.styles';
 interface ButtonProps {
   disabled?: boolean;
   endEnhancer?: React.ReactElement | string;
@@ -23,60 +20,6 @@ interface ButtonProps {
   children: React.ReactNode;
 }
 
-const kindStyles: Record<
-  ButtonKind,
-  { base: ViewStyle; disabled: ViewStyle; enabled: ViewStyle; text: TextStyle }
-> = {
-  [ButtonKind.PRIMARY]: {
-    base: { backgroundColor: appTheme.colors.primary, borderRadius: 8 },
-    enabled: { opacity: 1 },
-    disabled: { opacity: 0.5 },
-    text: { color: '#fff' },
-  },
-  [ButtonKind.SECONDARY]: {
-    base: { backgroundColor: appTheme.colors.secondary, borderRadius: 8 },
-    enabled: { opacity: 1 },
-    disabled: { opacity: 0.5 },
-    text: { color: '#fff' },
-  },
-  [ButtonKind.TERTIARY]: {
-    base: {
-      backgroundColor: appTheme.colors.background,
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: appTheme.colors.primary,
-    },
-    enabled: { opacity: 1 },
-    disabled: { opacity: 0.5 },
-    text: { color: appTheme.colors.primary },
-  },
-  [ButtonKind.DANGER]: {
-    base: { backgroundColor: appTheme.components.Button.variants.danger.bg, borderRadius: 8 },
-    enabled: { opacity: 1 },
-    disabled: { opacity: 0.5 },
-    text: { color: '#fff' },
-  },
-};
-
-const sizeStyles: Record<ButtonSize, { container: ViewStyle; text: TextStyle }> = {
-  [ButtonSize.COMPACT]: {
-    container: { padding: 8 },
-    text: { fontSize: 14 },
-  },
-  [ButtonSize.DEFAULT]: {
-    container: { padding: 10 },
-    text: { fontSize: 16 },
-  },
-  [ButtonSize.LARGE]: {
-    container: { padding: 14 },
-    text: { fontSize: 18 },
-  },
-  [ButtonSize.MINI]: {
-    container: { padding: 6 },
-    text: { fontSize: 12 },
-  },
-};
-
 const Button: React.FC<ButtonProps> = ({
   children,
   disabled = false,
@@ -87,8 +30,15 @@ const Button: React.FC<ButtonProps> = ({
   size = ButtonSize.DEFAULT,
   startEnhancer = undefined,
 }) => {
+  const kindStyles = useKindStyles();
+  const sizeStyles = useSizeStyles();
+
   const kindStyle = kindStyles[kind];
   const sizeStyle = sizeStyles[size];
+
+  const styles = useButtonStyles();
+
+  console.log(`Kind styles: ${JSON.stringify(kindStyle)}, kind: ${kind}`);
 
   return (
     <TouchableOpacity

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as LabelLarge } from './typography/label-large';
 export { default as ParagraphMedium } from './typography/paragraph-medium';
 export { default as ParagraphSmall } from './typography/paragraph-small';
 export { default as FormControl } from './form-control/form-control';
+export { default as Button } from './button/button';

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,0 +1,13 @@
+export enum ButtonKind {
+  PRIMARY = 'primary',
+  SECONDARY = 'secondary',
+  TERTIARY = 'tertiary',
+  DANGER = 'danger',
+}
+
+export enum ButtonSize {
+  COMPACT = 'compact',
+  DEFAULT = 'default',
+  LARGE = 'large',
+  MINI = 'mini',
+}


### PR DESCRIPTION
## ✨ Add Reusable `Button` Component (React Native)

This PR introduces a flexible, themeable `Button` component for React Native, inspired by the [MERN boilerplate Button](https://github.com/jalantechnologies/boilerplate-mern/tree/4b02697716aa3cadf0c272a40875383afa62ff85/src/apps/frontend/components/button). It supports multiple color “kinds,” sizes, loading states, and optional enhancers.

---

### 🛠 Features

- **Loading state** using React Native’s `ActivityIndicator` for primary buttons  
- **Disabled state** with opacity styling  
- **Customizable “kind”** (PRIMARY, SECONDARY, TERTIARY, DANGER)  
- **Four sizes** (MINI, COMPACT, DEFAULT, LARGE)  
- **Optional start/end enhancers** (icons, text, or React elements)  
- **Accessible** via `accessibilityRole="button"`

---

### 📦 Usage Example

```tsx
import { Button, ButtonKind, ButtonSize } from 'boilerplate-react-native/src/types/button';

<Button
  kind={ButtonKind.SECONDARY}
  size={ButtonSize.LARGE}
  isLoading={false}
  disabled={false}
  startEnhancer="🚀"
  endEnhancer={<Icon name="arrow-right" />}
  onClick={() => console.log('Pressed!')}
>
  Launch
</Button>
```

Screenshot:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/3febc3ae-6a68-4cf1-a35d-87e2664b496b" />

