### PR TITLE
test: internal track setup for play console

### DIFF
--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -100,8 +100,7 @@ jobs:
   google_play_deploy:
     name: Google Play Internal Track Preview Deploy
     needs: [checks]
-    if: false
-    # if: github.event.action != 'closed'
+    
     runs-on: ubuntu-latest
 
     env:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "com.android.application"
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 apply plugin: "com.facebook.react"
+apply plugin: 'com.google.gms.google-services'
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -108,18 +109,22 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libjsc.so'
+        pickFirst 'lib/arm64-v8a/libjsc.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+    }
 }
 
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
+    implementation 'org.jetbrains:annotations:16.0.2'
+    implementation 'com.google.firebase:firebase-messaging:23.1.2'
 
-    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
-    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
-        exclude group:'com.squareup.okhttp3', module:'okhttp'
-    }
-
-    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}")
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")
     } else {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,13 +3,11 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 24
-        compileSdkVersion = 34
-        targetSdkVersion = 34
-        kotlinVersion = findProperty('android.kotlinVersion') ?: "1.8.21"
-
-        // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
-        ndkVersion = "23.1.7779620"
+        minSdkVersion = 23
+        compileSdkVersion = 35
+        targetSdkVersion = 35
+        ndkVersion = "26.1.10909125"
+        kotlinVersion = "1.9.24"
     }
     repositories {
         google()
@@ -18,6 +16,10 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath "com.bugsnag:bugsnag-android-gradle-plugin:8.+"
+        classpath 'com.google.gms:google-services:4.4.2'
     }
 }
+
+apply plugin: "com.facebook.react.rootproject"

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :android do
 
     version_codes = google_play_track_version_codes(
       package_name: app_identifier,
-      track: "production",
+      track: "internal",
       json_key: ENV["ANDROID_JSON_KEY_FILE"]
     )
     
@@ -121,9 +121,10 @@ end
     )
     
     upload_to_play_store(
-      track: "production",
+      track: "internal",
+      release_status: "completed",
       json_key: ENV["ANDROID_JSON_KEY_FILE"],
-      skip_upload_apk: true,
+      skip_upload_apk: false,
     )
   end
   desc "Deploy APK to Google Play Internal Track App Distribution"


### PR DESCRIPTION
## Description
- Changed Fastlane track from production to internal.
- Enabled `skip_upload_apk: false` and `release_status: "completed"` to upload actual builds.
- This allows safe Play Store testing for the renamed package before production release.


## Screenshots
_NA_