### PR TITLE
fix: change api url

### DIFF
--- a/ios/.env.preview
+++ b/ios/.env.preview
@@ -1,5 +1,5 @@
 ENVIRONMENT=preview
-API_BASE_URL=https://boilerplate-mern.platform.jalantechnologies.com/api
+API_BASE_URL=https://flask-react-template.platform.bettrhq.com/api
 
 DD_APPLICATION_ID=6755ccc7-0bf2-443e-bd4e-8df82d66f19d
 DD_CLIENT_TOKEN=pubad56f120eb0de2c58f2c976eac4d292c


### PR DESCRIPTION
## Description
_This PR updates `API_BASE_URL` to `https://flask-react-template.platform.bettrhq.com/api` at `.env.preview`._

## Why this changes needed
- The old API `https://boilerplate-mern.platform.jalantechnologies.com/api` is deprecated and application now currently uses `https://flask-react-template.platform.bettrhq.com/api`


