### PR TITLE
ci: add strict version check for package.json in PRs

### DIFF
--- a/.github/scripts/check-version.py
+++ b/.github/scripts/check-version.py
@@ -18,14 +18,13 @@ def get_main_version():
         main_pkg_json = json.loads(result.stdout)
         return main_pkg_json['version']
     except subprocess.CalledProcessError:
-        print("❌ ERROR: Cannot access 'main:package.json'.")
-        print("💡 Did you fetch full history in GitHub Actions? Set fetch-depth: 0 in checkout step.")
+        print("ERROR: Cannot access 'main:package.json'.")
         sys.exit(1)
     except json.JSONDecodeError:
-        print("❌ ERROR: Unable to parse JSON from main:package.json.")
+        print("ERROR: Unable to parse JSON from main:package.json.")
         sys.exit(1)
     except Exception as e:
-        print(f"❌ Unexpected error: {e}")
+        print(f"Unexpected error: {e}")
         sys.exit(1)
 
 

--- a/.github/scripts/check-version.py
+++ b/.github/scripts/check-version.py
@@ -10,7 +10,7 @@ def get_pr_version():
 def get_main_version():
     try:
         result = subprocess.run(
-            ['git', 'show', 'main:package.json'],
+            ['git', 'show', 'origin/main:package.json'],
             capture_output=True,
             text=True,
             check=True

--- a/.github/scripts/check-version.py
+++ b/.github/scripts/check-version.py
@@ -9,12 +9,25 @@ def get_pr_version():
 
 def get_main_version():
     try:
-        result = subprocess.run(['git', 'show', 'main:package.json'], capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            ['git', 'show', 'main:package.json'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
         main_pkg_json = json.loads(result.stdout)
         return main_pkg_json['version']
-    except Exception as e:
-        print(f"Error fetching main branch package.json: {e}")
+    except subprocess.CalledProcessError:
+        print("❌ ERROR: Cannot access 'main:package.json'.")
+        print("💡 Did you fetch full history in GitHub Actions? Set fetch-depth: 0 in checkout step.")
         sys.exit(1)
+    except json.JSONDecodeError:
+        print("❌ ERROR: Unable to parse JSON from main:package.json.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        sys.exit(1)
+
 
 def version_tuple(v):
     return tuple(map(int, (v.split("."))))

--- a/.github/scripts/check-version.py
+++ b/.github/scripts/check-version.py
@@ -1,0 +1,34 @@
+import json
+import subprocess
+import sys
+
+def get_pr_version():
+    with open('package.json') as f:
+        data = json.load(f)
+        return data['version']
+
+def get_main_version():
+    try:
+        result = subprocess.run(['git', 'show', 'main:package.json'], capture_output=True, text=True, check=True)
+        main_pkg_json = json.loads(result.stdout)
+        return main_pkg_json['version']
+    except Exception as e:
+        print(f"Error fetching main branch package.json: {e}")
+        sys.exit(1)
+
+def version_tuple(v):
+    return tuple(map(int, (v.split("."))))
+
+def main():
+    pr_version = get_pr_version()
+    main_version = get_main_version()
+
+    if version_tuple(pr_version) <= version_tuple(main_version):
+        print(f"ERROR: The package.json version in the PR must be strictly greater than the version in the main branch.")
+        print(f"Current PR version: {pr_version}, Main branch version: {main_version}")
+        sys.exit(1)
+    else:
+        print(f"Version check passed: PR version {pr_version} > main version {main_version}")
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: '3.x'
 
     - name: Fetch main branch
-      run: git fetch origin main
+      run: git fetch origin main:main
 
     - name: Run version comparison script
       run: python3 .github/scripts/check-version.py

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,24 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Run version comparison script
+      run: python3 .github/scripts/check-version.py

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -14,7 +14,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0 
-        ref: ${{ github.head_ref }}
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -22,7 +21,7 @@ jobs:
         python-version: '3.x'
 
     - name: Fetch main branch
-      run: git fetch origin main:main
+      run: git fetch origin main
 
     - name: Run version comparison script
       run: python3 .github/scripts/check-version.py

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: '3.x'
 
     - name: Fetch main branch
-  run: git fetch origin main:main
+      run: git fetch origin main:main
 
     - name: Run version comparison script
       run: python3 .github/scripts/check-version.py

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0 
+        ref: ${{ github.head_ref }}
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -21,5 +21,8 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Fetch main branch
+  run: git fetch origin main:main
+
     - name: Run version comparison script
       run: python3 .github/scripts/check-version.py

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-react-native",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-react-native",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
### Summary

This pull request adds a CI check that ensures the `version` field in the `package.json` file of a pull request is strictly greater than the version in the `main` branch. This enforces proper semantic versioning and prevents unintentional overwrites or deployment issues.

---

### What’s Implemented

- A script that:
  - Retrieves `package.json` version from the PR branch.
  - Retrieves `package.json` version from the `main` branch.
  - Compares the versions and ensures the PR version is strictly greater.
  - Check-version script added to `.github/scripts/`
- CI job added to the GitHub Actions workflow:
  - Fails with a clear error if versioning rules are not met.
  - Passes if version is correctly incremented.
  - GitHub Actions workflow added to `.github/workflows/`

---

### Error Handling

If the PR version is not greater, CI logs display a message with the respective versions.

### Testing
Tested on feature branch by creating a dummy PR to main.

