### PR TITLE
Fix: Metro Server Error by Pre-Bundling Assets in CI for Android Preview Builds

### DIFF
--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -174,9 +174,6 @@ jobs:
             --bundle-output android/app/src/main/assets/index.android.bundle \
             --assets-dest android/app/src/main/res
 
-      - name: Set Java heap size for Gradle
-        run: echo "_JAVA_OPTIONS=-Xmx4096m" >> $GITHUB_ENV
-
       - name: Build & Deploy to Firebase App Distribution
         working-directory: android
         env:

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -160,18 +160,6 @@ jobs:
           echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
           echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
 
-      - name: Generate debug keystore
-        run: |
-          keytool -genkeypair -v \
-          -keystore debug.keystore \
-          -alias androiddebugkey \
-          -keyalg RSA \
-          -keysize 2048 \
-          -validity 10000 \
-          -storepass android \
-          -keypass android \
-          -dname "CN=Android Debug,O=Android,C=US"
-
       - name: Build & Deploy to Firebase App Distribution
         working-directory: android
         env:

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -160,6 +160,20 @@ jobs:
           echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
           echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
 
+      - name: Create bundle assets directories
+        run: |
+          mkdir -p android/app/src/main/assets
+          mkdir -p android/app/src/main/res
+
+      - name: Generate JS bundle for preview APK
+        run: |
+          npx react-native bundle \
+            --platform android \
+            --dev false \
+            --entry-file index.js \
+            --bundle-output android/app/src/main/assets/index.android.bundle \
+            --assets-dest android/app/src/main/res
+
       - name: Build & Deploy to Firebase App Distribution
         working-directory: android
         env:

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -160,6 +160,18 @@ jobs:
           echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
           echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
 
+      - name: Generate debug keystore
+        run: |
+          keytool -genkeypair -v \
+          -keystore debug.keystore \
+          -alias androiddebugkey \
+          -keyalg RSA \
+          -keysize 2048 \
+          -validity 10000 \
+          -storepass android \
+          -keypass android \
+          -dname "CN=Android Debug,O=Android,C=US"
+
       - name: Build & Deploy to Firebase App Distribution
         working-directory: android
         env:

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -174,6 +174,9 @@ jobs:
             --bundle-output android/app/src/main/assets/index.android.bundle \
             --assets-dest android/app/src/main/res
 
+      - name: Set Java heap size for Gradle
+        run: echo "_JAVA_OPTIONS=-Xmx4096m" >> $GITHUB_ENV
+
       - name: Build & Deploy to Firebase App Distribution
         working-directory: android
         env:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,10 +84,10 @@ android {
     }
     signingConfigs {
         debug {
-            storeFile file('debug.keystore')
-            storePassword 'android'
-            keyAlias 'androiddebugkey'
-            keyPassword 'android'
+            storeFile file(System.getenv("ANDROID_KEYSTORE_FILE"))
+            storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+            keyAlias System.getenv("ANDROID_KEY_ALIAS")
+            keyPassword System.getenv("ANDROID_KEY_PASSWORD")
         }
         release {
             storeFile file(System.getenv("ANDROID_KEYSTORE_FILE"))

--- a/android/fastlane/scripts/firebase_pr_deploy.rb
+++ b/android/fastlane/scripts/firebase_pr_deploy.rb
@@ -20,10 +20,6 @@ def firebase_pr_deploy(pr_number:, pr_title:, project_number:, app_id:, service_
     service_account_path: service_account_path
   )
 
-  sh("mkdir -p android/app/src/main/assets")
-  sh("mkdir -p android/app/src/main/res")
-  sh("npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res")
-
   firebase.build_apk
 
   apk_path = File.expand_path("../../app/build/outputs/apk/debug/app-debug.apk", __dir__)

--- a/android/fastlane/scripts/firebase_pr_deploy.rb
+++ b/android/fastlane/scripts/firebase_pr_deploy.rb
@@ -20,6 +20,10 @@ def firebase_pr_deploy(pr_number:, pr_title:, project_number:, app_id:, service_
     service_account_path: service_account_path
   )
 
+  sh("mkdir -p android/app/src/main/assets")
+  sh("mkdir -p android/app/src/main/res")
+  sh("npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res")
+
   firebase.build_apk
 
   apk_path = File.expand_path("../../app/build/outputs/apk/debug/app-debug.apk", __dir__)

--- a/android/fastlane/scripts/firebase_pr_deploy.rb
+++ b/android/fastlane/scripts/firebase_pr_deploy.rb
@@ -19,6 +19,9 @@ def firebase_pr_deploy(pr_number:, pr_title:, project_number:, app_id:, service_
     app_id: app_id,
     service_account_path: service_account_path
   )
+  sh("mkdir -p android/app/src/main/assets")
+  sh("mkdir -p android/app/src/main/res")
+  sh("npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res")
 
   firebase.build_apk
 


### PR DESCRIPTION
## Fix: Metro Server Error by Pre-Bundling Assets in CI for Android Preview Builds

### Why is this change needed?

This PR resolves the issue where preview APKs deployed via Firebase App Distribution failed to launch due to a missing JS bundle and assets.  
The React Native app was trying to connect to the Metro server, which is unavailable in CI-distributed builds, causing runtime errors on launch.

To fix this, the JS bundle and assets are now pre-generated during the CI process using `npx react-native bundle` and packaged into the APK. This ensures that the app can run standalone on any device without needing the Metro server.

### What does this PR do?

- Adds a bundling step (`react-native bundle`) before building the debug APK.
- Ensures output is written to `android/app/src/main/assets` and `android/app/src/main/res`.
- Fixes directory paths to match the Gradle build expectations.
- Updates both the Fastlane `firebase_pr_deploy.rb` script and GitHub Actions workflow.
- Increases Java heap size via `_JAVA_OPTIONS=-Xmx4096m` to prevent Gradle OOM errors during APK build.

### ✅ How was this tested?

- ✅ Ran `npx react-native bundle` locally and verified `index.android.bundle` and assets were generated correctly.  
- ✅ Downloaded preview APK from Firebase App Distribution.  
- ✅ Installed the APK on a physical Android device.  
- ✅ Verified the app launches successfully without attempting to connect to Metro server.  
- ✅ Confirmed all assets and JS logic are working as expected in the distributed APK.  
- ✅ Validated logs and CI artifacts in GitHub Actions build.  
![WhatsApp Image 2025-06-23 at 14 09 15_c0c5b266](https://github.com/user-attachments/assets/0e64d88a-2ae0-4a23-a359-364060803716)
