### PR TITLE
ci: test Firebase deploy workflow

### DIFF
--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -1,0 +1,81 @@
+name: Deploy PR Build to Firebase
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  build-and-deploy:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      - name: Install Fastlane
+        run: gem install fastlane
+
+      - name: Set up environment
+        run: |
+          echo "FIREBASE_CLI_TOKEN=${{ secrets.FIREBASE_CLI_TOKEN }}" >> $GITHUB_ENV
+          echo "FIREBASE_APP_ID=1:715635897715:android:0be885c6b27f7c99de0106" >> $GITHUB_ENV
+
+      - name: Build & Deploy to Firebase App Distribution
+        run: |
+          cd android
+          fastlane pr_deploy pr_number=${{ github.event.pull_request.number }} pr_title="${{ github.event.pull_request.title }}"
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const releaseUrl = "https://console.firebase.google.com/project/react-native-boilerplate-14974/appdistribution/app/1:715635897715:android:0be885c6b27f7c99de0106/releases";  // replace
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀 Deployed PR #${prNumber} to Firebase App Distribution.\n\n🔗 [View Releases](${releaseUrl})`
+            })
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Firebase CLI and jq
+        run: |
+          npm install -g firebase-tools
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Cleanup Firebase App Distribution Releases
+        env:
+          FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+          FIREBASE_APP_ID: 1:715635897715:android:0be885c6b27f7c99de0106  # Your app ID
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Fetching all releases for app $FIREBASE_APP_ID"
+          releases_json=$(firebase appdistribution:releases:list --app "$FIREBASE_APP_ID" --json --token "$FIREBASE_CLI_TOKEN")
+
+          echo "Searching for releases matching PR #$PR_NUMBER"
+          release_ids=$(echo "$releases_json" | jq -r --arg pr_num "$PR_NUMBER" '.releases[] | select(.releaseNotes | contains("PR #\($pr_num)")) | .id')
+
+          if [ -z "$release_ids" ]; then
+            echo "No releases found for PR #$PR_NUMBER"
+          else
+            for release_id in $release_ids; do
+              echo "Deleting release $release_id linked to PR #$PR_NUMBER"
+              firebase appdistribution:releases:delete --app "$FIREBASE_APP_ID" --release-id "$release_id" --token "$FIREBASE_CLI_TOKEN" --yes
+            done
+          fi

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install Firebase CLI and jq
         run: |
-          npm install -g firebase-tools@latest
+          curl -sL https://firebase.tools | bash
           sudo apt-get update
           sudo apt-get install -y jq
 

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -11,6 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.13.1'
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Install dependencies
+        run: yarn install
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -33,11 +33,14 @@ jobs:
         with:
           ruby-version: '3.1'
 
-      - name: Install Fastlane
-        run: gem install fastlane
+      - name: Install bundler
+        run: gem install bundler
 
-      - name: Install fastlane plugins
-        run: fastlane install_plugins
+      - name: Install gems and fastlane plugins
+        working-directory: android
+        run: |
+          bundle install
+          bundle exec fastlane install_plugins
 
       - name: Set up environment
         run: |
@@ -45,9 +48,8 @@ jobs:
           echo "FIREBASE_APP_ID=1:715635897715:android:0be885c6b27f7c99de0106" >> $GITHUB_ENV
 
       - name: Build & Deploy to Firebase App Distribution
-        run: |
-          cd android
-          fastlane android pr_deploy pr_number:"${{ github.event.pull_request.number }}" pr_title:"${{ github.event.pull_request.title }}"
+        working-directory: android
+        run: bundle exec fastlane android pr_deploy pr_number:"${{ github.event.pull_request.number }}" pr_title:"${{ github.event.pull_request.title }}"
 
       - name: Comment on PR
         uses: actions/github-script@v7

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -72,27 +72,18 @@ jobs:
 
       - name: Install Firebase CLI and jq
         run: |
-          curl -sL https://firebase.tools | bash
+          npm install -g firebase-tools@14.5.1
           sudo apt-get update
           sudo apt-get install -y jq
-          which firebase
-          firebase --version
-
-      - name: Check firebase version
-        run: |
-          which firebase
-          firebase --version
-
-          
 
       - name: Cleanup Firebase App Distribution Releases
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
-          FIREBASE_APP_ID: 1:715635897715:android:0be885c6b27f7c99de0106  # Your app ID
+          FIREBASE_APP_ID: 1:715635897715:android:0be885c6b27f7c99de0106 
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "Fetching all releases for app $FIREBASE_APP_ID"
-          releases_json=$(/usr/local/bin/firebase appdistribution:releases:list --app "$FIREBASE_APP_ID" --json --token "$FIREBASE_CLI_TOKEN")
+          releases_json=$(firebase appdistribution:releases:list --app "$FIREBASE_APP_ID" --json --token "$FIREBASE_CLI_TOKEN")
 
           echo "Searching for releases matching PR #$PR_NUMBER"
           release_ids=$(echo "$releases_json" | jq -r --arg pr_num "$PR_NUMBER" '.releases[] | select(.releaseNotes | contains("PR #\($pr_num)")) | .id')

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -77,7 +77,7 @@ jobs:
           sudo apt-get install -y jq
           which firebase
           firebase --version
-          
+
       - name: Check firebase version
         run: |
           which firebase
@@ -92,7 +92,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "Fetching all releases for app $FIREBASE_APP_ID"
-          releases_json=$(firebase appdistribution:releases:list --app "$FIREBASE_APP_ID" --json --token "$FIREBASE_CLI_TOKEN")
+          releases_json=$(/usr/local/bin/firebase appdistribution:releases:list --app "$FIREBASE_APP_ID" --json --token "$FIREBASE_CLI_TOKEN")
 
           echo "Searching for releases matching PR #$PR_NUMBER"
           release_ids=$(echo "$releases_json" | jq -r --arg pr_num "$PR_NUMBER" '.releases[] | select(.releaseNotes | contains("PR #\($pr_num)")) | .id')

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -42,57 +42,38 @@ jobs:
           bundle install
           bundle exec fastlane install_plugins
 
-      - name: Set up environment
-        run: |
-          echo "FIREBASE_CLI_TOKEN=${{ secrets.FIREBASE_CLI_TOKEN }}" >> $GITHUB_ENV
-          echo "FIREBASE_APP_ID=1:715635897715:android:0be885c6b27f7c99de0106" >> $GITHUB_ENV
+      - name: Decode and save GCP service account key
+        run: echo "${{ secrets.GCP_JSON_BASE64 }}" | base64 --decode > /tmp/gcp_key.json
 
       - name: Build & Deploy to Firebase App Distribution
         working-directory: android
-        run: bundle exec fastlane android pr_deploy pr_number:"${{ github.event.pull_request.number }}" pr_title:"${{ github.event.pull_request.title }}"
-
-      - name: Comment on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.issue.number;
-            const releaseUrl = "https://console.firebase.google.com/project/react-native-boilerplate-14974/appdistribution/app/1:715635897715:android:0be885c6b27f7c99de0106/releases";  // replace
-            github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🚀 Deployed PR #${prNumber} to Firebase App Distribution.\n\n🔗 [View Releases](${releaseUrl})`
-            })
+        run: bundle exec fastlane android pr_deploy pr_number:"${{ github.event.pull_request.number }}" pr_title:"${{ github.event.pull_request.title }}" project_number:"715635897715" app_id:"1:715635897715:android:0be885c6b27f7c99de0106"
 
   cleanup:
-    if: github.event.action == 'closed'
     runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - name: Install Firebase CLI and jq
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      - name: Install bundler
+        run: gem install bundler
+
+      - name: Install gems and fastlane plugins
+        working-directory: android
         run: |
-          npm install -g firebase-tools@14.5.1
-          sudo apt-get update
-          sudo apt-get install -y jq
+          bundle install
+          bundle exec fastlane install_plugins
 
-      - name: Cleanup Firebase App Distribution Releases
-        env:
-          FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
-          FIREBASE_APP_ID: 1:715635897715:android:0be885c6b27f7c99de0106 
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+      - name: Decode and save GCP service account key
+        run: echo "${{ secrets.GCP_JSON_BASE64 }}" | base64 --decode > /tmp/gcp_key.json
+
+      - name: Cleanup Firebase App Distribution for PR
+        working-directory: android
         run: |
-          echo "Fetching all releases for app $FIREBASE_APP_ID"
-          releases_json=$(firebase appdistribution:releases:list --app "$FIREBASE_APP_ID" --json --token "$FIREBASE_CLI_TOKEN")
-
-          echo "Searching for releases matching PR #$PR_NUMBER"
-          release_ids=$(echo "$releases_json" | jq -r --arg pr_num "$PR_NUMBER" '.releases[] | select(.releaseNotes | contains("PR #\($pr_num)")) | .id')
-
-          if [ -z "$release_ids" ]; then
-            echo "No releases found for PR #$PR_NUMBER"
-          else
-            for release_id in $release_ids; do
-              echo "Deleting release $release_id linked to PR #$PR_NUMBER"
-              firebase appdistribution:releases:delete --app "$FIREBASE_APP_ID" --release-id "$release_id" --token "$FIREBASE_CLI_TOKEN" --yes
-            done
-          fi
+          bundle exec fastlane android pr_cleanup pr_number:"${{ github.event.pull_request.number }}" pr_title:"${{ github.event.pull_request.title }}" project_number:"715635897715" app_id:"1:715635897715:android:0be885c6b27f7c99de0106"

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
+          distribution: 'temurin'
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install Firebase CLI and jq
         run: |
-          npm install -g firebase-tools
+          npm install -g firebase-tools@latest
           sudo apt-get update
           sudo apt-get install -y jq
 

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -77,6 +77,13 @@ jobs:
           sudo apt-get install -y jq
           which firebase
           firebase --version
+          
+      - name: Check firebase version
+        run: |
+          which firebase
+          firebase --version
+
+          
 
       - name: Cleanup Firebase App Distribution Releases
         env:

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install Fastlane
         run: gem install fastlane
 
+      - name: Install fastlane plugins
+        run: fastlane install_plugins
+
       - name: Set up environment
         run: |
           echo "FIREBASE_CLI_TOKEN=${{ secrets.FIREBASE_CLI_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build & Deploy to Firebase App Distribution
         run: |
           cd android
-          fastlane pr_deploy pr_number=${{ github.event.pull_request.number }} pr_title="${{ github.event.pull_request.title }}"
+          fastlane android pr_deploy pr_number:"${{ github.event.pull_request.number }}" pr_title:"${{ github.event.pull_request.title }}"
 
       - name: Comment on PR
         uses: actions/github-script@v7

--- a/.github/workflows/pr_app_distribute.yml
+++ b/.github/workflows/pr_app_distribute.yml
@@ -75,6 +75,8 @@ jobs:
           curl -sL https://firebase.tools | bash
           sudo apt-get update
           sudo apt-get install -y jq
+          which firebase
+          firebase --version
 
       - name: Cleanup Firebase App Distribution Releases
         env:

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -134,7 +134,11 @@ end
 
     gradle(
       task: "assemble",
-      build_type: "Debug"
+      build_type: "Debug",
+      properties: {
+        "org.gradle.jvmargs" => "-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+      },
+      options: "--no-parallel --max-workers=2 --stacktrace"
     )
 
     firebase_app_distribution(

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -138,7 +138,7 @@ end
       properties: {
         "org.gradle.jvmargs" => "-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
       },
-      options: "--no-parallel --max-workers=2 --stacktrace"
+      flags: ["--no-parallel", "--max-workers=2", "--stacktrace"]
     )
 
     firebase_app_distribution(

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -125,5 +125,25 @@ end
       json_key: ENV["ANDROID_JSON_KEY_FILE"],
       skip_upload_apk: true,
     )
+  end 
+
+  desc "Deploy PR build to Firebase App Distribution"
+  lane :pr_deploy do |options|
+    pr_number = options[:pr_number]
+    pr_title = options[:pr_title]
+
+    gradle(
+      task: "assemble",
+      build_type: "Debug"
+    )
+
+    firebase_app_distribution(
+      app: ENV["FIREBASE_APP_ID"],
+      testers: "shivam.jangid@bettrhq.com", 
+      release_notes: "PR ##{pr_number}: #{pr_title} - Build uploaded on #{Time.now.strftime('%Y-%m-%d %H:%M:%S')}",
+      firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],
+      apk_path: "android/app/build/outputs/apk/debug/app-debug.apk"
+    )
   end
+
 end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -142,7 +142,7 @@ end
       testers: "shivam.jangid@bettrhq.com", 
       release_notes: "PR ##{pr_number}: #{pr_title} - Build uploaded on #{Time.now.strftime('%Y-%m-%d %H:%M:%S')}",
       firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],
-      apk_path: "android/app/build/outputs/apk/debug/app-debug.apk"
+      apk_path: "app/build/outputs/apk/debug/app-debug.apk"
     )
   end
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -138,7 +138,7 @@ end
       properties: {
         "org.gradle.jvmargs" => "-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
       },
-      flags: ["--no-parallel", "--max-workers=2", "--stacktrace"]
+      flags: "--no-parallel --max-workers=2 --stacktrace"
     )
 
     firebase_app_distribution(

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -125,29 +125,178 @@ end
       json_key: ENV["ANDROID_JSON_KEY_FILE"],
       skip_upload_apk: true,
     )
-  end 
-
-  desc "Deploy PR build to Firebase App Distribution"
+  end
+  desc "Deploy APK to Firebase App Distribution"
   lane :pr_deploy do |options|
+    require 'uri'
+    require 'net/http'
+    require 'json'
+
     pr_number = options[:pr_number]
     pr_title = options[:pr_title]
+    project_number = options[:project_number]
+    app_id = options[:app_id]
+    service_account_path = "/tmp/gcp_key.json"
+    apk_path = File.expand_path("../app/build/outputs/apk/debug/app-debug.apk", __dir__)
+
+    # Authenticate 
+    sh("gcloud auth activate-service-account --key-file='#{service_account_path}'")
+    access_token = Actions.sh("gcloud auth print-access-token", log: false).strip
+    UI.message("✅ Access token fetched")
 
     gradle(
       task: "assemble",
-      build_type: "Debug",
-      properties: {
-        "org.gradle.jvmargs" => "-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
-      },
-      flags: "--no-parallel --max-workers=2 --stacktrace"
+      build_type: "Debug"
     )
 
-    firebase_app_distribution(
-      app: ENV["FIREBASE_APP_ID"],
-      testers: "shivam.jangid@bettrhq.com", 
-      release_notes: "PR ##{pr_number}: #{pr_title} - Build uploaded on #{Time.now.strftime('%Y-%m-%d %H:%M:%S')}",
-      firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],
-      apk_path: "app/build/outputs/apk/debug/app-debug.apk"
-    )
+    # Upload the APK binary
+    upload_url = "https://firebaseappdistribution.googleapis.com/upload/v1/projects/#{project_number}/apps/#{app_id}/releases:upload"
+    UI.message("🚀 Uploading APK to Firebase App Distribution...")
+
+    uri = URI(upload_url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    apk_data = File.binread(apk_path)
+    apk_filename = File.basename(apk_path)
+
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = "Bearer #{access_token}"
+    request["X-Goog-Upload-Protocol"] = "raw"
+    request["X-Goog-Upload-File-Name"] = apk_filename
+    request.body = apk_data
+
+    response = http.request(request)
+
+    if response.code.to_i != 200 && response.code.to_i != 201
+      UI.user_error!("Failed to upload APK: #{response.code} - #{response.body}")
+    end
+
+    upload_response = JSON.parse(response.body)
+    UI.message("✅ APK uploaded. Operation: #{upload_response['name']}")
+
+
+    operation_name = upload_response["name"]
+    operation_url = "https://firebaseappdistribution.googleapis.com/v1/#{operation_name}"
+
+    max_tries = 10
+    release_name = nil
+
+    max_tries.times do |i|
+      sleep(3)
+      uri = URI(operation_url)
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Bearer #{access_token}"
+      response = http.request(request)
+      if response.code.to_i != 200
+        UI.message("⏳ Waiting for operation to complete... Attempt #{i+1}")
+        next
+      end
+      op_response = JSON.parse(response.body)
+      if op_response["done"] && op_response["response"] && op_response["response"]["release"]
+        release_name = op_response["response"]["release"]["name"]
+        break
+      end
+    end
+
+    unless release_name
+      UI.user_error!("Timeout: Release not created after upload.")
+    end
+
+  UI.message("✅ Release created: #{release_name}")
+
+  # Now patch the release to add release notes
+  patch_url = "https://firebaseappdistribution.googleapis.com/v1/#{release_name}"
+  uri = URI(patch_url)
+
+  release_notes_text = "PR ##{pr_number}: #{pr_title} - Build uploaded on #{Time.now.strftime('%Y-%m-%d %H:%M:%S')}"
+
+  patch_body = {
+    "releaseNotes" => {
+      "text" => release_notes_text
+    }
+  }.to_json
+
+  request = Net::HTTP::Patch.new(uri)
+  request["Authorization"] = "Bearer #{access_token}"
+  request["Content-Type"] = "application/json"
+  request.body = patch_body
+
+  response = http.request(request)
+
+  if response.code.to_i != 200
+    UI.user_error!("Failed to patch release: #{response.code} - #{response.body}")
   end
 
+  UI.message("✅ Release updated with release notes for PR ##{pr_number}")
+end
+
+
+  desc "Clean up Firebase App Distribution releases for closed PR"
+  lane :pr_cleanup do |options|
+    project_number = options[:project_number]
+    app_id = options[:app_id]
+    pr_number = options[:pr_number]
+    service_account_path = "/tmp/gcp_key.json"
+
+    #Authenticate 
+    Actions.sh("gcloud auth activate-service-account --key-file='#{service_account_path}'")
+    access_token = Actions.sh("gcloud auth print-access-token", log: false).strip
+    UI.message("✅ Access token fetched")
+
+    #Get all releases
+    releases_url = "https://firebaseappdistribution.googleapis.com/v1/projects/#{project_number}/apps/#{app_id}/releases"
+    UI.message("📥 Fetching releases from: #{releases_url}")
+
+    uri = URI(releases_url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{access_token}"
+
+    response = http.request(request)
+
+    if response.code.to_i != 200
+      UI.user_error!("Failed to fetch releases: #{response.code} #{response.body}")
+    end
+
+    releases_json = response.body
+    releases = JSON.parse(releases_json)
+
+    matched_release_names = []
+
+    releases["releases"]&.each do |release|
+      notes = release.dig("releaseNotes", "text") || ""
+      if notes.include?("PR ##{pr_number}")
+        matched_release_names << release["name"]
+      end
+    end
+
+    if matched_release_names.empty?
+      UI.message("⚠️ No releases found for PR ##{pr_number}")
+      return
+    end
+
+    UI.message("🗑️ Found #{matched_release_names.size} releases to delete")
+
+    # Step 3: Call batchDelete API
+    batch_delete_url = "https://firebaseappdistribution.googleapis.com/v1/projects/#{project_number}/apps/#{app_id}/releases:batchDelete"
+    body = { names: matched_release_names }.to_json
+
+    token = access_token
+    body_json = body
+
+    command = %Q(
+      curl -s -X POST "#{batch_delete_url}" \\
+      -H "Authorization: Bearer #{token}" \\
+      -H "Content-Type: application/json" \\
+      -d '#{body_json}'
+    )
+
+    output = `#{command}`
+
+    UI.message("API call completed.")
+    UI.message("✅ Response from batchDelete: #{response}")
+  end
 end

--- a/android/fastlane/Pluginfile
+++ b/android/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-increment_version_code'
 gem 'fastlane-plugin-versioning'
+gem 'fastlane-plugin-firebase_app_distribution'


### PR DESCRIPTION
This commit is intended to trigger the GitHub Actions workflow that
handles Firebase App Distribution for pull requests. It will verify that:

- `pr_deploy` runs when a PR is opened or updated.
- `cleanup_pr` runs when a PR is closed or merged.
- The GCP service account key is correctly decoded from GitHub Secrets.

This is only for testing the CI behavior and does not introduce any code changes.