### PR TITLE
feat(linear progressbar): add themed linear progress bar component

### DIFF
--- a/src/components/linear-progress/linearprogress.test.tsx
+++ b/src/components/linear-progress/linearprogress.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NativeBaseProvider } from 'native-base';
+
+import LinearProgressBar from './linearprogress';
+import appTheme from '../../app-theme'; // use your actual theme file
+
+// Use same safe area context mock as SwitchComponent test
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<NativeBaseProvider theme={appTheme}>{ui}</NativeBaseProvider>);
+
+describe('LinearProgressBar', () => {
+  it('renders step variant with correct label and progress bars', () => {
+    const { getByText, getByTestId } = renderWithTheme(
+      <LinearProgressBar variant="step" completedSteps={3} totalSteps={5} />
+    );
+    expect(getByText('Step Progress (3/5)')).toBeTruthy();
+    expect(getByTestId('step-bar-0')).toBeTruthy();
+  });
+
+  it('renders default variant with calculated progress', () => {
+    const { getByText, getByTestId } = renderWithTheme(
+      <LinearProgressBar completedSteps={2} totalSteps={5} />
+    );
+    expect(getByText('2 of 5 steps completed')).toBeTruthy();
+    expect(getByTestId('progress-bar')).toBeTruthy();
+  });
+
+  it('renders bar variant with tick marks', () => {
+    const { getByTestId } = renderWithTheme(
+      <LinearProgressBar variant="bar" value={60} totalSteps={5} />
+    );
+    expect(getByTestId('tick-mark-0')).toBeTruthy();
+  });
+
+  it('renders text variant and highlights correct level', () => {
+    const value = 80;
+    const totalSteps = 5;
+    const currentLevel = Math.min(totalSteps, Math.max(1, Math.ceil((value / 100) * totalSteps)));
+
+    const { getByText } = renderWithTheme(
+      <LinearProgressBar variant="text" value={value} totalSteps={totalSteps} />
+    );
+    expect(getByText(`Lv ${currentLevel}`)).toBeTruthy();
+  });
+});

--- a/src/components/linear-progress/linearprogress.test.tsx
+++ b/src/components/linear-progress/linearprogress.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
 import { render } from '@testing-library/react-native';
 import { NativeBaseProvider } from 'native-base';
+import React from 'react';
+
+import appTheme from '../../app-theme';
 
 import LinearProgressBar from './linearprogress';
-import appTheme from '../../app-theme'; // use your actual theme file
 
 // Use same safe area context mock as SwitchComponent test
 jest.mock('react-native-safe-area-context', () => ({
@@ -17,7 +18,7 @@ const renderWithTheme = (ui: React.ReactElement) =>
 describe('LinearProgressBar', () => {
   it('renders step variant with correct label and progress bars', () => {
     const { getByText, getByTestId } = renderWithTheme(
-      <LinearProgressBar variant="step" completedSteps={3} totalSteps={5} />
+      <LinearProgressBar variant="step" completedSteps={3} totalSteps={5} />,
     );
     expect(getByText('Step Progress (3/5)')).toBeTruthy();
     expect(getByTestId('step-bar-0')).toBeTruthy();
@@ -25,7 +26,7 @@ describe('LinearProgressBar', () => {
 
   it('renders default variant with calculated progress', () => {
     const { getByText, getByTestId } = renderWithTheme(
-      <LinearProgressBar completedSteps={2} totalSteps={5} />
+      <LinearProgressBar completedSteps={2} totalSteps={5} />,
     );
     expect(getByText('2 of 5 steps completed')).toBeTruthy();
     expect(getByTestId('progress-bar')).toBeTruthy();
@@ -33,7 +34,7 @@ describe('LinearProgressBar', () => {
 
   it('renders bar variant with tick marks', () => {
     const { getByTestId } = renderWithTheme(
-      <LinearProgressBar variant="bar" value={60} totalSteps={5} />
+      <LinearProgressBar variant="bar" value={60} totalSteps={5} />,
     );
     expect(getByTestId('tick-mark-0')).toBeTruthy();
   });
@@ -44,7 +45,7 @@ describe('LinearProgressBar', () => {
     const currentLevel = Math.min(totalSteps, Math.max(1, Math.ceil((value / 100) * totalSteps)));
 
     const { getByText } = renderWithTheme(
-      <LinearProgressBar variant="text" value={value} totalSteps={totalSteps} />
+      <LinearProgressBar variant="text" value={value} totalSteps={totalSteps} />,
     );
     expect(getByText(`Lv ${currentLevel}`)).toBeTruthy();
   });

--- a/src/components/linear-progress/linearprogress.tsx
+++ b/src/components/linear-progress/linearprogress.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import { Box, HStack, VStack, Text, Progress, useTheme } from 'native-base';
+
+// Shared props
+type BaseProps = {
+    colorScheme?: keyof ReturnType<typeof useTheme>['colors'];
+    trackColor?: string;
+    label?: string;
+};
+
+// Step variant
+type StepProps = BaseProps & {
+    variant: 'step';
+    completedSteps: number;
+    totalSteps: number;
+};
+
+// Other variants
+type DefaultOrOtherVariantsProps = BaseProps & {
+    variant?: 'default' | 'level' | 'bar' | 'text';
+    value?: number;
+    totalSteps?: number;
+    completedSteps?: number;
+};
+
+type LinearProgressProps = StepProps | DefaultOrOtherVariantsProps;
+
+// Type guards
+const isStepProps = (props: LinearProgressProps): props is StepProps =>
+    props.variant === 'step';
+const isLevelVariant = (props: LinearProgressProps): props is DefaultOrOtherVariantsProps =>
+    props.variant === 'level';
+const isBarVariant = (props: LinearProgressProps): props is DefaultOrOtherVariantsProps =>
+    props.variant === 'bar' || (!props.variant && 'value' in props && 'totalSteps' in props);
+const isTextVariant = (props: LinearProgressProps): props is DefaultOrOtherVariantsProps =>
+    props.variant === 'text';
+
+const LinearProgressBar: React.FC<LinearProgressProps> = (props) => {
+    const {
+        colorScheme = 'primary',
+        trackColor = 'coolGray.200',
+        label,
+    } = props;
+
+    const theme = useTheme();
+
+    // STEP VARIANT
+    if (isStepProps(props)) {
+        const { completedSteps, totalSteps } = props;
+        return (
+            <VStack space={2} w="304px">
+                <HStack alignItems="center" space={2}>
+                    <Box
+                        w="8"
+                        h="8"
+                        rounded="full"
+                        bg="#087122"
+                        alignItems="center"
+                        justifyContent="center"
+                    >
+                        <Text fontSize="18px" color="#FFFFFF">✔</Text>
+                    </Box>
+                    <Text fontSize="18px" bold color="coolGray.700">
+                        Step Progress ({completedSteps}/{totalSteps})
+                    </Text>
+                </HStack>
+
+                <HStack space={1} alignItems="center">
+                    {Array.from({ length: totalSteps }).map((_, index) => (
+                        <Box
+                            key={index}
+                            flex={1}
+                            h="2"
+                            rounded="full"
+                            bg={index < completedSteps ? `${colorScheme}.600` : trackColor}
+                            testID={`step-bar-${index}`}
+                        />
+                    ))}
+                </HStack>
+
+                <Text fontSize="15px" color="coolGray.600">
+                    {completedSteps} of {totalSteps} steps completed
+                </Text>
+            </VStack>
+
+        );
+    }
+
+
+    // DEFAULT VARIANT
+    if (props.variant === 'default' || props.variant === undefined) {
+        const { completedSteps = 0, totalSteps = 1 } = props;
+
+        const calculatedValue = (completedSteps / totalSteps) * 100;
+        const autoLabel = `${completedSteps} of ${totalSteps} steps completed`;
+
+        return (
+            <VStack space={1} w="304px">
+                <Text fontSize="18px">{autoLabel}</Text>
+                <Progress
+                    value={calculatedValue}
+                    colorScheme={colorScheme}
+                    bg={trackColor}
+                    _filledTrack={{ bg: `${colorScheme}.500` }}
+                    testID="progress-bar"
+                />
+            </VStack>
+        );
+    }
+
+
+
+
+
+    // BAR VARIANT
+    if (isBarVariant(props)) {
+        const { value, totalSteps = 5 } = props;
+        return (
+            <VStack space={2} minW={totalSteps * 60} w="304px">
+                <Box position="relative" w="100%" h="10">
+                    <HStack
+                        position="absolute"
+                        top={-1}
+                        left={0}
+                        right={0}
+                        justifyContent="space-between"
+                        px={1}
+                    >
+                        {Array.from({ length: totalSteps }).map((_, index) => (
+                            <Box key={index} alignItems="center">
+                                <Box
+                                    w="1"
+                                    h="2"
+                                    bg="teal.700"
+                                    borderRadius="full"
+                                    testID={`tick-mark-${index}`}
+                                />
+                            </Box>
+                        ))}
+                    </HStack>
+                    <Box h="3" mt={2} bg={trackColor} rounded="full" overflow="hidden">
+                        <Box
+                            h="3"
+                            bg={`${colorScheme}.400`}
+                            width={`${value}%`}
+                            rounded="full"
+                        />
+                    </Box>
+
+
+                </Box>
+            </VStack>
+        );
+    }
+
+    // LEVEL VARIANT
+    if (isLevelVariant(props)) {
+        const { value, totalSteps = 5 } = props;
+        const currentLevel = Math.min(
+            totalSteps,
+            Math.max(1, Math.ceil((value / 100) * totalSteps))
+        );
+
+        return (
+            <VStack space={2} minW={totalSteps * 60} w="304px">
+                <Box position="relative" w="100%" h="6">
+                    <Box h="3" bg={trackColor} rounded="full" overflow="hidden">
+                        <Box
+                            h="3"
+                            bg={`${colorScheme}.500`}
+                            width={`${value}%`}
+                            rounded="full"
+                        />
+                    </Box>
+                    <HStack
+                        position="absolute"
+                        top={-2.5}
+                        left={0}
+                        right={0}
+                        justifyContent="space-between"
+                        px={1}
+                    >
+                        {Array.from({ length: totalSteps }).map((_, index) => (
+                            <Box key={index} alignItems="center">
+                                <Box
+                                    w="1"
+                                    h="4"
+                                    bg="bg={`${colorScheme}.500`}"
+                                    borderRadius="full"
+                                    testID={`level-box-${index}`}
+                                />
+                            </Box>
+                        ))}
+                    </HStack>
+                </Box>
+            </VStack>
+        );
+    }
+
+    // TEXT VARIANT
+    if (isTextVariant(props)) {
+        const { value, totalSteps = 5 } = props;
+        const currentLevel = Math.min(
+            totalSteps,
+            Math.max(1, Math.ceil((value / 100) * totalSteps))
+        );
+
+        return (
+            <HStack space={4} alignItems="flex-end" py={4} w="350px">
+                {Array.from({ length: totalSteps }).map((_, index) => {
+                    const level = index + 1;
+                    const isCurrent = level === currentLevel;
+                    return (
+                        <Box
+                            key={index}
+                            flex={1}
+                            alignItems="center"
+                            justifyContent="center"
+                            position="relative"
+                        >
+                            {isCurrent ? (
+                                <>
+                                    <Box
+                                        bg={`${colorScheme}.500`}
+                                        px={3}
+                                        py={2}
+                                        borderRadius="md"
+                                        position="relative"
+                                        zIndex={1}
+                                    >
+                                        <Text fontSize="18px" fontWeight="bold" color="black">
+                                            Lv {level}
+                                        </Text>
+                                        {/* Triangle Pointer */}
+                                        <Box
+                                            position="absolute"
+                                            bottom={-6}
+                                            left="50%"
+                                            ml="10%"
+                                            borderLeftWidth={6}
+                                            borderRightWidth={6}
+                                            borderTopWidth={6}
+                                            borderLeftColor="transparent"
+                                            borderRightColor="transparent"
+                                            borderTopColor={`${colorScheme}.500`}
+                                        />
+                                    </Box>
+                                </>
+                            ) : (
+                                <Text fontSize="18px" color="gray.500" fontWeight="medium">
+                                    Lv {level}
+                                </Text>
+                            )}
+                        </Box>
+                    );
+                })}
+            </HStack>
+        );
+    }
+
+    return null;
+};
+
+export default LinearProgressBar;

--- a/src/components/linear-progress/linearprogress.tsx
+++ b/src/components/linear-progress/linearprogress.tsx
@@ -47,11 +47,11 @@ const LinearProgressBar: React.FC<LinearProgressProps> = props => {
               w="8"
               h="8"
               rounded="full"
-              bg="#087122"
+              bg="success.700"
               alignItems="center"
               justifyContent="center"
             >
-              <Text fontSize="18px" color="#FFFFFF">
+              <Text fontSize="18px" color="secondary.50">
                 ✔
               </Text>
             </Box>

--- a/src/components/linear-progress/linearprogress.tsx
+++ b/src/components/linear-progress/linearprogress.tsx
@@ -1,264 +1,234 @@
+import { Box, HStack, Progress, ScrollView, Text, useTheme, VStack } from 'native-base';
 import React from 'react';
-import { Box, HStack, VStack, Text, Progress, useTheme } from 'native-base';
 
-// Shared props
 type BaseProps = {
-    colorScheme?: keyof ReturnType<typeof useTheme>['colors'];
-    trackColor?: string;
-    label?: string;
+  colorScheme?: keyof ReturnType<typeof useTheme>['colors'];
+  trackColor?: string;
+  label?: string;
 };
 
-// Step variant
 type StepProps = BaseProps & {
-    variant: 'step';
-    completedSteps: number;
-    totalSteps: number;
+  variant: 'step';
+  completedSteps: number;
+  totalSteps: number;
 };
 
-// Other variants
 type DefaultOrOtherVariantsProps = BaseProps & {
-    variant?: 'default' | 'level' | 'bar' | 'text';
-    value?: number;
-    totalSteps?: number;
-    completedSteps?: number;
+  variant?: 'default' | 'level' | 'bar' | 'text';
+  value?: number;
+  totalSteps?: number;
+  completedSteps?: number;
 };
 
 type LinearProgressProps = StepProps | DefaultOrOtherVariantsProps;
 
-// Type guards
-const isStepProps = (props: LinearProgressProps): props is StepProps =>
-    props.variant === 'step';
+const isStepProps = (props: LinearProgressProps): props is StepProps => props.variant === 'step';
+
 const isLevelVariant = (props: LinearProgressProps): props is DefaultOrOtherVariantsProps =>
-    props.variant === 'level';
+  props.variant === 'level';
+
 const isBarVariant = (props: LinearProgressProps): props is DefaultOrOtherVariantsProps =>
-    props.variant === 'bar' || (!props.variant && 'value' in props && 'totalSteps' in props);
+  props.variant === 'bar' || (!props.variant && 'value' in props && 'totalSteps' in props);
+
 const isTextVariant = (props: LinearProgressProps): props is DefaultOrOtherVariantsProps =>
-    props.variant === 'text';
+  props.variant === 'text';
 
-const LinearProgressBar: React.FC<LinearProgressProps> = (props) => {
-    const {
-        colorScheme = 'primary',
-        trackColor = 'coolGray.200',
-        label,
-    } = props;
+const LinearProgressBar: React.FC<LinearProgressProps> = props => {
+  const { colorScheme = 'primary', trackColor = 'coolGray.200' } = props;
 
-    const theme = useTheme();
+  if (isStepProps(props)) {
+    const { completedSteps, totalSteps } = props;
 
-    // STEP VARIANT
-    if (isStepProps(props)) {
-        const { completedSteps, totalSteps } = props;
-        return (
-            <VStack space={2} w="304px">
-                <HStack alignItems="center" space={2}>
-                    <Box
-                        w="8"
-                        h="8"
-                        rounded="full"
-                        bg="#087122"
-                        alignItems="center"
-                        justifyContent="center"
-                    >
-                        <Text fontSize="18px" color="#FFFFFF">✔</Text>
-                    </Box>
-                    <Text fontSize="18px" bold color="coolGray.700">
-                        Step Progress ({completedSteps}/{totalSteps})
-                    </Text>
-                </HStack>
+    return (
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <VStack space={2} w="304px">
+          <HStack alignItems="center" space={2}>
+            <Box
+              w="8"
+              h="8"
+              rounded="full"
+              bg="#087122"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Text fontSize="18px" color="#FFFFFF">
+                ✔
+              </Text>
+            </Box>
+            <Text fontSize="18px" bold color="coolGray.700">
+              Step Progress ({completedSteps}/{totalSteps})
+            </Text>
+          </HStack>
+          <HStack space={1} alignItems="center">
+            {Array.from({ length: totalSteps }).map((_, index) => (
+              <Box
+                key={index}
+                flex={1}
+                h="2"
+                rounded="full"
+                bg={index < completedSteps ? `${colorScheme}.600` : trackColor}
+                testID={`step-bar-${index}`}
+              />
+            ))}
+          </HStack>
+          <Text fontSize="15px" color="coolGray.600">
+            {completedSteps} of {totalSteps} steps completed
+          </Text>
+        </VStack>
+      </ScrollView>
+    );
+  }
 
-                <HStack space={1} alignItems="center">
-                    {Array.from({ length: totalSteps }).map((_, index) => (
-                        <Box
-                            key={index}
-                            flex={1}
-                            h="2"
-                            rounded="full"
-                            bg={index < completedSteps ? `${colorScheme}.600` : trackColor}
-                            testID={`step-bar-${index}`}
-                        />
-                    ))}
-                </HStack>
+  if (props.variant === 'default' || props.variant === undefined) {
+    const { completedSteps = 0, totalSteps = 1 } = props;
+    const calculatedValue = (completedSteps / totalSteps) * 100;
+    const autoLabel = `${completedSteps} of ${totalSteps} steps completed`;
 
-                <Text fontSize="15px" color="coolGray.600">
-                    {completedSteps} of {totalSteps} steps completed
-                </Text>
-            </VStack>
+    return (
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <VStack space={1} w="304px">
+          <Text fontSize="18px">{autoLabel}</Text>
+          <Progress
+            value={calculatedValue}
+            colorScheme={colorScheme}
+            bg={trackColor}
+            _filledTrack={{ bg: `${colorScheme}.500` }}
+            testID="progress-bar"
+          />
+        </VStack>
+      </ScrollView>
+    );
+  }
 
-        );
-    }
+  if (isBarVariant(props)) {
+    const { value = 0, totalSteps = 5 } = props;
 
-
-    // DEFAULT VARIANT
-    if (props.variant === 'default' || props.variant === undefined) {
-        const { completedSteps = 0, totalSteps = 1 } = props;
-
-        const calculatedValue = (completedSteps / totalSteps) * 100;
-        const autoLabel = `${completedSteps} of ${totalSteps} steps completed`;
-
-        return (
-            <VStack space={1} w="304px">
-                <Text fontSize="18px">{autoLabel}</Text>
-                <Progress
-                    value={calculatedValue}
-                    colorScheme={colorScheme}
-                    bg={trackColor}
-                    _filledTrack={{ bg: `${colorScheme}.500` }}
-                    testID="progress-bar"
-                />
-            </VStack>
-        );
-    }
-
-
-
-
-
-    // BAR VARIANT
-    if (isBarVariant(props)) {
-        const { value, totalSteps = 5 } = props;
-        return (
-            <VStack space={2} minW={totalSteps * 60} w="304px">
-                <Box position="relative" w="100%" h="10">
-                    <HStack
-                        position="absolute"
-                        top={-1}
-                        left={0}
-                        right={0}
-                        justifyContent="space-between"
-                        px={1}
-                    >
-                        {Array.from({ length: totalSteps }).map((_, index) => (
-                            <Box key={index} alignItems="center">
-                                <Box
-                                    w="1"
-                                    h="2"
-                                    bg="teal.700"
-                                    borderRadius="full"
-                                    testID={`tick-mark-${index}`}
-                                />
-                            </Box>
-                        ))}
-                    </HStack>
-                    <Box h="3" mt={2} bg={trackColor} rounded="full" overflow="hidden">
-                        <Box
-                            h="3"
-                            bg={`${colorScheme}.400`}
-                            width={`${value}%`}
-                            rounded="full"
-                        />
-                    </Box>
-
-
+    return (
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <VStack space={2} minW={totalSteps * 60} w="304px">
+          <Box position="relative" w="100%" h="10">
+            <HStack
+              position="absolute"
+              top={-1}
+              left={0}
+              right={0}
+              justifyContent="space-between"
+              px={1}
+            >
+              {Array.from({ length: totalSteps }).map((_, index) => (
+                <Box key={index} alignItems="center">
+                  <Box
+                    w="1"
+                    h="2"
+                    bg="teal.700"
+                    borderRadius="full"
+                    testID={`tick-mark-${index}`}
+                  />
                 </Box>
-            </VStack>
-        );
-    }
-
-    // LEVEL VARIANT
-    if (isLevelVariant(props)) {
-        const { value, totalSteps = 5 } = props;
-        const currentLevel = Math.min(
-            totalSteps,
-            Math.max(1, Math.ceil((value / 100) * totalSteps))
-        );
-
-        return (
-            <VStack space={2} minW={totalSteps * 60} w="304px">
-                <Box position="relative" w="100%" h="6">
-                    <Box h="3" bg={trackColor} rounded="full" overflow="hidden">
-                        <Box
-                            h="3"
-                            bg={`${colorScheme}.500`}
-                            width={`${value}%`}
-                            rounded="full"
-                        />
-                    </Box>
-                    <HStack
-                        position="absolute"
-                        top={-2.5}
-                        left={0}
-                        right={0}
-                        justifyContent="space-between"
-                        px={1}
-                    >
-                        {Array.from({ length: totalSteps }).map((_, index) => (
-                            <Box key={index} alignItems="center">
-                                <Box
-                                    w="1"
-                                    h="4"
-                                    bg="bg={`${colorScheme}.500`}"
-                                    borderRadius="full"
-                                    testID={`level-box-${index}`}
-                                />
-                            </Box>
-                        ))}
-                    </HStack>
-                </Box>
-            </VStack>
-        );
-    }
-
-    // TEXT VARIANT
-    if (isTextVariant(props)) {
-        const { value, totalSteps = 5 } = props;
-        const currentLevel = Math.min(
-            totalSteps,
-            Math.max(1, Math.ceil((value / 100) * totalSteps))
-        );
-
-        return (
-            <HStack space={4} alignItems="flex-end" py={4} w="350px">
-                {Array.from({ length: totalSteps }).map((_, index) => {
-                    const level = index + 1;
-                    const isCurrent = level === currentLevel;
-                    return (
-                        <Box
-                            key={index}
-                            flex={1}
-                            alignItems="center"
-                            justifyContent="center"
-                            position="relative"
-                        >
-                            {isCurrent ? (
-                                <>
-                                    <Box
-                                        bg={`${colorScheme}.500`}
-                                        px={3}
-                                        py={2}
-                                        borderRadius="md"
-                                        position="relative"
-                                        zIndex={1}
-                                    >
-                                        <Text fontSize="18px" fontWeight="bold" color="black">
-                                            Lv {level}
-                                        </Text>
-                                        {/* Triangle Pointer */}
-                                        <Box
-                                            position="absolute"
-                                            bottom={-6}
-                                            left="50%"
-                                            ml="10%"
-                                            borderLeftWidth={6}
-                                            borderRightWidth={6}
-                                            borderTopWidth={6}
-                                            borderLeftColor="transparent"
-                                            borderRightColor="transparent"
-                                            borderTopColor={`${colorScheme}.500`}
-                                        />
-                                    </Box>
-                                </>
-                            ) : (
-                                <Text fontSize="18px" color="gray.500" fontWeight="medium">
-                                    Lv {level}
-                                </Text>
-                            )}
-                        </Box>
-                    );
-                })}
+              ))}
             </HStack>
-        );
-    }
+            <Box h="3" mt={2} bg={trackColor} rounded="full" overflow="hidden">
+              <Box h="3" bg={`${colorScheme}.400`} width={`${value}%`} rounded="full" />
+            </Box>
+          </Box>
+        </VStack>
+      </ScrollView>
+    );
+  }
 
-    return null;
+  if (isLevelVariant(props)) {
+    const { value = 0, totalSteps = 5 } = props;
+
+    return (
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <VStack space={2} minW={totalSteps * 60} w="304px">
+          <Box position="relative" w="100%" h="6">
+            <Box h="3" bg={trackColor} rounded="full" overflow="hidden">
+              <Box h="3" bg={`${colorScheme}.500`} width={`${value}%`} rounded="full" />
+            </Box>
+            <HStack
+              position="absolute"
+              top={-2.5}
+              left={0}
+              right={0}
+              justifyContent="space-between"
+              px={1}
+            >
+              {Array.from({ length: totalSteps }).map((_, index) => (
+                <Box key={index} alignItems="center">
+                  <Box
+                    w="1"
+                    h="4"
+                    bg={`${colorScheme}.500`}
+                    borderRadius="full"
+                    testID={`level-box-${index}`}
+                  />
+                </Box>
+              ))}
+            </HStack>
+          </Box>
+        </VStack>
+      </ScrollView>
+    );
+  }
+
+  if (isTextVariant(props)) {
+    const { value = 0, totalSteps = 5 } = props;
+    const currentLevel = Math.min(totalSteps, Math.max(1, Math.ceil((value / 100) * totalSteps)));
+
+    return (
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <HStack space={4} alignItems="flex-end" py={4} px={2}>
+          {Array.from({ length: totalSteps }).map((_, index) => {
+            const level = index + 1;
+            const isCurrent = level === currentLevel;
+            return (
+              <Box
+                key={index}
+                flex={1}
+                alignItems="center"
+                justifyContent="center"
+                position="relative"
+              >
+                {isCurrent ? (
+                  <Box
+                    bg={`${colorScheme}.500`}
+                    px={3}
+                    py={2}
+                    borderRadius="md"
+                    position="relative"
+                    zIndex={1}
+                  >
+                    <Text fontSize="18px" fontWeight="bold" color="black">
+                      Lv {level}
+                    </Text>
+                    <Box
+                      position="absolute"
+                      bottom={-6}
+                      left="50%"
+                      ml="10%"
+                      borderLeftWidth={6}
+                      borderRightWidth={6}
+                      borderTopWidth={6}
+                      borderLeftColor="transparent"
+                      borderRightColor="transparent"
+                      borderTopColor={`${colorScheme}.500`}
+                    />
+                  </Box>
+                ) : (
+                  <Text fontSize="18px" color="gray.500" fontWeight="medium">
+                    Lv {level}
+                  </Text>
+                )}
+              </Box>
+            );
+          })}
+        </HStack>
+      </ScrollView>
+    );
+  }
+
+  return null;
 };
 
 export default LinearProgressBar;


### PR DESCRIPTION
## Description
This pull request introduces a **themed linear progress bar component** using `NativeBase`. It supports multiple visual variants including:
- `default`
- `step`
- `bar`
- `text`
- `level`

Each variant is visually distinct and customizable via props.

## Screenshots
<img width="346" height="555" alt="Screenshot 2025-07-15 215741" src="https://github.com/user-attachments/assets/bfbd6905-c90d-4410-902c-9d176b3abd0b" />

## Tests
### Automated test cases added
<img width="1093" height="360" alt="Screenshot 2025-07-15 215808" src="https://github.com/user-attachments/assets/b8324e6f-6102-467b-875e-78df27d1d27a" />


### Manual test cases run
- **Default Variant**
  - Pass `variant="default"` with `completedSteps=3` and `totalSteps=5`
  - ✅ Should render a progress bar and show text: “3 of 5 steps completed”

- **Step Variant**
  - Pass `variant="step"` with `completedSteps=2` and `totalSteps=5`
  - ✅ Should render horizontal bars and show label: “Step Progress (2/5)”

- **Bar Variant**
  - Pass `variant="bar"` with `value=60` and `totalSteps=5`
  - ✅ Should render a filled bar and 5 evenly spaced tick marks above

- **Text Variant**
  - Pass `variant="text"` with `value=80` and `totalSteps=5`
  - ✅ Should highlight “Lv 4” with a floating box and triangle pointer

- **Level Variant**
  - Pass `variant="level"` with `value=45` and `totalSteps=5`
  - ✅ Should show filled bar with vertical markers (level boxes)
