### PR TITLE
fix: update Privacy Policy link to new URL

### DIFF
--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -140,7 +140,7 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
             By continuing, you agree to our
             <Link
               _text={{ color: 'primary.500', underline: true, marginLeft: 1 }}
-              href="https://jalantechnologies.github.io/boilerplate-react-native/"
+              href="https://jalantechnologies.github.io/react-native-template/"
               isExternal
             >
               Privacy Policy


### PR DESCRIPTION
## Description

Updated the Privacy Policy link in the phone authentication form from
`https://jalantechnologies.github.io/boilerplate-react-native/`
to the new URL:
`https://jalantechnologies.github.io/react-native-template/`

This ensures users are redirected to the correct and updated Privacy Policy page.

## Screenshots

*No UI change; link update only.*

## Tests

### Automated test cases added

* No automated tests added — this change only updates a static link.

### Manual test cases run

* Verified that the Privacy Policy link in the login screen now opens the correct new URL in an external browser.
* Confirmed that the rest of the form works as expected (e.g., entering phone number, checkbox toggle).
* Checked on both Android and iOS simulators to ensure the link works consistently.
