### PR TITLE
Feat: Add CI Check to Enforce Strict Version Increment in package.json

### DIFF
--- a/.github/scripts/version_check.py
+++ b/.github/scripts/version_check.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+import sys
+from packaging.version import Version
+
+def get_pr_version():
+    with open('package.json') as f:
+        data = json.load(f)
+        return data['version']
+
+def get_main_version():
+    try:
+        result = subprocess.run(
+            ['git', 'show', 'main:package.json'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        main_pkg_json = json.loads(result.stdout)
+        return main_pkg_json['version']
+    except subprocess.CalledProcessError:
+        print("ERROR: Cannot access 'main:package.json'.")
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print("ERROR: Unable to parse JSON from main:package.json.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+        sys.exit(1)
+
+
+def main():
+    pr_version = get_pr_version()
+    main_version = get_main_version()
+
+    if Version(pr_version) <= Version(main_version):
+        print(f"ERROR: The package.json version in the PR must be strictly greater than the version in the main branch.")
+        print(f"Current PR version: {pr_version}, Main branch version: {main_version}")
+        sys.exit(1)
+    else:
+        print(f"Version check passed: PR version {pr_version} > main version {main_version}")
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/version_check.py
+++ b/.github/scripts/version_check.py
@@ -11,7 +11,7 @@ def get_pr_version():
 def get_main_version():
     try:
         result = subprocess.run(
-            ['git', 'show', 'main:package.json'],
+            ['git', 'show', 'origin/main:package.json'],
             capture_output=True,
             text=True,
             check=True

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,29 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    
+    - name: Install dependencies
+      run: pip install packaging
+
+    - name: Run version comparison script
+      run: python3 .github/scripts/version_check.py

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-react-native",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
# Feat: Add CI Check to Enforce Strict Version Increment in `package.json`

## Why is this change needed?
This PR introduces a GitHub Actions-based CI check to **enforce strict version increments** in `package.json` on every pull request targeting the `main` branch.  
It ensures proper semantic versioning and prevents unintentional version downgrades or duplicates during deployment.

## What does this PR do?
- Adds a Python script at `.github/scripts/check_version.py` to compare the PR version with the `main` branch version.
- Integrates this script into a GitHub Actions workflow `.github/workflows/version-check.yml`.
- Validates that the `package.json` version in the PR is **strictly greater** than the version in the main branch.

## How was this tested?
- ✅ Tested with PR version greater than main (pass)
- ❌ Tested with PR version equal or less than main (fail)
- Included meaningful log messages in the CI pipeline output

## Screenshot
![Screenshot 2025-06-03 125050](https://github.com/user-attachments/assets/41d2cb50-22dd-4b76-99a5-7d3ed9f2e5da)

