### PR TITLE
chore: update src/ file structure references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "boilerplate-react-native",
+  "name": "react-native-template",
   "version": "0.0.3",
   "private": true,
   "description": "Boilerplate project for React Native apps.",

--- a/src/components/avatar/avatar.styles.ts
+++ b/src/components/avatar/avatar.styles.ts
@@ -1,7 +1,7 @@
-import { AvatarSize } from 'react-native-template/src/types';
 import { useTheme } from 'native-base';
 import { StyleSheet } from 'react-native';
 import type { ViewStyle, ImageStyle, TextStyle } from 'react-native';
+import { AvatarSize } from 'react-native-template/src/types';
 
 const sizeMap = {
   [AvatarSize.small]: 32,

--- a/src/components/avatar/avatar.styles.ts
+++ b/src/components/avatar/avatar.styles.ts
@@ -1,4 +1,4 @@
-import { AvatarSize } from 'boilerplate-react-native/src/types';
+import { AvatarSize } from 'react-native-template/src/types';
 import { useTheme } from 'native-base';
 import { StyleSheet } from 'react-native';
 import type { ViewStyle, ImageStyle, TextStyle } from 'react-native';

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -1,4 +1,4 @@
-import { AvatarShape, AvatarSize } from 'boilerplate-react-native/src/types';
+import { AvatarShape, AvatarSize } from 'react-native-template/src/types';
 import { Box, Text, Image } from 'native-base';
 import React, { useState } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -1,7 +1,7 @@
-import { AvatarShape, AvatarSize } from 'react-native-template/src/types';
 import { Box, Text, Image } from 'native-base';
 import React, { useState } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
+import { AvatarShape, AvatarSize } from 'react-native-template/src/types';
 
 import { useAvatarStyles } from './avatar.styles';
 export interface AvatarProps {

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -31,7 +31,9 @@ const Badge: React.FC<BadgeProps> = ({
     type === BadgeType.LIGHT || type === BadgeType.TEXT ? colorStyle.text : { color: 'white' };
 
   const renderEnhancer = (enhancer?: React.ReactNode) => {
-    if (!enhancer) return null;
+    if (!enhancer) {
+      return null;
+    }
 
     if (typeof enhancer === 'string' || typeof enhancer === 'number') {
       return <Text style={[styles.label, sizeStyle.text, textColorStyle]}>{enhancer}</Text>;

--- a/src/components/brand/brand.test.tsx
+++ b/src/components/brand/brand.test.tsx
@@ -9,7 +9,7 @@ const inset = {
   insets: { top: 0, left: 0, right: 0, bottom: 0 },
 };
 
-jest.mock('boilerplate-react-native/assets/img/logo.svg', () => {
+jest.mock('react-native-template/assets/img/logo.svg', () => {
   const TestReact = require('react');
   return () => TestReact.createElement('SvgMock');
 });

--- a/src/components/brand/brand.tsx
+++ b/src/components/brand/brand.tsx
@@ -1,5 +1,5 @@
-import BrandLogo from 'boilerplate-react-native/assets/img/logo.svg';
-import { SpinnerSize, SpinnerTypes } from 'boilerplate-react-native/src/types/spinner';
+import BrandLogo from 'react-native-template/assets/img/logo.svg';
+import { SpinnerSize, SpinnerTypes } from 'react-native-template/src/types/spinner';
 import { useTheme, Box } from 'native-base';
 import React, { useRef, useEffect, useMemo } from 'react';
 import { Animated, Dimensions, Text, StyleSheet } from 'react-native';

--- a/src/components/brand/brand.tsx
+++ b/src/components/brand/brand.tsx
@@ -1,8 +1,8 @@
-import BrandLogo from 'react-native-template/assets/img/logo.svg';
-import { SpinnerSize, SpinnerTypes } from 'react-native-template/src/types/spinner';
 import { useTheme, Box } from 'native-base';
 import React, { useRef, useEffect, useMemo } from 'react';
 import { Animated, Dimensions, Text, StyleSheet } from 'react-native';
+import BrandLogo from 'react-native-template/assets/img/logo.svg';
+import { SpinnerSize, SpinnerTypes } from 'react-native-template/src/types/spinner';
 
 import Spinner from '../spinner/spinner';
 

--- a/src/components/inputs/password-input.tsx
+++ b/src/components/inputs/password-input.tsx
@@ -1,8 +1,8 @@
-import VisibilityOffIcon from 'react-native-template/assets/icons/visibility-off.svg';
-import VisibilityIcon from 'react-native-template/assets/icons/visibility.svg';
 import { useTheme } from 'native-base';
 import React, { useState } from 'react';
 import { View, TouchableOpacity } from 'react-native';
+import VisibilityOffIcon from 'react-native-template/assets/icons/visibility-off.svg';
+import VisibilityIcon from 'react-native-template/assets/icons/visibility.svg';
 
 import { InputStatus, KeyboardTypes, PasswordInputProps } from '../../types';
 

--- a/src/components/inputs/password-input.tsx
+++ b/src/components/inputs/password-input.tsx
@@ -1,5 +1,5 @@
-import VisibilityOffIcon from 'boilerplate-react-native/assets/icons/visibility-off.svg';
-import VisibilityIcon from 'boilerplate-react-native/assets/icons/visibility.svg';
+import VisibilityOffIcon from 'react-native-template/assets/icons/visibility-off.svg';
+import VisibilityIcon from 'react-native-template/assets/icons/visibility.svg';
 import { useTheme } from 'native-base';
 import React, { useState } from 'react';
 import { View, TouchableOpacity } from 'react-native';

--- a/src/components/modal/modal-footer.component.tsx
+++ b/src/components/modal/modal-footer.component.tsx
@@ -1,5 +1,5 @@
-import { Nullable } from 'boilerplate-react-native/src/types';
-import { ButtonKind } from 'boilerplate-react-native/src/types/button';
+import { Nullable } from 'react-native-template/src/types';
+import { ButtonKind } from 'react-native-template/src//types/button';
 import React from 'react';
 import { View } from 'react-native';
 

--- a/src/components/modal/modal-footer.component.tsx
+++ b/src/components/modal/modal-footer.component.tsx
@@ -1,7 +1,7 @@
-import { Nullable } from 'react-native-template/src/types';
-import { ButtonKind } from 'react-native-template/src//types/button';
 import React from 'react';
 import { View } from 'react-native';
+import { ButtonKind } from 'react-native-template/src//types/button';
+import { Nullable } from 'react-native-template/src/types';
 
 import Button from '../button/button';
 

--- a/src/components/modal/modal-header.component.tsx
+++ b/src/components/modal/modal-header.component.tsx
@@ -1,5 +1,5 @@
-import Close from 'boilerplate-react-native/assets/icons/close.svg';
-import { ButtonKind } from 'boilerplate-react-native/src/types/button';
+import Close from 'react-native-template/assets/icons/close.svg';
+import { ButtonKind } from 'react-native-template/src/types/button';
 import { useTheme } from 'native-base';
 import React from 'react';
 import { View, Text, TextStyle } from 'react-native';

--- a/src/components/modal/modal-header.component.tsx
+++ b/src/components/modal/modal-header.component.tsx
@@ -1,8 +1,8 @@
-import Close from 'react-native-template/assets/icons/close.svg';
-import { ButtonKind } from 'react-native-template/src/types/button';
 import { useTheme } from 'native-base';
 import React from 'react';
 import { View, Text, TextStyle } from 'react-native';
+import Close from 'react-native-template/assets/icons/close.svg';
+import { ButtonKind } from 'react-native-template/src/types/button';
 
 import Button from '../button/button';
 

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,5 +1,5 @@
 // Tag.tsx
-import Close from 'boilerplate-react-native/assets/icons/close.svg';
+import Close from 'react-native-template/assets/icons/close.svg';
 import { Box, Text, Pressable } from 'native-base';
 import React from 'react';
 

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,7 +1,7 @@
 // Tag.tsx
-import Close from 'react-native-template/assets/icons/close.svg';
 import { Box, Text, Pressable } from 'native-base';
 import React from 'react';
+import Close from 'react-native-template/assets/icons/close.svg';
 
 import { useTagStyles } from './tag.styles';
 

--- a/src/components/typography/h2.tsx
+++ b/src/components/typography/h2.tsx
@@ -1,7 +1,7 @@
-import { TypographyProps } from 'react-native-template/src/types/typography';
-import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { H2Styles as styles } from './typography.styles';
 

--- a/src/components/typography/h2.tsx
+++ b/src/components/typography/h2.tsx
@@ -1,5 +1,5 @@
-import { TypographyProps } from 'boilerplate-react-native/src/types/typography';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
 

--- a/src/components/typography/heading-large.tsx
+++ b/src/components/typography/heading-large.tsx
@@ -1,7 +1,7 @@
-import { TypographyProps } from 'react-native-template/src/types/typography';
-import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { HeadingLargeStyles as styles } from './typography.styles';
 

--- a/src/components/typography/heading-large.tsx
+++ b/src/components/typography/heading-large.tsx
@@ -1,5 +1,5 @@
-import { TypographyProps } from 'boilerplate-react-native/src/types/typography';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
 

--- a/src/components/typography/heading-medium.tsx
+++ b/src/components/typography/heading-medium.tsx
@@ -1,7 +1,7 @@
-import { TypographyProps } from 'react-native-template/src/types/typography';
-import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { HeadingMediumStyles as styles } from './typography.styles';
 

--- a/src/components/typography/heading-medium.tsx
+++ b/src/components/typography/heading-medium.tsx
@@ -1,5 +1,5 @@
-import { TypographyProps } from 'boilerplate-react-native/src/types/typography';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
 

--- a/src/components/typography/heading-small.tsx
+++ b/src/components/typography/heading-small.tsx
@@ -1,5 +1,5 @@
-import { TypographyProps } from 'boilerplate-react-native/src/types/typography';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
 

--- a/src/components/typography/heading-small.tsx
+++ b/src/components/typography/heading-small.tsx
@@ -1,7 +1,7 @@
-import { TypographyProps } from 'react-native-template/src/types/typography';
-import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { HeadingSmallStyles as styles } from './typography.styles';
 

--- a/src/components/typography/label-large.tsx
+++ b/src/components/typography/label-large.tsx
@@ -1,7 +1,7 @@
-import { TypographyProps } from 'react-native-template/src/types/typography';
-import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { LabelLargeStyles as styles } from './typography.styles';
 

--- a/src/components/typography/label-large.tsx
+++ b/src/components/typography/label-large.tsx
@@ -1,5 +1,5 @@
-import { TypographyProps } from 'boilerplate-react-native/src/types/typography';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
 

--- a/src/components/typography/paragraph-medium.tsx
+++ b/src/components/typography/paragraph-medium.tsx
@@ -1,7 +1,7 @@
-import { TypographyProps } from 'react-native-template/src/types/typography';
-import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { ParagraphMediumStyles as styles } from './typography.styles';
 

--- a/src/components/typography/paragraph-medium.tsx
+++ b/src/components/typography/paragraph-medium.tsx
@@ -1,5 +1,5 @@
-import { TypographyProps } from 'boilerplate-react-native/src/types/typography';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
 

--- a/src/components/typography/paragraph-small.tsx
+++ b/src/components/typography/paragraph-small.tsx
@@ -1,5 +1,5 @@
-import { TypographyProps } from 'boilerplate-react-native/src/types/typography';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
 

--- a/src/components/typography/paragraph-small.tsx
+++ b/src/components/typography/paragraph-small.tsx
@@ -1,7 +1,7 @@
-import { TypographyProps } from 'react-native-template/src/types/typography';
-import { useThemeColor } from 'react-native-template/src/utils';
 import React, { PropsWithChildren } from 'react';
 import { Text } from 'react-native';
+import { TypographyProps } from 'react-native-template/src/types/typography';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { ParagraphSmallStyles as styles } from './typography.styles';
 

--- a/src/logger/internals/types.ts
+++ b/src/logger/internals/types.ts
@@ -9,7 +9,6 @@ export default interface Logger {
 
   critical(message: string): void;
 }
-
 export enum LoggerTransport {
   Console = 'console',
   Datadog = 'datadog',

--- a/src/navigators/authenticated.tsx
+++ b/src/navigators/authenticated.tsx
@@ -1,10 +1,10 @@
 import { DdSdkReactNative } from '@datadog/mobile-react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
-import HomeIcon from 'react-native-template/assets/icons/home.svg';
-import PersonIcon from 'react-native-template/assets/icons/person.svg';
 import { useTheme } from 'native-base';
 import React, { useEffect } from 'react';
+import HomeIcon from 'react-native-template/assets/icons/home.svg';
+import PersonIcon from 'react-native-template/assets/icons/person.svg';
 
 import { AuthenticatedStackParamsList, AuthenticatedTabParamsList } from '../../@types/navigation';
 import { FullScreenSpinner } from '../components';

--- a/src/navigators/authenticated.tsx
+++ b/src/navigators/authenticated.tsx
@@ -1,8 +1,8 @@
 import { DdSdkReactNative } from '@datadog/mobile-react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
-import HomeIcon from 'boilerplate-react-native/assets/icons/home.svg';
-import PersonIcon from 'boilerplate-react-native/assets/icons/person.svg';
+import HomeIcon from 'react-native-template/assets/icons/home.svg';
+import PersonIcon from 'react-native-template/assets/icons/person.svg';
 import { useTheme } from 'native-base';
 import React, { useEffect } from 'react';
 

--- a/src/screens/auth/change-api-url/change-api-url-modal.tsx
+++ b/src/screens/auth/change-api-url/change-api-url-modal.tsx
@@ -1,9 +1,9 @@
-import { FormControl, Input, Modal } from 'react-native-template/src/components';
-import { ModalProps } from 'react-native-template/src/components/modal/modal';
-import { useLocalStorage } from 'react-native-template/src/utils';
 import { Toast } from 'native-base';
 import React, { useState } from 'react';
 import Config from 'react-native-config';
+import { FormControl, Input, Modal } from 'react-native-template/src/components';
+import { ModalProps } from 'react-native-template/src/components/modal/modal';
+import { useLocalStorage } from 'react-native-template/src/utils';
 
 const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose }) => {
   const localStorage = useLocalStorage();

--- a/src/screens/auth/change-api-url/change-api-url-modal.tsx
+++ b/src/screens/auth/change-api-url/change-api-url-modal.tsx
@@ -1,6 +1,6 @@
-import { FormControl, Input, Modal } from 'boilerplate-react-native/src/components';
-import { ModalProps } from 'boilerplate-react-native/src/components/modal/modal';
-import { useLocalStorage } from 'boilerplate-react-native/src/utils';
+import { FormControl, Input, Modal } from 'react-native-template/src/components';
+import { ModalProps } from 'react-native-template/src/components/modal/modal';
+import { useLocalStorage } from 'react-native-template/src/utils';
 import { Toast } from 'native-base';
 import React, { useState } from 'react';
 import Config from 'react-native-config';

--- a/src/screens/auth/change-api-url/change-api-url.tsx
+++ b/src/screens/auth/change-api-url/change-api-url.tsx
@@ -1,6 +1,6 @@
-import GearIcon from 'boilerplate-react-native/assets/icons/gear.svg';
-import { Button } from 'boilerplate-react-native/src/components';
-import { ButtonKind } from 'boilerplate-react-native/src/types/button';
+import GearIcon from 'react-native-template/assets/icons/gear.svg';
+import { Button } from 'react-native-template/src/components';
+import { ButtonKind } from 'react-native-template/src/types/button';
 import { useTheme } from 'native-base';
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';

--- a/src/screens/auth/change-api-url/change-api-url.tsx
+++ b/src/screens/auth/change-api-url/change-api-url.tsx
@@ -1,10 +1,10 @@
-import GearIcon from 'react-native-template/assets/icons/gear.svg';
-import { Button } from 'react-native-template/src/components';
-import { ButtonKind } from 'react-native-template/src/types/button';
 import { useTheme } from 'native-base';
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Config from 'react-native-config';
+import GearIcon from 'react-native-template/assets/icons/gear.svg';
+import { Button } from 'react-native-template/src/components';
+import { ButtonKind } from 'react-native-template/src/types/button';
 
 import ChangeApiUrlModal from './change-api-url-modal';
 

--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -1,7 +1,3 @@
-import CheckIcon from 'react-native-template/assets/icons/check.svg';
-import { FormControl, Input, Button } from 'react-native-template/src/components';
-import { ButtonKind } from 'react-native-template/src/types/button';
-import { useThemeColor } from 'react-native-template/src/utils';
 import {
   VStack,
   Container,
@@ -17,6 +13,10 @@ import {
   Checkbox,
 } from 'native-base';
 import React, { useState } from 'react';
+import CheckIcon from 'react-native-template/assets/icons/check.svg';
+import { FormControl, Input, Button } from 'react-native-template/src/components';
+import { ButtonKind } from 'react-native-template/src/types/button';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 import { CountrySelectOptions } from '../../../constants';
 import { AsyncError, PhoneNumber } from '../../../types';

--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -1,7 +1,7 @@
-import CheckIcon from 'boilerplate-react-native/assets/icons/check.svg';
-import { FormControl, Input, Button } from 'boilerplate-react-native/src/components';
-import { ButtonKind } from 'boilerplate-react-native/src/types/button';
-import { useThemeColor } from 'boilerplate-react-native/src/utils';
+import CheckIcon from 'react-native-template/assets/icons/check.svg';
+import { FormControl, Input, Button } from 'react-native-template/src/components';
+import { ButtonKind } from 'react-native-template/src/types/button';
+import { useThemeColor } from 'react-native-template/src/utils';
 import {
   VStack,
   Container,

--- a/src/screens/auth/registration/registration-form.tsx
+++ b/src/screens/auth/registration/registration-form.tsx
@@ -1,4 +1,4 @@
-import { Button, FormControl, Input } from 'boilerplate-react-native/src/components';
+import { Button, FormControl, Input } from 'react-native-template/src/components';
 import { Container, Heading, VStack } from 'native-base';
 import React from 'react';
 

--- a/src/screens/auth/registration/registration-form.tsx
+++ b/src/screens/auth/registration/registration-form.tsx
@@ -1,6 +1,6 @@
-import { Button, FormControl, Input } from 'react-native-template/src/components';
 import { Container, Heading, VStack } from 'native-base';
 import React from 'react';
+import { Button, FormControl, Input } from 'react-native-template/src/components';
 
 import { AsyncError } from '../../../types';
 

--- a/src/screens/dashboard/task-section/task-add-edit-modal.tsx
+++ b/src/screens/dashboard/task-section/task-add-edit-modal.tsx
@@ -1,4 +1,4 @@
-import { Button, FormControl, Input, Modal } from 'boilerplate-react-native/src/components';
+import { Button, FormControl, Input, Modal } from 'react-native-template/src/components';
 import { VStack } from 'native-base';
 import React from 'react';
 

--- a/src/screens/dashboard/task-section/task-add-edit-modal.tsx
+++ b/src/screens/dashboard/task-section/task-add-edit-modal.tsx
@@ -1,6 +1,6 @@
-import { Button, FormControl, Input, Modal } from 'react-native-template/src/components';
 import { VStack } from 'native-base';
 import React from 'react';
+import { Button, FormControl, Input, Modal } from 'react-native-template/src/components';
 
 import { TaskModal, TaskOperation } from '../../../constants';
 import { AsyncError, Nullable, Task } from '../../../types';

--- a/src/screens/dashboard/task-section/task-delete-modal.tsx
+++ b/src/screens/dashboard/task-section/task-delete-modal.tsx
@@ -1,11 +1,11 @@
+import { t } from 'i18next';
+import { Box, Text, Toast, useTheme } from 'native-base';
+import React from 'react';
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import { Button, Modal } from 'react-native-template/src/components';
 import { useTaskContext } from 'react-native-template/src/contexts';
 import { AsyncError, Task } from 'react-native-template/src/types';
 import { ButtonKind, ButtonColor } from 'react-native-template/src/types/button';
-import { t } from 'i18next';
-import { Box, Text, Toast, useTheme } from 'native-base';
-import React from 'react';
 
 interface TaskDeleteModalProps {
   handleModalClose: () => void;

--- a/src/screens/dashboard/task-section/task-delete-modal.tsx
+++ b/src/screens/dashboard/task-section/task-delete-modal.tsx
@@ -1,8 +1,8 @@
-import DeleteIcon from 'boilerplate-react-native/assets/icons/delete.svg';
-import { Button, Modal } from 'boilerplate-react-native/src/components';
-import { useTaskContext } from 'boilerplate-react-native/src/contexts';
-import { AsyncError, Task } from 'boilerplate-react-native/src/types';
-import { ButtonKind, ButtonColor } from 'boilerplate-react-native/src/types/button';
+import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
+import { Button, Modal } from 'react-native-template/src/components';
+import { useTaskContext } from 'react-native-template/src/contexts';
+import { AsyncError, Task } from 'react-native-template/src/types';
+import { ButtonKind, ButtonColor } from 'react-native-template/src/types/button';
 import { t } from 'i18next';
 import { Box, Text, Toast, useTheme } from 'native-base';
 import React from 'react';

--- a/src/screens/dashboard/task-section/task-header.tsx
+++ b/src/screens/dashboard/task-section/task-header.tsx
@@ -1,7 +1,7 @@
-import AddIcon from 'react-native-template/assets/icons/add.svg';
-import { Button } from 'react-native-template/src/components';
 import { HStack, Heading, useTheme } from 'native-base';
 import React from 'react';
+import AddIcon from 'react-native-template/assets/icons/add.svg';
+import { Button } from 'react-native-template/src/components';
 
 interface TaskHeaderProps {
   onHeaderButtonPress: () => void;

--- a/src/screens/dashboard/task-section/task-header.tsx
+++ b/src/screens/dashboard/task-section/task-header.tsx
@@ -1,5 +1,5 @@
-import AddIcon from 'boilerplate-react-native/assets/icons/add.svg';
-import { Button } from 'boilerplate-react-native/src/components';
+import AddIcon from 'react-native-template/assets/icons/add.svg';
+import { Button } from 'react-native-template/src/components';
 import { HStack, Heading, useTheme } from 'native-base';
 import React from 'react';
 

--- a/src/screens/dashboard/task-section/task.tsx
+++ b/src/screens/dashboard/task-section/task.tsx
@@ -1,8 +1,8 @@
-import DeleteIcon from 'boilerplate-react-native/assets/icons/delete.svg';
-import EditIcon from 'boilerplate-react-native/assets/icons/edit.svg';
-import { Button, Card } from 'boilerplate-react-native/src/components';
-import { Task } from 'boilerplate-react-native/src/types';
-import { ButtonKind } from 'boilerplate-react-native/src/types/button';
+import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
+import EditIcon from 'react-native-template/assets/icons/edit.svg';
+import { Button, Card } from 'react-native-template/src/components';
+import { Task } from 'react-native-template/src/types';
+import { ButtonKind } from 'react-native-template/src/types/button';
 import { Text, useTheme } from 'native-base';
 import React, { useState } from 'react';
 import { View } from 'react-native';

--- a/src/screens/dashboard/task-section/task.tsx
+++ b/src/screens/dashboard/task-section/task.tsx
@@ -1,11 +1,11 @@
+import { Text, useTheme } from 'native-base';
+import React, { useState } from 'react';
+import { View } from 'react-native';
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import EditIcon from 'react-native-template/assets/icons/edit.svg';
 import { Button, Card } from 'react-native-template/src/components';
 import { Task } from 'react-native-template/src/types';
 import { ButtonKind } from 'react-native-template/src/types/button';
-import { Text, useTheme } from 'native-base';
-import React, { useState } from 'react';
-import { View } from 'react-native';
 
 import TaskDeleteModal from './task-delete-modal';
 import { useTaskStyles } from './task.style';

--- a/src/screens/profile/edit-profile/edit-profile.tsx
+++ b/src/screens/profile/edit-profile/edit-profile.tsx
@@ -1,4 +1,4 @@
-import { Button, FormControl, Input } from 'boilerplate-react-native/src/components';
+import { Button, FormControl, Input } from 'react-native-template/src/components';
 import { KeyboardAvoidingView, Toast, VStack } from 'native-base';
 import React from 'react';
 import { Platform } from 'react-native';

--- a/src/screens/profile/edit-profile/edit-profile.tsx
+++ b/src/screens/profile/edit-profile/edit-profile.tsx
@@ -1,7 +1,7 @@
-import { Button, FormControl, Input } from 'react-native-template/src/components';
 import { KeyboardAvoidingView, Toast, VStack } from 'native-base';
 import React from 'react';
 import { Platform } from 'react-native';
+import { Button, FormControl, Input } from 'react-native-template/src/components';
 
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';

--- a/src/screens/profile/home/account-delete-modal.tsx
+++ b/src/screens/profile/home/account-delete-modal.tsx
@@ -1,8 +1,8 @@
+import { Box, Text, useTheme } from 'native-base';
+import React from 'react';
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import { Button, Modal } from 'react-native-template/src/components';
 import { ButtonKind, ButtonColor } from 'react-native-template/src/types/button';
-import { Box, Text, useTheme } from 'native-base';
-import React from 'react';
 
 interface AccountDeleteModalProps {
   handleDeleteAccountPress: () => void;

--- a/src/screens/profile/home/account-delete-modal.tsx
+++ b/src/screens/profile/home/account-delete-modal.tsx
@@ -1,6 +1,6 @@
-import DeleteIcon from 'boilerplate-react-native/assets/icons/delete.svg';
-import { Button, Modal } from 'boilerplate-react-native/src/components';
-import { ButtonKind, ButtonColor } from 'boilerplate-react-native/src/types/button';
+import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
+import { Button, Modal } from 'react-native-template/src/components';
+import { ButtonKind, ButtonColor } from 'react-native-template/src/types/button';
 import { Box, Text, useTheme } from 'native-base';
 import React from 'react';
 

--- a/src/screens/profile/home/index.tsx
+++ b/src/screens/profile/home/index.tsx
@@ -1,8 +1,8 @@
+import { Box, Divider, Toast, useTheme, VStack } from 'native-base';
+import React, { useState } from 'react';
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import LogoutIcon from 'react-native-template/assets/icons/logout.svg';
 import { Button } from 'react-native-template/src/components';
-import { Box, Divider, Toast, useTheme, VStack } from 'native-base';
-import React, { useState } from 'react';
 
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
 import { useAccountContext, useAuthContext } from '../../../contexts';

--- a/src/screens/profile/home/index.tsx
+++ b/src/screens/profile/home/index.tsx
@@ -1,6 +1,6 @@
-import DeleteIcon from 'boilerplate-react-native/assets/icons/delete.svg';
-import LogoutIcon from 'boilerplate-react-native/assets/icons/logout.svg';
-import { Button } from 'boilerplate-react-native/src/components';
+import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
+import LogoutIcon from 'react-native-template/assets/icons/logout.svg';
+import { Button } from 'react-native-template/src/components';
 import { Box, Divider, Toast, useTheme, VStack } from 'native-base';
 import React, { useState } from 'react';
 

--- a/src/screens/profile/home/profile-action.tsx
+++ b/src/screens/profile/home/profile-action.tsx
@@ -1,6 +1,6 @@
-import ChevronRightIcon from 'react-native-template/assets/icons/chevron-right.svg';
 import { Pressable, HStack, Heading, IPressableProps, useTheme } from 'native-base';
 import React from 'react';
+import ChevronRightIcon from 'react-native-template/assets/icons/chevron-right.svg';
 
 interface ProfileActionProps extends IPressableProps {
   title: string;

--- a/src/screens/profile/home/profile-action.tsx
+++ b/src/screens/profile/home/profile-action.tsx
@@ -1,4 +1,4 @@
-import ChevronRightIcon from 'boilerplate-react-native/assets/icons/chevron-right.svg';
+import ChevronRightIcon from 'react-native-template/assets/icons/chevron-right.svg';
 import { Pressable, HStack, Heading, IPressableProps, useTheme } from 'native-base';
 import React from 'react';
 

--- a/src/screens/profile/home/profile-info-section.tsx
+++ b/src/screens/profile/home/profile-info-section.tsx
@@ -1,8 +1,8 @@
+import { Box, Heading, Text, useTheme } from 'native-base';
+import React from 'react';
 import EditIcon from 'react-native-template/assets/icons/edit.svg';
 import { Avatar, Button } from 'react-native-template/src/components';
 import { ButtonKind, ButtonSize } from 'react-native-template/src/types/button';
-import { Box, Heading, Text, useTheme } from 'native-base';
-import React from 'react';
 
 import { Account, Nullable } from '../../../types';
 

--- a/src/screens/profile/home/profile-info-section.tsx
+++ b/src/screens/profile/home/profile-info-section.tsx
@@ -1,6 +1,6 @@
-import EditIcon from 'boilerplate-react-native/assets/icons/edit.svg';
-import { Avatar, Button } from 'boilerplate-react-native/src/components';
-import { ButtonKind, ButtonSize } from 'boilerplate-react-native/src/types/button';
+import EditIcon from 'react-native-template/assets/icons/edit.svg';
+import { Avatar, Button } from 'react-native-template/src/components';
+import { ButtonKind, ButtonSize } from 'react-native-template/src/types/button';
 import { Box, Heading, Text, useTheme } from 'native-base';
 import React from 'react';
 


### PR DESCRIPTION
## Description
_This PR updates import paths from `boilerplate-react-native/...` to `react-native-template/...` with the project rename. The previous naming caused ESLint (`import/order` rule) to treat the paths as external modules, but after renaming to `react-native-template`, they were interpreted as internal imports, which triggered linting errors._

## Why this changes needed
- The project was renamed from `boilerplate-react-native` → `react-native-template`.
- ESLint groups imports by type **(builtin, external, internal, etc.)**.
- With the old name, ESLint mistakenly categorized the imports as **external modules** (like from `node_modules`), so no errors were raised.  
  - Reference: [eslint-plugin-import · Order rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#groups-array) — shows how imports are grouped (`builtin`, `external`, `internal`) and why naming affects categorization.  
- With the new name, ESLint correctly categorized the imports as internal project code, which meant the `import/order` rules got applied correctly.
- To resolve this, the imports were reordered automatically with `yarn eslint --ext .ts,.tsx . --fix`.
- This ensures consistency with linting rules and makes the codebase compliant with our ESLint config.

## Screenshots
<img width="1275" height="877" alt="Screenshot 2025-09-09 163458" src="https://github.com/user-attachments/assets/72fd0ac2-6f1d-4135-bdb0-a5555cce28b6" />


<img width="1277" height="860" alt="Screenshot 2025-09-09 163600" src="https://github.com/user-attachments/assets/96ecae77-d373-4c83-9cf1-2863dd8ca6cc" />

<img width="1210" height="875" alt="Screenshot 2025-09-09 164022" src="https://github.com/user-attachments/assets/265e954c-14a5-4fa5-b90b-0207ad3201f5" />

## Tests
### Automated test cases added
- Ran `yarn eslint --ext .ts,.tsx .` → no lint errors remain.

### Manual test cases run - 
- Built app with `./gradlew bundleRelease`.
- Tested app on `BrowerStack` and verified the navigation and buttons works as expected.
