### PR TITLE
fix: map over data.items in TaskContextProvider instead of data

### DIFF
--- a/src/contexts/task-context.tsx
+++ b/src/contexts/task-context.tsx
@@ -44,7 +44,7 @@ export const TaskContextProvider: React.FC<PropsWithChildren> = ({ children }) =
     setIsTasksLoading(true);
     const { data, error } = await taskService.getAllTasks(getAccessToken());
     if (data) {
-      setTasks(data.map((task: Task) => new Task({ ...task })));
+      setTasks(data.items.map((task: Task) => new Task({ ...task })));
     }
     if (error) {
       setIsTasksLoading(false);


### PR DESCRIPTION
# Description

This PR fixes a bug in the TaskContextProvider where the code was attempting to map over the `data` object directly instead of the `data.items` array. The API response structure returns tasks within an `items` property, so we need to access `data.items` to properly iterate over the task list. This change ensures that tasks are correctly loaded and displayed in the application.

**Root Cause:** The `taskService.getAllTasks()` API returns a response with the structure `{ items: Task[], ... }` rather than a direct array of tasks.

**Fix:** Updated the mapping logic to access `data.items` instead of `data` directly.

# Screenshots

<img width="482" height="892" alt="Screenshot from 2025-07-27 16-36-55" src="https://github.com/user-attachments/assets/ee595e1a-8ee5-407c-abb3-34b52390ec0d" />

# Video

[click here](https://www.loom.com/share/05732327c6e540a1b3e3eecac96cc5b0?sid=f78d94c5-f578-4b06-bddd-727433c1fa40)

# Tests

## Manual test cases run

**For each manual test case, list the steps to test or reproduce the PR.**

- **Test Case 1: Verify tasks load correctly**
  1. Navigate to the tasks screen/component that uses TaskContextProvider
  2. Ensure the app doesn't crash on load
  3. Verify that all tasks are displayed correctly
  4. Confirm loading state works as expected

- **Test Case 2: Test with empty task list**
  1. Clear all tasks from the backend/mock empty response
  2. Load the tasks screen
  3. Verify the app handles empty `data.items` array gracefully
  4. Confirm no errors are thrown
