### PR TITLE
Feat: Add Support for Variable Package Names via Build Flavors and GitHub Action

### DIFF
--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -83,6 +83,14 @@ jobs:
           gem install bundler
           bundle install
 
+      - name: Patch Boost Podspec
+        run: |
+          BOOST_PODSPEC="node_modules/react-native/third-party-podspecs/boost.podspec"
+          # Use a GitHub-hosted archive instead of the broken checksum tarball
+          sed -i.bak 's|https://.*boost_1_76_0.tar.gz|https://github.com/boostorg/boost/archive/refs/tags/boost-1.76.0.tar.gz|' $BOOST_PODSPEC
+          # Replace the checksum with a blank (to skip validation)
+          sed -i '' '/checksum/d' $BOOST_PODSPEC || true
+
       - name: Clean and Reinstall Pods (After Boost Override)
         working-directory: ios
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -110,6 +110,7 @@ jobs:
             --scheme "Boilerplate" \
             --export_method "development" \
             --output_name "Boilerplate-Prod.ipa"
+            --allowProvisioningUpdates
 
       - name: List Xcode Schemes
         run: |
@@ -128,10 +129,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ios-production-ipa
-          path: ios/YourApp-Prod.ipa
+          path: ios/Boilerplate-Prod.ipa
 
       - name: Upload Dev IPA
         uses: actions/upload-artifact@v4
         with:
           name: ios-dev-ipa
-          path: ios/YourApp-Dev-${{ env.BUILD_HASH }}.ipa
+          path: ios/Boilerplate-Dev-${{ env.BUILD_HASH }}.ipa

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -82,10 +82,11 @@ jobs:
           cd ios
           gem install bundler
           bundle install
-          
+
       - name: Clean and Install Pods
         working-directory: ios
         run: |
+          pod cache clean --all
           rm -rf Pods
           rm -f Podfile.lock
           pod install --repo-update

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '22'
+          node-version: '22.13.1'
 
       - name: Install Dependencies
         run: yarn install
@@ -82,15 +82,19 @@ jobs:
           bundle exec fastlane gym \
             --scheme "Boilerplate" \
             --export_method "development" \
-            --output_name "YourApp-Prod.ipa"
+            --output_name "Boilerplate-Prod.ipa"
+
+      - name: List Xcode Schemes
+        run: |
+          xcodebuild -list -workspace ios/YourApp.xcworkspace
 
       - name: Build Dev IPA with BUILD_HASH
         run: |
           cd ios
           bundle exec fastlane gym \
-            --scheme "YourApp" \
+            --scheme "Boilerplate" \
             --export_method "development" \
-            --output_name "YourApp-Dev-${BUILD_HASH}.ipa" \
+            --output_name "Boilerplate-Dev-${BUILD_HASH}.ipa" \
             --xcargs "BUILD_HASH=${BUILD_HASH}"
 
       - name: Upload Production IPA

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -83,13 +83,14 @@ jobs:
           gem install bundler
           bundle install
 
-      - name: Clean and Reinstall Pods
+      - name: Clean and Reinstall Pods (After Boost Override)
         working-directory: ios
         run: |
+          pod cache clean --all
           rm -rf Pods
           rm -f Podfile.lock
+          pod deintegrate
           pod install --repo-update --clean-install
-
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -82,7 +82,13 @@ jobs:
           cd ios
           gem install bundler
           bundle install
-          pod install
+          
+      - name: Clean and Install Pods
+        working-directory: ios
+        run: |
+          rm -rf Pods
+          rm -f Podfile.lock
+          pod install --repo-update
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -6,54 +6,54 @@ on:
       - main
 
 jobs:
-  android:
-    runs-on: ubuntu-latest
-    env:
-      BUILD_HASH: pr${{ github.event.pull_request.number }}
+  # android:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     BUILD_HASH: pr${{ github.event.pull_request.number }}
 
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v3
 
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
 
-      - name: Write local.properties with BUILD_HASH
-        run: echo "BUILD_HASH=${BUILD_HASH}" > android/local.properties
+  #     - name: Write local.properties with BUILD_HASH
+  #       run: echo "BUILD_HASH=${BUILD_HASH}" > android/local.properties
 
-      - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+  #     - name: Set up Gradle
+  #       uses: gradle/gradle-build-action@v2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.13.1'
+  #     - name: Set up Node.js
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: '22.13.1'
 
-      - name: Install Dependencies
-        run: yarn install
+  #     - name: Install Dependencies
+  #       run: yarn install
 
-      - name: Build Production APK
-        run: ./gradlew assembleProductionDebug
-        working-directory: android
+  #     - name: Build Production APK
+  #       run: ./gradlew assembleProductionDebug
+  #       working-directory: android
 
-      - name: Build Dev APK
-        run: ./gradlew assembleDevDebug
-        working-directory: android
+  #     - name: Build Dev APK
+  #       run: ./gradlew assembleDevDebug
+  #       working-directory: android
 
-      - name: Upload Production APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-production-apk
-          path: android/app/build/outputs/apk/production/debug/app-production-debug.apk
+  #     - name: Upload Production APK
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: android-production-apk
+  #         path: android/app/build/outputs/apk/production/debug/app-production-debug.apk
 
-      - name: Upload Dev APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-dev-apk
-          path: android/app/build/outputs/apk/dev/debug/app-dev-debug.apk
+  #     - name: Upload Dev APK
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: android-dev-apk
+  #         path: android/app/build/outputs/apk/dev/debug/app-dev-debug.apk
 
   ios:
     runs-on: macos-latest
@@ -89,7 +89,7 @@ jobs:
           pod cache clean --all
           rm -rf Pods
           rm -f Podfile.lock
-          pod install --repo-update --verbose --sources=https://github.com/CocoaPods/Specs.git
+          pod install --repo-update
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -82,7 +82,7 @@ jobs:
           cd ios
           gem install bundler
           bundle install
-          pod install
+          pod install --repo-update
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -82,7 +82,7 @@ jobs:
           cd ios
           gem install bundler
           bundle install
-          pod install --repo-update
+          pod install
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -1,4 +1,4 @@
-name: Build Dev APK
+name: Build Android & iOS Dual Flavors
 
 on:
   pull_request:
@@ -6,8 +6,10 @@ on:
       - main
 
 jobs:
-  build:
+  android:
     runs-on: ubuntu-latest
+    env:
+      BUILD_HASH: pr${{ github.event.pull_request.number }}
 
     steps:
       - name: Checkout Code
@@ -19,10 +21,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Write local.properties with build hash
-        run: |
-          echo "BUILD_HASH=pr${{ github.event.pull_request.number }}" > android/local.properties
-
+      - name: Write local.properties with BUILD_HASH
+        run: echo "BUILD_HASH=${BUILD_HASH}" > android/local.properties
 
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
@@ -30,17 +30,77 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '22.13.1'
+          node-version: '22'
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: yarn install
+
+      - name: Build Production APK
+        run: ./gradlew assembleProductionDebug
+        working-directory: android
 
       - name: Build Dev APK
         run: ./gradlew assembleDevDebug
         working-directory: android
 
+      - name: Upload Production APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-production-apk
+          path: android/app/build/outputs/apk/production/debug/app-production-debug.apk
+
       - name: Upload Dev APK
         uses: actions/upload-artifact@v4
         with:
-          name: dev-apk
+          name: android-dev-apk
           path: android/app/build/outputs/apk/dev/debug/app-dev-debug.apk
+
+  ios:
+    runs-on: macos-latest
+    env:
+      BUILD_HASH: pr${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby & Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+
+      - name: Install CocoaPods
+        run: |
+          cd ios
+          gem install bundler
+          bundle install
+          pod install
+
+      - name: Build Production IPA
+        run: |
+          cd ios
+          bundle exec fastlane gym \
+            --scheme "Boilerplate" \
+            --export_method "development" \
+            --output_name "YourApp-Prod.ipa"
+
+      - name: Build Dev IPA with BUILD_HASH
+        run: |
+          cd ios
+          bundle exec fastlane gym \
+            --scheme "YourApp" \
+            --export_method "development" \
+            --output_name "YourApp-Dev-${BUILD_HASH}.ipa" \
+            --xcargs "BUILD_HASH=${BUILD_HASH}"
+
+      - name: Upload Production IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-production-ipa
+          path: ios/YourApp-Prod.ipa
+
+      - name: Upload Dev IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-dev-ipa
+          path: ios/YourApp-Dev-${{ env.BUILD_HASH }}.ipa

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -69,6 +69,14 @@ jobs:
         with:
           ruby-version: '3.0'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.13.1'
+
+      - name: Install Dependencies
+        run: yarn install
+
       - name: Install CocoaPods
         run: |
           cd ios

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -86,8 +86,10 @@ jobs:
       - name: Clean and Reinstall Pods
         working-directory: ios
         run: |
-          pod deintegrate
+          rm -rf Pods
+          rm -f Podfile.lock
           pod install --repo-update --clean-install
+
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -86,14 +86,8 @@ jobs:
       - name: Clean and Reinstall Pods
         working-directory: ios
         run: |
-          pod cache clean --all
-          rm -rf Pods
-          rm -f Podfile.lock
-          rm -rf ~/Library/Caches/CocoaPods
-          rm -rf ~/Library/Developer/Xcode/DerivedData/*
           pod deintegrate
-          pod install --repo-update
-
+          pod install --repo-update --clean-install
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -78,27 +78,30 @@ jobs:
         run: yarn install
 
       - name: Install CocoaPods
+        working-directory: ios
         run: |
-          cd ios
           gem install bundler
           bundle install
-
-      - name: Patch Boost Podspec
+    
+      - name: Patch Boost Podspec with Custom Source
+        working-directory: node_modules/react-native/third-party-podspecs
         run: |
-          BOOST_PODSPEC="node_modules/react-native/third-party-podspecs/boost.podspec"
-          # Use a GitHub-hosted archive instead of the broken checksum tarball
-          sed -i.bak 's|https://.*boost_1_76_0.tar.gz|https://github.com/boostorg/boost/archive/refs/tags/boost-1.76.0.tar.gz|' $BOOST_PODSPEC
-          # Replace the checksum with a blank (to skip validation)
-          sed -i '' '/checksum/d' $BOOST_PODSPEC || true
+          awk '
+          BEGIN { found=0 }
+          /spec.source/ { found=1; print "  spec.source = { :http => '\''https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.gz'\'', :sha256 => '\''7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca'\'' }"; next }
+          found && /^\s*:sha256/ { next }
+          found && /\}/ { found=0; next }
+          { print }
+          ' boost.podspec > boost.podspec.tmp && mv boost.podspec.tmp boost.podspec
 
-      - name: Clean and Reinstall Pods (After Boost Override)
+      - name: Clean and install Pods
         working-directory: ios
         run: |
           pod cache clean --all
           rm -rf Pods
           rm -f Podfile.lock
           pod deintegrate
-          pod install --repo-update --clean-install
+          pod install --repo-update
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -1,0 +1,46 @@
+name: Build Dev APK
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Write local.properties with build hash
+        run: |
+          echo "BUILD_HASH=pr${{ github.event.pull_request.number }}" > android/local.properties
+
+
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.13.1'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Dev APK
+        run: ./gradlew assembleDevDebug
+        working-directory: android
+
+      - name: Upload Dev APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-apk
+          path: android/app/build/outputs/apk/dev/debug/app-dev-debug.apk

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -89,7 +89,7 @@ jobs:
           pod cache clean --all
           rm -rf Pods
           rm -f Podfile.lock
-          pod install --repo-update
+          pod install --repo-update --verbose --sources=https://github.com/CocoaPods/Specs.git
 
       - name: Build Production IPA
         run: |

--- a/.github/workflows/build_dev_apk.yml
+++ b/.github/workflows/build_dev_apk.yml
@@ -83,13 +83,17 @@ jobs:
           gem install bundler
           bundle install
 
-      - name: Clean and Install Pods
+      - name: Clean and Reinstall Pods
         working-directory: ios
         run: |
           pod cache clean --all
           rm -rf Pods
           rm -f Podfile.lock
+          rm -rf ~/Library/Caches/CocoaPods
+          rm -rf ~/Library/Developer/Xcode/DerivedData/*
+          pod deintegrate
           pod install --repo-update
+
 
       - name: Build Production IPA
         run: |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,6 +102,28 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    flavorDimensions "version"
+
+    productFlavors {
+        production {
+            dimension "version"
+            applicationId "com.bettrsw.boilerplate"
+        }
+        test {
+            dimension "version"
+
+            // Read BUILD_HASH from local.properties
+            def localProperties = new Properties()
+            def localFile = rootProject.file("local.properties")
+            if (localFile.exists()) {
+                localProperties.load(new FileInputStream(localFile))
+            }
+
+            def buildHash = localProperties.getProperty("BUILD_HASH") ?: "test"
+
+            applicationId "com.bettrsw.boilerplate.test.${buildHash}"
+        }
+    }
 }
 
 dependencies {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,7 +109,7 @@ android {
             dimension "version"
             applicationId "com.bettrsw.boilerplate"
         }
-        test {
+        dev {
             dimension "version"
 
             // Read BUILD_HASH from local.properties

--- a/ios/Boilerplate.xcodeproj/project.pbxproj
+++ b/ios/Boilerplate.xcodeproj/project.pbxproj
@@ -448,6 +448,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 136CAD3D51CF1761349DC114 /* Pods-Boilerplate-BoilerplateTests.debug.xcconfig */;
 			buildSettings = {
+				BUILD_HASH = prod;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -465,7 +466,7 @@
 					"-lc++",
 					"$(inherited)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bettrsw.boilerplate.$(BUILD_HASH);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Boilerplate.app/Boilerplate";
 			};
@@ -475,6 +476,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 37B8FAD1B1A1C50F4665E560 /* Pods-Boilerplate-BoilerplateTests.release.xcconfig */;
 			buildSettings = {
+				BUILD_HASH = prod;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = BoilerplateTests/Info.plist;
@@ -499,6 +501,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 50DCB761BC48FA9428392835 /* Pods-Boilerplate.debug.xcconfig */;
 			buildSettings = {
+				BUILD_HASH = prod;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -528,6 +531,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A6B4F8F7F01641D64DD7ABAB /* Pods-Boilerplate.release.xcconfig */;
 			buildSettings = {
+				BUILD_HASH = prod;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -554,6 +558,7 @@
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_HASH = prod;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
@@ -627,6 +632,7 @@
 		83CBBA211A601CBA00E9B192 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_HASH = prod;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";

--- a/ios/Boilerplate.xcodeproj/project.pbxproj
+++ b/ios/Boilerplate.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 					"-lc++",
 					"$(inherited)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bettrsw.boilerplate.$(BUILD_HASH);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bettrsw.boilerplate.$(BUILD_HASH)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Boilerplate.app/Boilerplate";
 			};

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "fastlane"
+gem "cocoapods"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -45,7 +45,7 @@ target 'Boilerplate' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'DatadogCore', '~> 2.27.0'  # Explicitly match the dependency
+  pod 'DatadogCore', '~> 2.27.0' 
   pod 'DatadogSDKReactNative', :path => '../node_modules/@datadog/mobile-react-native'
 
   target 'BoilerplateTests' do

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -45,6 +45,9 @@ target 'Boilerplate' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
+  pod 'DatadogCore', '~> 2.27.0'  # Explicitly match the dependency
+  pod 'DatadogSDKReactNative', :path => '../node_modules/@datadog/mobile-react-native'
+
   target 'BoilerplateTests' do
     inherit! :complete
     # Pods for testing

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,7 +30,7 @@ target 'Boilerplate' do
 
   # Flags change depending on the env values.
   flags = get_default_flags()
-
+  pod 'boost', :http => 'https://dl.bintray.com/boostorg/release/1.76.0/source/boost_1_76_0.tar.gz'
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,7 +30,7 @@ target 'Boilerplate' do
 
   # Flags change depending on the env values.
   flags = get_default_flags()
-  pod 'boost', :http => 'https://dl.bintray.com/boostorg/release/1.76.0/source/boost_1_76_0.tar.gz'
+  
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -45,9 +45,6 @@ target 'Boilerplate' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'DatadogCore', '~> 2.27.0' 
-  pod 'DatadogSDKReactNative', :path => '../node_modules/@datadog/mobile-react-native'
-
   target 'BoilerplateTests' do
     inherit! :complete
     # Pods for testing


### PR DESCRIPTION
# feat: Add Support for Variable Package names for ease in Testing

## Why is this change needed?

This PR resolves **issue #21** by allowing developers and testers to install both the **production** and **development** versions of the mobile app **simultaneously**.

Currently, using the same `applicationId` (package name) for both environments causes one version to overwrite the other, complicating internal testing. This enhancement ensures smoother development workflows by leveraging **Gradle build flavors** and **unique build hashes**, enabling parallel installations for production and internal testing builds.

---

## What does this PR do?

- ✅ Adds **build flavor support** in `android/app/build.gradle`:
  - **`production`**: retains the standard `applicationId`
  - **`dev`**: uses a dynamic `applicationId` with a unique `BUILD_HASH` suffix

- ✅ Reads the `BUILD_HASH` value from a new `local.properties` file

- ✅ Adds a new **GitHub Actions workflow** (`build_dev_apk.yml`) to:
  - Automatically generate a `BUILD_HASH` from the pull request number
  - Inject it into `local.properties`
  - Build a development APK using the `dev` flavor
  - Upload the generated APK as an **artifact** for QA/testing

- ✅ Ensures all log messages in the CI pipeline are clear and meaningful for debugging and traceability

---

## ✅ How was this tested?

- ✅ Installed both **production** and **dev** APKs on the same device – both coexist independently
- ✅ Verified the applicationID of both the applications.
- ✅ GitHub Action correctly generates and uses `BUILD_HASH` for the dev flavor
- ✅ APK builds successfully via CI and is uploaded as an artifact

---

## 📁 Files Changed

- `android/app/build.gradle`:
  - Added flavor dimensions and productFlavors block
  - Variable applicationId for dev flavor using `local.properties`

- `.github/workflows/build_dev_apk.yml`:
  - CI setup for dev APK builds
  - Generates and injects `BUILD_HASH`
  - Uploads built dev APK as artifact

---

## 📸 Screenshots
![Screenshot from 2025-06-05 16-18-49](https://github.com/user-attachments/assets/b7f27f1f-8a20-4f3f-bf08-b82b951fb7cf)
![Screenshot from 2025-06-05 16-21-42](https://github.com/user-attachments/assets/5f2a1926-29d3-4519-980b-92e50df76a66)


