### PR TITLE
feat(stepper): add themed steppers component

### DIFF
--- a/src/components/stepper/stepper.test.tsx
+++ b/src/components/stepper/stepper.test.tsx
@@ -1,0 +1,99 @@
+import { render, fireEvent } from '@testing-library/react-native';
+import { NativeBaseProvider } from 'native-base';
+import React from 'react';
+
+import appTheme from '../../app-theme';
+
+import Stepper from './stepper';
+
+// Mock SafeAreaProvider for NativeBase
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<NativeBaseProvider theme={appTheme}>{ui}</NativeBaseProvider>);
+
+describe('Stepper Component', () => {
+  it('renders stepper with correct number of steps and highlights completed ones', () => {
+    const { getByText, getAllByText } = renderWithTheme(
+      <Stepper
+        numberOfSteps={5}
+        lastActivated={3}
+        stepDetailsList={['Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5']}
+      />,
+    );
+
+    expect(getByText('3 of 5 steps completed')).toBeTruthy();
+
+    const checkmarks = getAllByText('✓');
+    expect(checkmarks.length).toBeGreaterThan(0);
+  });
+
+  it('shows tooltip on step press and hides on second press', () => {
+    const { getByText, queryByText } = renderWithTheme(
+      <Stepper
+        numberOfSteps={3}
+        lastActivated={1}
+        stepDetailsList={['Step A', 'Step B', 'Step C']}
+      />,
+    );
+
+    const step1 = getByText('✓');
+    fireEvent.press(step1);
+
+    expect(getByText('Step A')).toBeTruthy();
+
+    fireEvent.press(step1);
+    expect(queryByText('Step A')).toBeNull();
+  });
+
+  it('shows failed step when lastFailedStep is passed', () => {
+    const { getByText } = renderWithTheme(
+      <Stepper
+        numberOfSteps={3}
+        lastActivated={2}
+        lastFailedStep={3}
+        stepDetailsList={['Start', 'Middle', 'Error Step']}
+      />,
+    );
+
+    expect(getByText('✕')).toBeTruthy();
+  });
+
+  it('applies custom colors if passed', () => {
+    const { getByText } = renderWithTheme(
+      <Stepper
+        numberOfSteps={2}
+        lastActivated={1}
+        successColor="primary.500"
+        failedColor="error.600"
+        hoverBackground="coolGray.200"
+        hoverTextColor="coolGray.800"
+        stepDetailsList={['First', 'Second']}
+      />,
+    );
+
+    const step = getByText('✓');
+    fireEvent.press(step);
+
+    expect(getByText('First')).toBeTruthy();
+  });
+
+  it('uses default stepDetails text when none provided', () => {
+    const { getByText } = renderWithTheme(<Stepper numberOfSteps={2} lastActivated={1} />);
+
+    fireEvent.press(getByText('✓'));
+
+    expect(getByText('Step 1 details')).toBeTruthy();
+  });
+
+  it('renders correct width if provided', () => {
+    const { getByText } = renderWithTheme(
+      <Stepper numberOfSteps={2} lastActivated={1} width={400} stepDetailsList={['A', 'B']} />,
+    );
+
+    expect(getByText('1 of 2 steps completed')).toBeTruthy();
+  });
+});

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -1,0 +1,229 @@
+import { Text, useTheme } from 'native-base';
+import React, { useState } from 'react';
+import { View, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+
+interface StepperProps {
+  numberOfSteps: number;
+  lastActivated: number;
+  lastFailedStep?: number;
+  stepDetailsList?: string[];
+  successColor?: string;
+  failedColor?: string;
+  hoverBackground?: string;
+  hoverTextColor?: string;
+  width?: number;
+}
+
+const Stepper: React.FC<StepperProps> = ({
+  numberOfSteps,
+  lastActivated,
+  lastFailedStep,
+  stepDetailsList = [],
+  successColor,
+  failedColor,
+  hoverBackground,
+  hoverTextColor,
+  width = 304, // Default width
+}) => {
+  const theme = useTheme();
+  const [activeTooltip, setActiveTooltip] = useState<number | null>(null);
+
+  const getColor = (key: string) => {
+    if (!key) return null;
+    if (key.includes('.')) {
+      const [colorName, shade] = key.split('.');
+      const colorGroup = theme.colors[colorName as keyof typeof theme.colors];
+      if (colorGroup && typeof colorGroup === 'object' && shade in colorGroup) {
+        return (colorGroup as any)[shade];
+      }
+    } else {
+      const color = theme.colors[key as keyof typeof theme.colors];
+      if (typeof color === 'string') {
+        return color;
+      }
+    }
+    return null;
+  };
+
+  const resolvedSuccess =
+    (successColor && getColor(successColor)) || theme.colors.success?.[500] || 'green';
+
+  const resolvedFailed =
+    (failedColor && getColor(failedColor)) || theme.colors.error?.[500] || 'red';
+
+  const resolvedHoverBg =
+    (hoverBackground && getColor(hoverBackground)) || theme.colors.coolGray?.[100] || 'white';
+
+  const resolvedHoverText =
+    (hoverTextColor && getColor(hoverTextColor)) || theme.colors.coolGray?.[900] || 'black';
+
+  return (
+    <View style={{ width }}>
+      {/* Progress Indicator */}
+      <View style={styles.progressContainer}>
+        <Text style={styles.progressText}>
+          <Text style={{ color: resolvedSuccess }}>{`${lastActivated}`}</Text>
+          {` of ${numberOfSteps} steps completed`}
+        </Text>
+      </View>
+
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={styles.container}>
+          {Array.from({ length: numberOfSteps }).map((_, i) => {
+            const isLast = i === numberOfSteps - 1;
+            const isCompleted = i + 1 <= lastActivated;
+            const isFailed = lastFailedStep === i + 1;
+
+            const bgColor = isFailed ? resolvedFailed : isCompleted ? resolvedSuccess : 'white';
+
+            const borderColor = isFailed || isCompleted ? bgColor : '#9ca3af';
+            const stepText = isFailed ? '✕' : isCompleted ? '✓' : `${i + 1}`;
+
+            return (
+              <View key={i} style={styles.stepItem}>
+                <View style={styles.circleWrapper}>
+                  <TouchableOpacity
+                    onPress={() => setActiveTooltip(activeTooltip === i ? null : i)}
+                    activeOpacity={0.7}
+                    style={styles.touchableArea}
+                  >
+                    <View style={[styles.circle, { backgroundColor: bgColor, borderColor }]}>
+                      <Text
+                        style={[styles.text, (isCompleted || isFailed) && styles.completedText]}
+                      >
+                        {stepText}
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+
+                  {/* Tooltip */}
+                  {activeTooltip === i && (
+                    <View style={styles.tooltipContainer}>
+                      <View style={[styles.tooltipArrow, { borderBottomColor: resolvedHoverBg }]} />
+                      <View style={[styles.tooltipBox, { backgroundColor: resolvedHoverBg }]}>
+                        <Text style={[styles.tooltipText, { color: resolvedHoverText }]}>
+                          {stepDetailsList[i] || `Step ${i + 1} details`}
+                        </Text>
+                      </View>
+                    </View>
+                  )}
+                </View>
+
+                {!isLast && <View style={styles.dottedLine} />}
+              </View>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  progressContainer: {
+    marginBottom: 1,
+    paddingHorizontal: 20,
+  },
+  progressText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#374151',
+    lineHeight: 20,
+  },
+  container: {
+    // height: 150,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 35,
+    paddingHorizontal: 20,
+    // backgroundColor: "green"
+  },
+  stepItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    position: 'relative',
+  },
+  circleWrapper: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+  },
+  touchableArea: {
+    padding: 8,
+  },
+  circle: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: '#6b7280',
+    fontWeight: '500',
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  completedText: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  dottedLine: {
+    width: 20,
+    height: 1,
+    borderStyle: 'dotted',
+    borderWidth: 1,
+    borderColor: '#9ca3af',
+    marginHorizontal: 4,
+  },
+  tooltipContainer: {
+    position: 'absolute',
+    top: 40,
+    left: -75,
+    right: -75,
+    alignItems: 'center',
+    zIndex: 1000,
+  },
+  tooltipBox: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    minWidth: 100,
+    maxWidth: 150,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  tooltipText: {
+    fontSize: 12,
+    textAlign: 'center',
+    flexWrap: 'wrap',
+  },
+  tooltipArrow: {
+    width: 0,
+    height: 0,
+    borderLeftWidth: 6,
+    borderRightWidth: 6,
+    borderBottomWidth: 6,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderTopColor: 'transparent',
+    marginBottom: -1,
+  },
+});
+
+Stepper.defaultProps = {
+  stepDetailsList: [],
+  successColor: undefined,
+  failedColor: undefined,
+  hoverBackground: undefined,
+  hoverTextColor: undefined,
+  lastFailedStep: undefined,
+  width: 304,
+};
+
+export default Stepper;

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -76,7 +76,7 @@ const Stepper: React.FC<StepperProps> = ({
 
             const bgColor = isFailed ? resolvedFailed : isCompleted ? resolvedSuccess : 'white';
 
-            const borderColor = isFailed || isCompleted ? bgColor : '#9ca3af';
+            const borderColor = isFailed || isCompleted ? bgColor : 'secondary.500';
             const stepText = isFailed ? '✕' : isCompleted ? '✓' : `${i + 1}`;
 
             return (
@@ -127,7 +127,7 @@ const styles = StyleSheet.create({
   progressText: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#374151',
+    color: 'secondary.700',
     lineHeight: 20,
   },
   container: {
@@ -160,7 +160,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   text: {
-    color: '#6b7280',
+    color: 'secondary.600',
     fontWeight: '500',
     fontSize: 14,
     textAlign: 'center',
@@ -174,7 +174,7 @@ const styles = StyleSheet.create({
     height: 1,
     borderStyle: 'dotted',
     borderWidth: 1,
-    borderColor: '#9ca3af',
+    borderColor: 'secondary.500',
     marginHorizontal: 4,
   },
   tooltipContainer: {
@@ -192,7 +192,7 @@ const styles = StyleSheet.create({
     minWidth: 100,
     maxWidth: 150,
     alignItems: 'center',
-    shadowColor: '#000',
+    shadowColor: 'secondary.900',
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.25,
     shadowRadius: 4,


### PR DESCRIPTION
## Description

This pull request introduces a new feature: **Themed Stepper Component**.  
The goal is to add a customizable, visually interactive stepper UI component using `native-base` and React Native.

### Features:
- Dynamic number of steps with completed and failed state indicators
- Tooltip support on each step for additional context
- Supports custom colors via theme tokens or direct input
- Responsive layout with optional width customization

## Screenshots


https://github.com/user-attachments/assets/3022e802-de97-49be-a303-1a55aca30666


## Tests
### Automated test cases added
<img width="908" height="404" alt="Steppers" src="https://github.com/user-attachments/assets/7e489b8d-ca6b-4fea-858a-20e6194c270e" />


### Manual test cases run
## Manual Test Cases

_For each manual test case, list the steps to test or reproduce the PR._

### ✅ Test Case 1: Renders Correct Number of Steps
- Render the `<Stepper />` component with `numberOfSteps={5}`.
- Ensure 5 step indicators are visible on the screen.
- Confirm the first `n` steps (based on `lastActivated`) are marked as completed.

### ✅ Test Case 2: Tooltip Display and Toggle
- Tap on any step circle.
- Tooltip should appear with correct step description.
- Tap again on the same step to hide the tooltip.

### ✅ Test Case 3: Failed Step Highlighting
- Pass `lastFailedStep={3}` and `lastActivated={2}`.
- Ensure the 3rd step shows a red ✕ icon.
