### PR TITLE
feat: Add central theming system with light/dark modefeat: add central theming system with light/dark mode and useTheme hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-native-svg": "^13.10.0",
     "react-native-swipeable-list": "^0.1.2",
     "react-native-vector-icons": "^10.0.0",
+    "styled-components": "^6.1.19",
     "yup": "^1.4.0"
   },
   "devDependencies": {
@@ -64,6 +65,7 @@
     "@types/react": "^18.0.24",
     "@types/react-native-vector-icons": "^6.4.18",
     "@types/react-test-renderer": "^18.0.0",
+    "@types/styled-components-react-native": "^5.2.5",
     "babel-jest": "^29.2.1",
     "babel-plugin-inline-dotenv": "^1.7.0",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,11 @@ import { NativeBaseProvider } from 'native-base';
 import React, { useCallback } from 'react';
 import ErrorBoundary from 'react-native-error-boundary';
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
+import { ThemeProvider } from 'styled-components/native';
+import { lightTheme, darkTheme } from '../src/theme/theme';
+import  {useState } from 'react';
+
+
 
 import appTheme from './app-theme';
 import { ErrorFallback } from './components';
@@ -16,27 +21,29 @@ import DatadogConfig, { onDataDogSDKInitialized } from './services/datadog';
 const App = () => {
   Logger.initializeLoggers();
   const ErrorComponent = useCallback(() => <ErrorFallback />, []);
+  const [isDarkMode, setIsDarkMode] = useState(false); 
 
   return (
-    <NativeBaseProvider theme={appTheme}>
-      <ErrorBoundary
-        onError={(e, stack) => Logger.error(`App Error: ${e} ${stack}`)}
-        FallbackComponent={ErrorComponent}
-      >
-        <DatadogProvider configuration={DatadogConfig} onInitialization={onDataDogSDKInitialized}>
-          <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-            <AuthContextProvider>
-              <AccountContextProvider>
-                <TaskContextProvider>
-                  <ApplicationNavigator />
-                </TaskContextProvider>
-              </AccountContextProvider>
-            </AuthContextProvider>
-          </SafeAreaProvider>
-        </DatadogProvider>
-      </ErrorBoundary>
-    </NativeBaseProvider>
+    <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
+      <NativeBaseProvider theme={appTheme}>
+        <ErrorBoundary
+          onError={(e, stack) => Logger.error(`App Error: ${e} ${stack}`)}
+          FallbackComponent={ErrorComponent}
+        >
+          <DatadogProvider configuration={DatadogConfig} onInitialization={onDataDogSDKInitialized}>
+            <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+              <AuthContextProvider>
+                <AccountContextProvider>
+                  <TaskContextProvider>
+                    <ApplicationNavigator />
+                  </TaskContextProvider>
+                </AccountContextProvider>
+              </AuthContextProvider>
+            </SafeAreaProvider>
+          </DatadogProvider>
+        </ErrorBoundary>
+      </NativeBaseProvider>
+    </ThemeProvider>
   );
-};
-
+} 
 export default App;

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -29,18 +29,28 @@ export const Tag: React.FC<TagProps> = ({
   const textStyle =
     variant === TagVariant.OUTLINED ? styles.outlinedTextColor : styles.filledTextColor;
 
-  const Container = onClick ? Pressable : Box;
-  const containerProps = onClick ? { onPress: onClick } : {};
+  if (onClick) {
+    return (
+      <Pressable onPress={onClick} style={[styles.tag, variantStyle] as any}>
+        <Text style={[styles.text, textStyle]}>{label}</Text>
+        {onDeleted && (
+          <Pressable onPress={onDeleted} style={styles.iconWrapper} hitSlop={8}>
+            <Close width={16} height={16} fill={textStyle.color} />
+          </Pressable>
+        )}
+      </Pressable>
+    );
+  }
 
   return (
-    <Container style={[styles.tag, variantStyle]} {...containerProps}>
+    <Box style={[styles.tag, variantStyle] as any}>
       <Text style={[styles.text, textStyle]}>{label}</Text>
       {onDeleted && (
         <Pressable onPress={onDeleted} style={styles.iconWrapper} hitSlop={8}>
           <Close width={16} height={16} fill={textStyle.color} />
         </Pressable>
       )}
-    </Container>
+    </Box>
   );
 };
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,6 @@
+import { useTheme as styledUseTheme } from 'styled-components/native';
+import { DefaultTheme } from 'styled-components/native';
+
+export const useTheme = (): DefaultTheme => {
+  return styledUseTheme();
+};

--- a/src/navigators/authenticated.tsx
+++ b/src/navigators/authenticated.tsx
@@ -1,10 +1,11 @@
 import { DdSdkReactNative } from '@datadog/mobile-react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
-import { useTheme } from 'native-base';
 import React, { useEffect } from 'react';
 import HomeIcon from 'react-native-template/assets/icons/home.svg';
 import PersonIcon from 'react-native-template/assets/icons/person.svg';
+import { useTheme } from 'styled-components/native';
+
 
 import { AuthenticatedStackParamsList, AuthenticatedTabParamsList } from '../../@types/navigation';
 import { FullScreenSpinner } from '../components';
@@ -22,7 +23,6 @@ const getTabBarIcon = (routeName: string) => {
     const themeColor = useThemeColor(color);
 
     let icon;
-
     switch (routeName) {
       case 'Home':
         icon = <HomeIcon width={size} height={size} fill={themeColor} />;
@@ -42,7 +42,8 @@ const getTabBarIcon = (routeName: string) => {
 const AuthenticatedStack = () => {
   const { isNewUser, isAccountLoading, getAccountDetails, accountDetails } = useAccountContext();
   const { logout } = useAuthContext();
-  const { colors } = useTheme();
+  const theme = useTheme(); 
+  const { colors } = theme;
 
   useEffect(() => {
     getAccountDetails().catch(() => {
@@ -72,8 +73,8 @@ const AuthenticatedStack = () => {
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarIcon: getTabBarIcon(route.name),
-        tabBarActiveTintColor: colors.primary[500],
-        tabBarInactiveTintColor: colors.muted[400],
+        tabBarActiveTintColor: colors.primary, 
+        tabBarInactiveTintColor: colors.muted, 
       })}
     >
       <Tab.Screen name="Home" component={Dashboard} />

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -1,0 +1,23 @@
+import 'styled-components/native';
+
+declare module 'styled-components/native' {
+  export interface DefaultTheme {
+    colors: {
+      background: string;
+      text: string;
+      primary: string;
+      secondary: string;
+      muted: string;
+    };
+    spacing: {
+      s: number;
+      m: number;
+      l: number;
+    };
+    fontSizes: {
+      small: number;
+      medium: number;
+      large: number;
+    };
+  }
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,25 @@
+import { DefaultTheme } from 'styled-components/native';
+
+export const lightTheme: DefaultTheme = {
+  colors: {
+    background: '#ffffff',
+    text: '#000000',
+    primary: '#4f46e5',
+    secondary: '#6b7280',
+    muted: '#a3a3a3',
+  },
+  spacing: { s: 8, m: 16, l: 24 },
+  fontSizes: { small: 12, medium: 16, large: 20 },
+};
+
+export const darkTheme: DefaultTheme = {
+  colors: {
+    background: '#121212',
+    text: '#ffffff',
+    primary: '#6366f1',
+    secondary: '#9ca3af',
+    muted: '#6b7280',
+  },
+  spacing: { s: 8, m: 16, l: 24 },
+  fontSizes: { small: 12, medium: 16, large: 20 },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,6 +1341,23 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
+"@emotion/is-prop-valid@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz#d4175076679c6a26faa92b03bb786f9e52612337"
+  integrity sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
+
+"@emotion/unitless@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
+  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
@@ -3055,6 +3072,13 @@
   resolved "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz"
   integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.7"
+  resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz#306e3a3a73828522efa1341159da4846e7573a6c"
+  integrity sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==
+  dependencies:
+    hoist-non-react-statics "^3.3.0"
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.5"
   resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz"
@@ -3177,6 +3201,29 @@
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/styled-components-react-native@^5.2.5":
+  version "5.2.5"
+  resolved "https://registry.npmjs.org/@types/styled-components-react-native/-/styled-components-react-native-5.2.5.tgz#224ff6b7a49b73d2c2563c5317a3e61da3f1fb87"
+  integrity sha512-hDYioy4gAusO9NJI0n1e0Dwne4zofRVjou8i+FdNNz4vOG/iEBS99Rl87ybytjx/WD3NXqZQJ5g98AA+ZW7JKA==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-native" "^0.70"
+    "@types/styled-components" "*"
+
+"@types/styled-components@*":
+  version "5.1.34"
+  resolved "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz#4107df8ef8a7eaba4fa6b05f78f93fba4daf0300"
+  integrity sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    csstype "^3.0.2"
+
+"@types/stylis@4.2.5":
+  version "4.2.5"
+  resolved "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz#1daa6456f40959d06157698a653a9ab0a70281df"
+  integrity sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -3860,6 +3907,11 @@ camelcase@^6.2.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+camelize@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
+  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
+
 caniuse-lite@^1.0.30001503:
   version "1.0.30001509"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz"
@@ -4143,6 +4195,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
+
 css-in-js-utils@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz"
@@ -4160,6 +4217,15 @@ css-select@^5.1.0:
     domhandler "^5.0.2"
     domutils "^3.0.1"
     nth-check "^2.0.1"
+
+css-to-react-native@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
+  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@^1.1.3:
   version "1.1.3"
@@ -4196,6 +4262,11 @@ csso@^5.0.5:
   integrity sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==
   dependencies:
     css-tree "~2.2.0"
+
+csstype@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
 csstype@^3.0.2:
   version "3.1.2"
@@ -7318,6 +7389,11 @@ nanoid@^3.1.23:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
+nanoid@^3.3.7:
+  version "3.3.11"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
 native-base@^3.4.28:
   version "3.4.28"
   resolved "https://registry.npmjs.org/native-base/-/native-base-3.4.28.tgz"
@@ -7780,6 +7856,20 @@ possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
+
+postcss-value-parser@^4.0.2:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@8.4.49:
+  version "8.4.49"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
+  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -8452,6 +8542,11 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+shallowequal@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
@@ -8517,7 +8612,7 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-source-map-js@^1.0.1:
+source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -8760,6 +8855,26 @@ strnum@^1.0.5:
   resolved "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
+styled-components@^6.1.19:
+  version "6.1.19"
+  resolved "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz#9a41b4db79a3b7a2477daecabe8dd917235263d6"
+  integrity sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==
+  dependencies:
+    "@emotion/is-prop-valid" "1.2.2"
+    "@emotion/unitless" "0.8.1"
+    "@types/stylis" "4.2.5"
+    css-to-react-native "3.2.0"
+    csstype "3.1.3"
+    postcss "8.4.49"
+    shallowequal "1.1.0"
+    stylis "4.3.2"
+    tslib "2.6.2"
+
+stylis@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz#8f76b70777dd53eb669c6f58c997bf0a9972e444"
+  integrity sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==
+
 sudo-prompt@^9.0.0:
   version "9.2.1"
   resolved "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz"
@@ -8909,6 +9024,11 @@ tsconfig-paths@^3.15.0:
     json5 "^1.0.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
**Description**

This PR introduces a central theming system for the app to ensure consistent styling across components and support light/dark mode toggling.

**Why this change was needed**

Previously, components used styles defined individually, leading to inconsistent styling across the app. Updating colors, spacing, or fonts required multiple changes in different files. There was no easy way to implement light/dark mode globally.

By introducing a central theming system, we gain:

- Centralized management of colors, spacing, and fonts
- Easy implementation of light/dark mode toggling
- Consistent styling across all components
- Simplified updates to theme values without touching multiple files

**Key changes**

- Created lightTheme and darkTheme objects in src/theme/theme.ts
- Wrapped the app in ThemeProvider in App.tsx to provide theme values globally
- Created a useTheme() hook for components to access theme values
- Refactored core components to use theme tokens (colors, spacing, fonts)
- Added support for light/dark mode toggling