### PR TITLE
fix: add authorization header to deleteAccount API call

### DIFF
--- a/src/services/account.service.ts
+++ b/src/services/account.service.ts
@@ -1,4 +1,5 @@
 import { AccessToken, APIResponse } from '../types';
+
 import { APIService } from './api-service';
 
 export class AccountService extends APIService {

--- a/src/services/account.service.ts
+++ b/src/services/account.service.ts
@@ -1,5 +1,4 @@
 import { AccessToken, APIResponse } from '../types';
-
 import { APIService } from './api-service';
 
 export class AccountService extends APIService {
@@ -26,6 +25,9 @@ export class AccountService extends APIService {
   };
 
   deleteAccount = async (userAccessToken: AccessToken): Promise<APIResponse> => {
-    return this.delete(`/accounts/${userAccessToken.accountId}`);
+    return this.delete(
+      `/accounts/${userAccessToken.accountId}`,
+      this.getAuthorizationHeader(userAccessToken.token),
+    );
   };
 }


### PR DESCRIPTION
## Description
Added the missing authorization header to the `deleteAccount` method in `AccountService`.  
This ensures that the delete API call is authenticated, aligning it with other methods like `getAccount` and `updateAccount`.  
No new endpoints were created; this change updates the request to include the existing auth header.

## Screenshots

<img width="540" height="1206" alt="image" src="https://github.com/user-attachments/assets/eedff45d-d293-4c6c-9d6c-c390615ed254" />

<img width="540" height="1206" alt="image" src="https://github.com/user-attachments/assets/3602b284-dedf-4d83-8086-47bd19665d53" />



## Tests
### Automated test cases added
- N/A – this is a small service layer fix; no new automated tests were added.

### Manual test cases run
- Verified that deleting an account now correctly sends the Authorization header.
- Confirmed the API successfully deletes the account when a valid token is provided.
- Confirmed the API responds with an unauthorized error when an invalid token is used.

## Video
[Loom Video](https://www.loom.com/share/1403bd84628d4b168daaab9b338654d3?sid=7a5ce863-da1d-463b-b440-bf36a7b92a34)
