### PR TITLE
feat: Add Divider component and theme support 

### DIFF
--- a/src/components/divider/README.md
+++ b/src/components/divider/README.md
@@ -1,0 +1,30 @@
+# Divider Component
+
+A customizable and theme-consistent `Divider` component for React Native apps, used to separate content visually with support for orientation, thickness, length, and dash styles. 
+
+## ✨ Features
+
+- **Fixed Theme Colors**: Divider uses app-defined theme colors only (not user-provided).
+- **Orientation Support**: Horizontal and Vertical dividers.
+- **Dash Styles**: Supports `solid`, `dashed`, and `dotted` styles.
+- **Custom Thickness and Length**: Flexible styling while enforcing brand consistency.
+
+## 🔧 Props
+
+| Prop         | Type                                | Default                         | Description                                      |
+|--------------|-------------------------------------|----------------------------------|--------------------------------------------------|
+| `orientation`| `horizontal` \| `vertical`          | `horizontal`                     | Divider layout direction                         |
+| `thickness`  | `number`                            | `1`                              | Line thickness                                   |
+| `length`     | `number` \| `string`                | `'100%'`                         | Length of the divider (px or percentage)         |
+| `dashStyle`  | `solid` \| `dashed` \| `dotted`     | `solid`                          | Border style                                     |
+| `style`      | `StyleProp<ViewStyle>`              | `undefined`                      | Additional custom styles (excluding color)       |
+
+## 🎨 Theming
+
+Divider color is derived from the app's theme using `ALLOWED_DIVIDER_COLORS` and `useThemeColor`. Consumers cannot override the color directly.
+
+```ts
+// Example internally used:
+const color: AllowedColor = 'primary';
+const shade: AllowedShade = ALLOWED_DIVIDER_COLORS[color];
+const dividerColor = useThemeColor(`${color}.${shade}`);

--- a/src/components/divider/README.md
+++ b/src/components/divider/README.md
@@ -1,6 +1,6 @@
 # Divider Component
 
-A customizable and theme-consistent `Divider` component for React Native apps, used to separate content visually with support for orientation, thickness, length, and dash styles. 
+A customizable and theme-consistent `Divider` component for React Native apps, used to separate content visually with support for orientation, thickness, length, and dash styles.
 
 ## ✨ Features
 
@@ -11,20 +11,12 @@ A customizable and theme-consistent `Divider` component for React Native apps, u
 
 ## 🔧 Props
 
-| Prop         | Type                                | Default                         | Description                                      |
-|--------------|-------------------------------------|----------------------------------|--------------------------------------------------|
-| `orientation`| `horizontal` \| `vertical`          | `horizontal`                     | Divider layout direction                         |
-| `thickness`  | `number`                            | `1`                              | Line thickness                                   |
-| `length`     | `number` \| `string`                | `'100%'`                         | Length of the divider (px or percentage)         |
-| `dashStyle`  | `solid` \| `dashed` \| `dotted`     | `solid`                          | Border style                                     |
-| `style`      | `StyleProp<ViewStyle>`              | `undefined`                      | Additional custom styles (excluding color)       |
+| Prop         | Type                               | Default                         | Description                                      |
+|--------------|------------------------------------|----------------------------------|--------------------------------------------------|
+| `orientation`| `horizontal` \| `vertical`         | `horizontal`                     | Divider layout direction                         |
+| `thickness`  | `number`                           | `1`                              | Line thickness                                   |
+| `testID`     | `string`                           | `divider`                        | Custom test identifier                           |
 
 ## 🎨 Theming
 
-Divider color is derived from the app's theme using `ALLOWED_DIVIDER_COLORS` and `useThemeColor`. Consumers cannot override the color directly.
-
-```ts
-// Example internally used:
-const color: AllowedColor = 'primary';
-const shade: AllowedShade = ALLOWED_DIVIDER_COLORS[color];
-const dividerColor = useThemeColor(`${color}.${shade}`);
+Divider color is derived from the app's theme. Consumers cannot override the color directly. The divider will use the theme's default color for consistency across your app.

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -1,0 +1,41 @@
+import { StyleSheet, ViewStyle } from 'react-native';
+
+import appTheme from '../../app-theme';
+
+export type Shade = keyof (typeof appTheme.colors)['primary'];
+
+export enum DividerOrientation {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}
+
+export enum DividerDashStyle {
+  Solid = 'solid',
+  Dashed = 'dashed',
+  Dotted = 'dotted',
+}
+
+interface DividerStyleProps {
+  orientation: DividerOrientation;
+  thickness: number;
+  dashStyle: DividerDashStyle;
+  dividerColor: string;
+}
+
+export const useDividerStyles = ({
+  orientation,
+  thickness,
+  dashStyle,
+  dividerColor,
+}: DividerStyleProps) => {
+  return StyleSheet.create({
+    divider: {
+      ...(orientation === DividerOrientation.Horizontal
+        ? { width: '100%', height: thickness }
+        : { height: '100%', width: thickness }),
+      ...(dashStyle === DividerDashStyle.Solid
+        ? { backgroundColor: dividerColor }
+        : { borderStyle: dashStyle, borderWidth: thickness, borderColor: dividerColor }),
+    } as ViewStyle,
+  });
+};

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -28,18 +28,19 @@ export const useDividerStyles = ({
   dashStyle,
   dividerColor,
 }: DividerStyleProps) => {
-  const baseStyle: ViewStyle =
-    orientation === DividerOrientation.Horizontal
-      ? { width: '100%', height: thickness }
-      : { height: '100%', width: thickness };
+  const isHorizontal = orientation === DividerOrientation.Horizontal;
+
+  const baseStyle: ViewStyle = {
+    width: isHorizontal ? '100%' : thickness,
+    height: isHorizontal ? thickness : '100%',
+  };
 
   if (dashStyle === DividerDashStyle.Solid) {
     baseStyle.backgroundColor = dividerColor;
   } else {
     baseStyle.borderStyle = dashStyle;
-    baseStyle.borderWidth = thickness;
     baseStyle.borderColor = dividerColor;
-    baseStyle.backgroundColor = undefined;
+    baseStyle.borderWidth = thickness;
   }
 
   return StyleSheet.create({

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -1,4 +1,3 @@
-import { useTheme } from 'native-base';
 import { StyleSheet, ViewStyle } from 'react-native';
 
 export type DividerOrientation = 'horizontal' | 'vertical';
@@ -9,20 +8,22 @@ interface DividerStyleProps {
   color?: string;
 }
 
-export const useDividerStyles = ({ orientation, thickness, color }: DividerStyleProps) => {
-  const theme = useTheme();
-  const dividerColor = color || theme.colors?.gray?.[400] || '#888888';
+export const useDividerStyles = ({
+  orientation,
+  thickness,
+  color = '#888888',
+}: DividerStyleProps) => {
   const isHorizontal = orientation === 'horizontal';
   const style: ViewStyle = isHorizontal
     ? {
         width: '100%',
         height: thickness,
-        backgroundColor: dividerColor,
+        backgroundColor: color,
       }
     : {
         width: thickness,
         height: '100%',
-        backgroundColor: dividerColor,
+        backgroundColor: color,
       };
 
   return StyleSheet.create({

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -28,14 +28,21 @@ export const useDividerStyles = ({
   dashStyle,
   dividerColor,
 }: DividerStyleProps) => {
+  const baseStyle: ViewStyle =
+    orientation === DividerOrientation.Horizontal
+      ? { width: '100%', height: thickness }
+      : { height: '100%', width: thickness };
+
+  if (dashStyle === DividerDashStyle.Solid) {
+    baseStyle.backgroundColor = dividerColor;
+  } else {
+    baseStyle.borderStyle = dashStyle;
+    baseStyle.borderWidth = thickness;
+    baseStyle.borderColor = dividerColor;
+    baseStyle.backgroundColor = undefined;
+  }
+
   return StyleSheet.create({
-    divider: {
-      ...(orientation === DividerOrientation.Horizontal
-        ? { width: '100%', height: thickness }
-        : { height: '100%', width: thickness }),
-      ...(dashStyle === DividerDashStyle.Solid
-        ? { backgroundColor: dividerColor }
-        : { borderStyle: dashStyle, borderWidth: thickness, borderColor: dividerColor }),
-    } as ViewStyle,
+    divider: baseStyle,
   });
 };

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -1,29 +1,31 @@
+import { useTheme } from 'native-base';
 import { StyleSheet, ViewStyle } from 'react-native';
 
-export type DividerOrientation = 'horizontal' | 'vertical';
+export enum DividerOrientation {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}
 
 interface DividerStyleProps {
   orientation: DividerOrientation;
   thickness: number;
-  color?: string;
 }
 
-export const useDividerStyles = ({
-  orientation,
-  thickness,
-  color = '#888888',
-}: DividerStyleProps) => {
-  const isHorizontal = orientation === 'horizontal';
+export const useDividerStyles = ({ orientation, thickness }: DividerStyleProps) => {
+  const theme = useTheme();
+  const resolvedColor = theme.colors.gray[400];
+
+  const isHorizontal = orientation === DividerOrientation.Horizontal;
   const style: ViewStyle = isHorizontal
     ? {
         width: '100%',
         height: thickness,
-        backgroundColor: color,
+        backgroundColor: resolvedColor,
       }
     : {
         width: thickness,
         height: '100%',
-        backgroundColor: color,
+        backgroundColor: resolvedColor,
       };
 
   return StyleSheet.create({

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -1,49 +1,31 @@
+import { useTheme } from 'native-base';
 import { StyleSheet, ViewStyle } from 'react-native';
 
-import appTheme from '../../app-theme';
-
-export type Shade = keyof (typeof appTheme.colors)['primary'];
-
-export enum DividerOrientation {
-  Horizontal = 'horizontal',
-  Vertical = 'vertical',
-}
-
-export enum DividerDashStyle {
-  Solid = 'solid',
-  Dashed = 'dashed',
-  Dotted = 'dotted',
-}
+export type DividerOrientation = 'horizontal' | 'vertical';
 
 interface DividerStyleProps {
   orientation: DividerOrientation;
   thickness: number;
-  dashStyle: DividerDashStyle;
-  dividerColor: string;
+  color?: string;
 }
 
-export const useDividerStyles = ({
-  orientation,
-  thickness,
-  dashStyle,
-  dividerColor,
-}: DividerStyleProps) => {
-  const isHorizontal = orientation === DividerOrientation.Horizontal;
-
-  const baseStyle: ViewStyle = {
-    width: isHorizontal ? '100%' : thickness,
-    height: isHorizontal ? thickness : '100%',
-  };
-
-  if (dashStyle === DividerDashStyle.Solid) {
-    baseStyle.backgroundColor = dividerColor;
-  } else {
-    baseStyle.borderStyle = dashStyle;
-    baseStyle.borderColor = dividerColor;
-    baseStyle.borderWidth = thickness;
-  }
+export const useDividerStyles = ({ orientation, thickness, color }: DividerStyleProps) => {
+  const theme = useTheme();
+  const dividerColor = color || theme.colors?.gray?.[400] || '#888888';
+  const isHorizontal = orientation === 'horizontal';
+  const style: ViewStyle = isHorizontal
+    ? {
+        width: '100%',
+        height: thickness,
+        backgroundColor: dividerColor,
+      }
+    : {
+        width: thickness,
+        height: '100%',
+        backgroundColor: dividerColor,
+      };
 
   return StyleSheet.create({
-    divider: baseStyle,
+    divider: style,
   });
 };

--- a/src/components/divider/divider.test.tsx
+++ b/src/components/divider/divider.test.tsx
@@ -1,102 +1,53 @@
-import { render, screen } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import React from 'react';
 
-import Divider, { DividerProps } from './divider';
-import { DividerOrientation, DividerDashStyle } from './divider.styles';
+import Divider from './divider';
 
 describe('Divider', () => {
-  const renderDivider = (props: Partial<DividerProps> = {}) => render(<Divider {...props} />);
-
-  it('renders correctly with default props', () => {
-    renderDivider();
-    const divider = screen.getByTestId('divider');
-    expect(divider).toBeTruthy();
+  it('renders with default props (horizontal)', () => {
+    const { getByTestId } = render(<Divider />);
+    const divider = getByTestId('divider');
     expect(divider.props.style).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          backgroundColor: '#E0E0E0',
+          width: '100%',
           height: 1,
-          width: '100%',
-        }),
-      ]),
-    );
-  });
-
-  it('renders horizontal divider with custom thickness and color', () => {
-    renderDivider({
-      orientation: DividerOrientation.Horizontal,
-      thickness: 2,
-      color: 'primary',
-      shade: '200',
-    });
-    const divider = screen.getByTestId('divider');
-    expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          backgroundColor: '#99C2FF',
-          height: 2,
-          width: '100%',
-        }),
-      ]),
-    );
-  });
-
-  it('renders vertical divider with custom thickness', () => {
-    renderDivider({
-      orientation: DividerOrientation.Vertical,
-      thickness: 3,
-    });
-    const divider = screen.getByTestId('divider');
-    expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
           backgroundColor: '#E0E0E0',
-          width: 3,
+        }),
+      ]),
+    );
+  });
+
+  it('renders vertical divider', () => {
+    const { getByTestId } = render(
+      <Divider orientation="vertical" thickness={2} color="#123456" />,
+    );
+    const divider = getByTestId('divider');
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          width: 2,
           height: '100%',
+          backgroundColor: '#123456',
         }),
       ]),
     );
   });
 
-  it('applies dashed style correctly', () => {
-    renderDivider({ dashStyle: DividerDashStyle.Dashed, thickness: 1 });
-    const divider = screen.getByTestId('divider');
+  it('accepts custom style', () => {
+    const { getByTestId } = render(<Divider style={{ marginVertical: 8 }} />);
+    const divider = getByTestId('divider');
     expect(divider.props.style).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          borderStyle: 'dashed',
-          borderWidth: 1,
-          borderColor: '#E0E0E0',
+          marginVertical: 8,
         }),
       ]),
     );
   });
 
-  it('renders with percentage width', () => {
-    renderDivider({ orientation: DividerOrientation.Horizontal, thickness: 1 });
-    const divider = screen.getByTestId('divider');
-    expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          backgroundColor: '#E0E0E0',
-          height: 1,
-          width: '100%',
-        }),
-      ]),
-    );
-  });
-
-  it('uses default props when none provided', () => {
-    renderDivider({});
-    const divider = screen.getByTestId('divider');
-    expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          backgroundColor: '#E0E0E0',
-          height: 1,
-          width: '100%',
-        }),
-      ]),
-    );
+  it('accepts custom testID', () => {
+    const { getByTestId } = render(<Divider testID="custom-divider" />);
+    expect(getByTestId('custom-divider')).toBeTruthy();
   });
 });

--- a/src/components/divider/divider.test.tsx
+++ b/src/components/divider/divider.test.tsx
@@ -3,6 +3,17 @@ import React from 'react';
 
 import Divider from './divider';
 
+jest.mock('native-base', () => ({
+  useTheme: () => ({
+    colors: {
+      gray: { 400: '#888888' },
+      coolGray: { 500: '#555555' },
+      warmGray: { 300: '#bbbbbb' },
+      blueGray: { 700: '#222244' },
+    },
+  }),
+}));
+
 describe('Divider', () => {
   it('renders with default props (horizontal)', () => {
     const { getByTestId } = render(<Divider />);
@@ -29,6 +40,18 @@ describe('Divider', () => {
           width: 2,
           height: '100%',
           backgroundColor: '#123456',
+        }),
+      ]),
+    );
+  });
+
+  it('renders with palette color string', () => {
+    const { getByTestId } = render(<Divider color="coolGray.500" />);
+    const divider = getByTestId('divider');
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: '#555555',
         }),
       ]),
     );

--- a/src/components/divider/divider.test.tsx
+++ b/src/components/divider/divider.test.tsx
@@ -1,59 +1,11 @@
 import { render, screen } from '@testing-library/react-native';
 import React from 'react';
-import { ViewStyle } from 'react-native';
 
 import Divider, { DividerProps } from './divider';
 import { DividerOrientation, DividerDashStyle } from './divider.styles';
 
-jest.mock('@/utils/use-theme-color.hook', () => ({
-  useThemeColor: jest.fn((color: string) => {
-    const colorMap: { [key: string]: string } = {
-      'neutral.200': '#E0E0E0',
-      'primary.200': '#99C2FF',
-    };
-    return colorMap[color] || color;
-  }),
-}));
-
-jest.mock('./divider.styles', () => {
-  const actual = jest.requireActual('./divider.styles');
-  return {
-    ...actual,
-    useDividerStyles: jest.fn(
-      ({ orientation, thickness, length, dashStyle, dividerColor }: any) => {
-        const baseStyle: ViewStyle = {
-          backgroundColor: dividerColor,
-          borderStyle: dashStyle === actual.DividerDashStyle.Solid ? undefined : dashStyle,
-        };
-
-        if (orientation === actual.DividerOrientation.Horizontal) {
-          return {
-            divider: {
-              ...baseStyle,
-              height: thickness,
-              width: length || '100%',
-            },
-          };
-        } else {
-          return {
-            divider: {
-              ...baseStyle,
-              width: thickness,
-              height: '100%',
-            },
-          };
-        }
-      },
-    ),
-  };
-});
-
 describe('Divider', () => {
   const renderDivider = (props: Partial<DividerProps> = {}) => render(<Divider {...props} />);
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
 
   it('renders correctly with default props', () => {
     renderDivider();
@@ -74,6 +26,8 @@ describe('Divider', () => {
     renderDivider({
       orientation: DividerOrientation.Horizontal,
       thickness: 2,
+      color: 'primary',
+      shade: '200',
     });
     const divider = screen.getByTestId('divider');
     expect(divider.props.style).toEqual(
@@ -110,10 +64,9 @@ describe('Divider', () => {
     expect(divider.props.style).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          backgroundColor: '#E0E0E0',
           borderStyle: 'dashed',
-          height: 1,
-          width: '100%',
+          borderWidth: 1,
+          borderColor: '#E0E0E0',
         }),
       ]),
     );

--- a/src/components/divider/divider.test.tsx
+++ b/src/components/divider/divider.test.tsx
@@ -12,7 +12,7 @@ describe('Divider', () => {
         expect.objectContaining({
           width: '100%',
           height: 1,
-          backgroundColor: '#E0E0E0',
+          backgroundColor: '#888888',
         }),
       ]),
     );

--- a/src/components/divider/divider.test.tsx
+++ b/src/components/divider/divider.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from '@testing-library/react-native';
+import React from 'react';
+import { ViewStyle } from 'react-native';
+
+import Divider, { DividerProps } from './divider';
+import { DividerOrientation, DividerDashStyle } from './divider.styles';
+
+jest.mock('@/utils/use-theme-color.hook', () => ({
+  useThemeColor: jest.fn((color: string) => {
+    const colorMap: { [key: string]: string } = {
+      'neutral.200': '#E0E0E0',
+      'primary.200': '#99C2FF',
+    };
+    return colorMap[color] || color;
+  }),
+}));
+
+jest.mock('./divider.styles', () => {
+  const actual = jest.requireActual('./divider.styles');
+  return {
+    ...actual,
+    useDividerStyles: jest.fn(
+      ({ orientation, thickness, length, dashStyle, dividerColor }: any) => {
+        const baseStyle: ViewStyle = {
+          backgroundColor: dividerColor,
+          borderStyle: dashStyle === actual.DividerDashStyle.Solid ? undefined : dashStyle,
+        };
+
+        if (orientation === actual.DividerOrientation.Horizontal) {
+          return {
+            divider: {
+              ...baseStyle,
+              height: thickness,
+              width: length || '100%',
+            },
+          };
+        } else {
+          return {
+            divider: {
+              ...baseStyle,
+              width: thickness,
+              height: '100%',
+            },
+          };
+        }
+      },
+    ),
+  };
+});
+
+describe('Divider', () => {
+  const renderDivider = (props: Partial<DividerProps> = {}) => render(<Divider {...props} />);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly with default props', () => {
+    renderDivider();
+    const divider = screen.getByTestId('divider');
+    expect(divider).toBeTruthy();
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: '#E0E0E0',
+          height: 1,
+          width: '100%',
+        }),
+      ]),
+    );
+  });
+
+  it('renders horizontal divider with custom thickness and color', () => {
+    renderDivider({
+      orientation: DividerOrientation.Horizontal,
+      thickness: 2,
+    });
+    const divider = screen.getByTestId('divider');
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: '#99C2FF',
+          height: 2,
+          width: '100%',
+        }),
+      ]),
+    );
+  });
+
+  it('renders vertical divider with custom thickness', () => {
+    renderDivider({
+      orientation: DividerOrientation.Vertical,
+      thickness: 3,
+    });
+    const divider = screen.getByTestId('divider');
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: '#E0E0E0',
+          width: 3,
+          height: '100%',
+        }),
+      ]),
+    );
+  });
+
+  it('applies dashed style correctly', () => {
+    renderDivider({ dashStyle: DividerDashStyle.Dashed, thickness: 1 });
+    const divider = screen.getByTestId('divider');
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: '#E0E0E0',
+          borderStyle: 'dashed',
+          height: 1,
+          width: '100%',
+        }),
+      ]),
+    );
+  });
+
+  it('renders with percentage width', () => {
+    renderDivider({ orientation: DividerOrientation.Horizontal, thickness: 1 });
+    const divider = screen.getByTestId('divider');
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: '#E0E0E0',
+          height: 1,
+          width: '100%',
+        }),
+      ]),
+    );
+  });
+
+  it('uses default props when none provided', () => {
+    renderDivider({});
+    const divider = screen.getByTestId('divider');
+    expect(divider.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: '#E0E0E0',
+          height: 1,
+          width: '100%',
+        }),
+      ]),
+    );
+  });
+});

--- a/src/components/divider/divider.test.tsx
+++ b/src/components/divider/divider.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react-native';
 import React from 'react';
 
 import Divider from './divider';
+import { DividerOrientation } from './divider.styles';
 
 jest.mock('native-base', () => ({
   useTheme: () => ({
@@ -19,53 +20,25 @@ describe('Divider', () => {
     const { getByTestId } = render(<Divider />);
     const divider = getByTestId('divider');
     expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          width: '100%',
-          height: 1,
-          backgroundColor: '#888888',
-        }),
-      ]),
+      expect.objectContaining({
+        width: '100%',
+        height: 1,
+        backgroundColor: '#888888',
+      }),
     );
   });
 
   it('renders vertical divider', () => {
     const { getByTestId } = render(
-      <Divider orientation="vertical" thickness={2} color="#123456" />,
+      <Divider orientation={DividerOrientation.Vertical} thickness={2} />,
     );
     const divider = getByTestId('divider');
     expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          width: 2,
-          height: '100%',
-          backgroundColor: '#123456',
-        }),
-      ]),
-    );
-  });
-
-  it('renders with palette color string', () => {
-    const { getByTestId } = render(<Divider color="coolGray.500" />);
-    const divider = getByTestId('divider');
-    expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          backgroundColor: '#555555',
-        }),
-      ]),
-    );
-  });
-
-  it('accepts custom style', () => {
-    const { getByTestId } = render(<Divider style={{ marginVertical: 8 }} />);
-    const divider = getByTestId('divider');
-    expect(divider.props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          marginVertical: 8,
-        }),
-      ]),
+      expect.objectContaining({
+        width: 2,
+        height: '100%',
+        backgroundColor: '#888888',
+      }),
     );
   });
 

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -25,26 +25,17 @@ const Divider: React.FC<DividerProps> = ({
 }) => {
   const theme = useTheme();
   const colors = theme.colors as typeof appTheme.colors;
-  let dividerColor: string = '#E0E0E0';
 
-  if (
-    color &&
-    typeof color === 'string' &&
-    shade &&
-    typeof colors?.[color as keyof typeof colors] === 'object'
-  ) {
-    const shadeColor = (colors[color as keyof typeof colors] as Record<string, string>)[shade];
-    if (typeof shadeColor === 'string') {
-      dividerColor = shadeColor;
-    }
-  } else if (color && typeof colors?.[color as keyof typeof colors] === 'string') {
-    const colorValue = colors[color as keyof typeof colors];
-    if (typeof colorValue === 'string' || typeof colorValue === 'number') {
-      dividerColor = String(colorValue);
-    }
-  } else if (colors?.primary && typeof colors.primary === 'object' && colors.primary['200']) {
-    dividerColor = colors.primary['200'];
-  }
+  let dividerColor: string =
+    (color &&
+      shade &&
+      typeof colors?.[color as keyof typeof colors] === 'object' &&
+      (colors[color as keyof typeof colors] as Record<string, string>)[shade]) ||
+    (color &&
+      typeof colors?.[color as keyof typeof colors] === 'string' &&
+      (colors[color as keyof typeof colors] as string)) ||
+    (colors?.primary && typeof colors.primary === 'object' && colors.primary['200']) ||
+    '#E0E0E0';
 
   const styles = useDividerStyles({
     orientation: orientation ?? DividerOrientation.Horizontal,

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -1,50 +1,26 @@
-import { useTheme } from 'native-base';
 import React from 'react';
-import { View, ViewStyle, StyleProp } from 'react-native';
+import { View } from 'react-native';
 
-import { useDividerStyles } from './divider.styles';
+import { useDividerStyles, DividerOrientation } from './divider.styles';
 
 export interface DividerProps {
-  orientation?: 'horizontal' | 'vertical';
+  orientation?: DividerOrientation;
   thickness?: number;
-  color?: string;
-  style?: StyleProp<ViewStyle>;
   testID?: string;
 }
 
-const getThemeColor = (theme: any, color?: string) => {
-  if (!color) {
-    return theme.colors.gray[400];
-  }
-  const [palette, shade] = color.split('.');
-  return theme.colors?.[palette]?.[shade] || color;
-};
-
-const Divider: React.FC<DividerProps> = ({
-  orientation,
-  thickness,
-  color,
-  style,
-  testID,
-  ...rest
-}) => {
-  const theme = useTheme();
-  const resolvedColor = getThemeColor(theme, color);
-
+const Divider: React.FC<DividerProps> = ({ orientation, thickness, testID, ...rest }) => {
   const styles = useDividerStyles({
-    orientation: orientation ?? 'horizontal',
+    orientation: orientation ?? DividerOrientation.Horizontal,
     thickness: thickness ?? 1,
-    color: resolvedColor,
   });
 
-  return <View testID={testID ?? 'divider'} style={[styles.divider, style]} {...rest} />;
+  return <View testID={testID ?? 'divider'} style={styles.divider} {...rest} />;
 };
 
 Divider.defaultProps = {
-  orientation: 'horizontal',
+  orientation: DividerOrientation.Horizontal,
   thickness: 1,
-  color: 'gray.400',
-  style: undefined,
   testID: 'divider',
 };
 

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -1,66 +1,39 @@
-import { useTheme } from 'native-base';
 import React from 'react';
-import { View } from 'react-native';
+import { View, ViewStyle, StyleProp } from 'react-native';
 
-import appTheme from '../../app-theme';
-
-import { DividerOrientation, DividerDashStyle, useDividerStyles, Shade } from './divider.styles';
+import { useDividerStyles } from './divider.styles';
 
 export interface DividerProps {
-  color?: string;
-  dashStyle?: DividerDashStyle;
-  orientation?: DividerOrientation;
-  shade?: Shade;
-  testID?: string;
+  orientation?: 'horizontal' | 'vertical';
   thickness?: number;
+  color?: string;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
 }
 
-const getDividerColor = (
-  themeColors: typeof appTheme.colors,
-  color?: string,
-  shade?: Shade,
-): string => {
-  if (!color) {
-    return '#E0E0E0';
-  }
-
-  const colorValue = themeColors[color as keyof typeof themeColors];
-
-  if (typeof colorValue === 'object' && shade) {
-    return (colorValue as Record<string, string>)[shade] || '#E0E0E0';
-  }
-
-  if (typeof colorValue === 'string') {
-    return colorValue;
-  }
-
-  return '#E0E0E0';
-};
-
-const Divider: React.FC<DividerProps> = props => {
-  const { color, dashStyle, orientation, shade, testID, thickness } = props;
-
-  const theme = useTheme();
-  const colors = theme.colors as typeof appTheme.colors;
-  const dividerColor = getDividerColor(colors, color, shade);
-
+const Divider: React.FC<DividerProps> = ({
+  orientation,
+  thickness,
+  color,
+  style,
+  testID,
+  ...rest
+}) => {
   const styles = useDividerStyles({
-    orientation: orientation ?? DividerOrientation.Horizontal,
+    orientation: orientation ?? 'horizontal',
     thickness: thickness ?? 1,
-    dashStyle: dashStyle ?? DividerDashStyle.Solid,
-    dividerColor,
+    color,
   });
 
-  return <View testID={testID} style={[styles.divider]} />;
+  return <View testID={testID ?? 'divider'} style={[styles.divider, style]} {...rest} />;
 };
 
 Divider.defaultProps = {
-  color: 'primary',
-  dashStyle: DividerDashStyle.Solid,
-  orientation: DividerOrientation.Horizontal,
-  shade: '200',
-  testID: 'divider',
+  orientation: 'horizontal',
   thickness: 1,
+  color: '#888888',
+  testID: 'divider',
+  style: null,
 };
 
 export default Divider;

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -25,17 +25,26 @@ const Divider: React.FC<DividerProps> = ({
 }) => {
   const theme = useTheme();
   const colors = theme.colors as typeof appTheme.colors;
-  const dividerColor =
+  let dividerColor: string = '#E0E0E0';
+
+  if (
     color &&
+    typeof color === 'string' &&
     shade &&
-    typeof colors[color as keyof typeof colors] === 'object' &&
-    (colors[color as keyof typeof colors] as Record<string, string>)[shade]
-      ? (colors[color as keyof typeof colors] as Record<string, string>)[shade]
-      : typeof colors[color as keyof typeof colors] === 'string'
-      ? (colors[color as keyof typeof colors] as string)
-      : colors.primary && typeof colors.primary === 'object' && colors.primary['200']
-      ? colors.primary['200']
-      : '#E0E0E0';
+    typeof colors?.[color as keyof typeof colors] === 'object'
+  ) {
+    const shadeColor = (colors[color as keyof typeof colors] as Record<string, string>)[shade];
+    if (typeof shadeColor === 'string') {
+      dividerColor = shadeColor;
+    }
+  } else if (color && typeof colors?.[color as keyof typeof colors] === 'string') {
+    const colorValue = colors[color as keyof typeof colors];
+    if (typeof colorValue === 'string' || typeof colorValue === 'number') {
+      dividerColor = String(colorValue);
+    }
+  } else if (colors?.primary && typeof colors.primary === 'object' && colors.primary['200']) {
+    dividerColor = colors.primary['200'];
+  }
 
   const styles = useDividerStyles({
     orientation: orientation ?? DividerOrientation.Horizontal,

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -1,0 +1,55 @@
+import { useTheme } from 'native-base';
+import React from 'react';
+import { View } from 'react-native';
+
+import appTheme from '../../app-theme';
+
+import { DividerOrientation, DividerDashStyle, useDividerStyles, Shade } from './divider.styles';
+
+export interface DividerProps {
+  color?: string;
+  dashStyle?: DividerDashStyle;
+  orientation?: DividerOrientation;
+  shade?: Shade;
+  testID?: string;
+  thickness?: number;
+}
+
+const Divider: React.FC<DividerProps> = ({
+  color,
+  dashStyle,
+  orientation,
+  shade,
+  testID,
+  thickness,
+}) => {
+  const theme = useTheme();
+  const colors = theme.colors as typeof appTheme.colors;
+  const dividerColor =
+    color &&
+    shade &&
+    colors[color as keyof typeof colors] &&
+    typeof colors[color as keyof typeof colors] === 'object'
+      ? (colors[color as keyof typeof colors] as Record<string, string>)[shade]
+      : colors.primary['200'];
+
+  const styles = useDividerStyles({
+    orientation: orientation ?? DividerOrientation.Horizontal,
+    thickness: thickness ?? 1,
+    dashStyle: dashStyle ?? DividerDashStyle.Solid,
+    dividerColor,
+  });
+
+  return <View testID={testID ?? 'divider'} style={[styles.divider]} />;
+};
+
+Divider.defaultProps = {
+  color: 'primary',
+  dashStyle: DividerDashStyle.Solid,
+  orientation: DividerOrientation.Horizontal,
+  shade: '200',
+  testID: 'divider',
+  thickness: 1,
+};
+
+export default Divider;

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/require-default-props */
- import { useTheme } from 'native-base';
+import { useTheme } from 'native-base';
 import React from 'react';
 import { View } from 'react-native';
 
@@ -24,37 +23,44 @@ const getDividerColor = (
   if (!color) {
     return '#E0E0E0';
   }
+
   const colorValue = themeColors[color as keyof typeof themeColors];
+
   if (typeof colorValue === 'object' && shade) {
     return (colorValue as Record<string, string>)[shade] || '#E0E0E0';
   }
+
   if (typeof colorValue === 'string') {
     return colorValue;
   }
+
   return '#E0E0E0';
 };
 
-const Divider: React.FC<DividerProps> = ({
-  color = 'primary',
-  dashStyle = DividerDashStyle.Solid,
-  orientation = DividerOrientation.Horizontal,
-  shade = '200',
-  testID = 'divider',
-  thickness = 1,
-}) => {
+const Divider: React.FC<DividerProps> = props => {
+  const { color, dashStyle, orientation, shade, testID, thickness } = props;
+
   const theme = useTheme();
   const colors = theme.colors as typeof appTheme.colors;
-
   const dividerColor = getDividerColor(colors, color, shade);
 
   const styles = useDividerStyles({
-    orientation,
-    thickness,
-    dashStyle,
+    orientation: orientation ?? DividerOrientation.Horizontal,
+    thickness: thickness ?? 1,
+    dashStyle: dashStyle ?? DividerDashStyle.Solid,
     dividerColor,
   });
 
   return <View testID={testID} style={[styles.divider]} />;
+};
+
+Divider.defaultProps = {
+  color: 'primary',
+  dashStyle: DividerDashStyle.Solid,
+  orientation: DividerOrientation.Horizontal,
+  shade: '200',
+  testID: 'divider',
+  thickness: 1,
 };
 
 export default Divider;

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -28,10 +28,11 @@ const Divider: React.FC<DividerProps> = ({
   const dividerColor =
     color &&
     shade &&
-    colors[color as keyof typeof colors] &&
     typeof colors[color as keyof typeof colors] === 'object' &&
     (colors[color as keyof typeof colors] as Record<string, string>)[shade]
       ? (colors[color as keyof typeof colors] as Record<string, string>)[shade]
+      : typeof colors[color as keyof typeof colors] === 'string'
+      ? (colors[color as keyof typeof colors] as string)
       : colors.primary && typeof colors.primary === 'object' && colors.primary['200']
       ? colors.primary['200']
       : '#E0E0E0';

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from 'native-base';
 import React from 'react';
 import { View, ViewStyle, StyleProp } from 'react-native';
 
@@ -11,6 +12,14 @@ export interface DividerProps {
   testID?: string;
 }
 
+const getThemeColor = (theme: any, color?: string) => {
+  if (!color) {
+    return theme.colors.gray[400];
+  }
+  const [palette, shade] = color.split('.');
+  return theme.colors?.[palette]?.[shade] || color;
+};
+
 const Divider: React.FC<DividerProps> = ({
   orientation,
   thickness,
@@ -19,10 +28,13 @@ const Divider: React.FC<DividerProps> = ({
   testID,
   ...rest
 }) => {
+  const theme = useTheme();
+  const resolvedColor = getThemeColor(theme, color);
+
   const styles = useDividerStyles({
     orientation: orientation ?? 'horizontal',
     thickness: thickness ?? 1,
-    color,
+    color: resolvedColor,
   });
 
   return <View testID={testID ?? 'divider'} style={[styles.divider, style]} {...rest} />;
@@ -31,9 +43,9 @@ const Divider: React.FC<DividerProps> = ({
 Divider.defaultProps = {
   orientation: 'horizontal',
   thickness: 1,
-  color: '#888888',
+  color: 'gray.400',
+  style: undefined,
   testID: 'divider',
-  style: null,
 };
 
 export default Divider;

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -15,45 +15,45 @@ export interface DividerProps {
   thickness?: number;
 }
 
+const getDividerColor = (
+  themeColors: typeof appTheme.colors,
+  color?: string,
+  shade?: Shade,
+): string => {
+  if (!color) {
+    return '#E0E0E0';
+  }
+  const colorValue = themeColors[color as keyof typeof themeColors];
+  if (typeof colorValue === 'object' && shade) {
+    return (colorValue as Record<string, string>)[shade] || '#E0E0E0';
+  }
+  if (typeof colorValue === 'string') {
+    return colorValue;
+  }
+  return '#E0E0E0';
+};
+
 const Divider: React.FC<DividerProps> = ({
-  color,
-  dashStyle,
-  orientation,
-  shade,
-  testID,
-  thickness,
+  color = 'primary',
+  dashStyle = DividerDashStyle.Solid,
+  orientation = DividerOrientation.Horizontal,
+  shade = '200',
+  testID = 'divider',
+  thickness = 1,
 }) => {
   const theme = useTheme();
   const colors = theme.colors as typeof appTheme.colors;
 
-  let dividerColor: string =
-    (color &&
-      shade &&
-      typeof colors?.[color as keyof typeof colors] === 'object' &&
-      (colors[color as keyof typeof colors] as Record<string, string>)[shade]) ||
-    (color &&
-      typeof colors?.[color as keyof typeof colors] === 'string' &&
-      (colors[color as keyof typeof colors] as string)) ||
-    (colors?.primary && typeof colors.primary === 'object' && colors.primary['200']) ||
-    '#E0E0E0';
+  const dividerColor = getDividerColor(colors, color, shade);
 
   const styles = useDividerStyles({
-    orientation: orientation ?? DividerOrientation.Horizontal,
-    thickness: thickness ?? 1,
-    dashStyle: dashStyle ?? DividerDashStyle.Solid,
+    orientation,
+    thickness,
+    dashStyle,
     dividerColor,
   });
 
-  return <View testID={testID ?? 'divider'} style={[styles.divider]} />;
-};
-
-Divider.defaultProps = {
-  color: 'primary',
-  dashStyle: DividerDashStyle.Solid,
-  orientation: DividerOrientation.Horizontal,
-  shade: '200',
-  testID: 'divider',
-  thickness: 1,
+  return <View testID={testID} style={[styles.divider]} />;
 };
 
 export default Divider;

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -29,9 +29,12 @@ const Divider: React.FC<DividerProps> = ({
     color &&
     shade &&
     colors[color as keyof typeof colors] &&
-    typeof colors[color as keyof typeof colors] === 'object'
+    typeof colors[color as keyof typeof colors] === 'object' &&
+    (colors[color as keyof typeof colors] as Record<string, string>)[shade]
       ? (colors[color as keyof typeof colors] as Record<string, string>)[shade]
-      : colors.primary['200'];
+      : colors.primary && typeof colors.primary === 'object' && colors.primary['200']
+      ? colors.primary['200']
+      : '#E0E0E0';
 
   const styles = useDividerStyles({
     orientation: orientation ?? DividerOrientation.Horizontal,

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -1,4 +1,5 @@
-import { useTheme } from 'native-base';
+/* eslint-disable react/require-default-props */
+ import { useTheme } from 'native-base';
 import React from 'react';
 import { View } from 'react-native';
 

--- a/src/components/divider/index.ts
+++ b/src/components/divider/index.ts
@@ -1,0 +1,3 @@
+export { default } from './divider';
+export * from './divider';
+export * from './divider.styles';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,3 +27,5 @@ export { default as Tag } from './tag/tag';
 export { Input } from './inputs';
 export { PasswordInput } from './inputs';
 export { TextAreaInput } from './inputs';
+export { default as Divider } from './divider/divider';
+export * from './divider';

--- a/src/screens/profile/edit-profile/edit-profile.tsx
+++ b/src/screens/profile/edit-profile/edit-profile.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { Platform } from 'react-native';
 
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
+import Divider from '../../../components/divider';
+import { DividerOrientation } from '../../../components/divider/divider.styles';
 import { AsyncError } from '../../../types';
 import ProfileLayout from '../profile-layout';
 
@@ -63,9 +65,12 @@ const EditProfile: React.FC<ProfileStackScreenProps<'EditProfile'>> = ({ navigat
           </FormControl>
         </VStack>
 
-        <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
-          Save Changes
-        </Button>
+        <VStack space={4} mt={8}>
+          <Divider orientation={DividerOrientation.Horizontal} thickness={1} length="100%" />
+          <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
+            Save Changes
+          </Button>
+        </VStack>
       </KeyboardAvoidingView>
     </ProfileLayout>
   );

--- a/src/screens/profile/edit-profile/edit-profile.tsx
+++ b/src/screens/profile/edit-profile/edit-profile.tsx
@@ -5,7 +5,6 @@ import { Platform } from 'react-native';
 
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
 import Divider from '../../../components/divider';
-import { DividerOrientation } from '../../../components/divider/divider.styles';
 import { AsyncError } from '../../../types';
 import ProfileLayout from '../profile-layout';
 
@@ -66,7 +65,7 @@ const EditProfile: React.FC<ProfileStackScreenProps<'EditProfile'>> = ({ navigat
         </VStack>
 
         <VStack space={4} mt={8}>
-          <Divider orientation={DividerOrientation.Horizontal} thickness={1} length="100%" />
+          <Divider orientation={'horizontal'} thickness={1} />
           <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
             Save Changes
           </Button>

--- a/src/screens/profile/edit-profile/edit-profile.tsx
+++ b/src/screens/profile/edit-profile/edit-profile.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { Platform } from 'react-native';
 
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
-import Divider from '../../../components/divider';
 import { AsyncError } from '../../../types';
 import ProfileLayout from '../profile-layout';
 
@@ -64,12 +63,9 @@ const EditProfile: React.FC<ProfileStackScreenProps<'EditProfile'>> = ({ navigat
           </FormControl>
         </VStack>
 
-        <VStack space={4} mt={8}>
-          <Divider orientation={'horizontal'} thickness={1} />
-          <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
-            Save Changes
-          </Button>
-        </VStack>
+        <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
+          Save Changes
+        </Button>
       </KeyboardAvoidingView>
     </ProfileLayout>
   );


### PR DESCRIPTION
### Why is this change needed?
This PR introduces a reusable Divider component [issue 142](https://github.com/jalantechnologies/react-native-template/issues/142) to ensure consistent visual separation across the app, especially in EditProfile and similar screens. It also includes necessary theming support via `use-theme-color`.

### What is changing?
- Added new Divider component in `src/components/divider/`
- Updated `use-theme-color.hook.ts` to support Divider theming
- Normalized line endings to LF across the project for consistency

### API / Database changes
None.

### UI Screenshot
![Screenshot_1750756712](https://github.com/user-attachments/assets/06ea4573-ba23-4acb-bc93-b15ad8f0c071)
![Screenshot_1750756719](https://github.com/user-attachments/assets/d4bfb5e3-1296-42ca-bb63-66b88660f0eb)




### Manual / Automated Test Notes
- Added unit test for Divider: `divider.test.tsx`
- Verified correct rendering across light/dark themes

### Additional Notes
This PR is aligned to our standard practices:
- Small, self-contained changes
- Clear commit messages
- No cross-module imports or magic numbers
