### PR TITLE
feat: fix slider component changes 

### DIFF
--- a/src/components/slider/index.ts
+++ b/src/components/slider/index.ts
@@ -1,0 +1,2 @@
+export { default } from './slider';
+export * from '../../types/slider';

--- a/src/components/slider/slider.styles.ts
+++ b/src/components/slider/slider.styles.ts
@@ -1,0 +1,119 @@
+import { useTheme } from 'native-base';
+import { StyleSheet, TextStyle } from 'react-native';
+
+export const useSliderStyles = () => {
+  const theme = useTheme();
+
+  return StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      gap: theme.space['0'],
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+    },
+    sliderLine: {
+      width: '100%',
+      marginTop: theme.space[2],
+      height: theme.sizes['2'],
+      borderRadius: theme.radii.full,
+      justifyContent: 'center',
+      backgroundColor: theme.colors.primary['50'],
+    },
+    sliderFilledLine: {
+      position: 'absolute',
+      borderRadius: theme.radii.full,
+      backgroundColor: theme.colors.primary['500'],
+      height: theme.sizes['2'],
+    },
+    sliderHandle: {
+      position: 'absolute',
+      width: theme.sizes['5'],
+      height: theme.sizes['5'],
+      backgroundColor: theme.colors.primary['500'],
+      borderRadius: theme.radii.full,
+      borderWidth: parseInt(theme.borderWidths['4'], 10),
+      borderColor: theme.colors.white,
+    },
+    valueLabelWrapper: {
+      position: 'absolute',
+      alignItems: 'center',
+      zIndex: 10,
+    },
+    valueLabel: {
+      ...theme.shadows['7'],
+      backgroundColor: theme.colors.white,
+      paddingHorizontal: theme.space['2.5'],
+      paddingVertical: theme.space[1.5],
+      borderRadius: theme.radii.sm,
+      borderWidth: parseInt(theme.borderWidths['2'], 10),
+      borderColor: theme.colors.white,
+      minWidth: theme.sizes['10'],
+      minHeight: theme.sizes['10'],
+      alignItems: 'center',
+      justifyContent: 'center',
+      position: 'relative',
+    },
+    valueLabelText: {
+      fontSize: theme.fontSizes.md,
+      fontWeight: `${theme.fontWeights.normal}` as TextStyle['fontWeight'],
+      color: theme.colors.secondary['500'],
+    },
+    pointer: {
+      backgroundColor: theme.colors.white,
+      position: 'absolute',
+      bottom: -theme.sizes['2.5'],
+      borderLeftWidth: theme.borderWidths[0],
+      borderTopWidth: theme.borderWidths[0],
+      width: theme.sizes['4'],
+      height: theme.sizes['4'],
+      transform: [{ rotate: '45deg' }],
+      zIndex: -1,
+    },
+    endMarkersRow: {
+      width: '100%',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginTop: theme.space['1'],
+      alignItems: 'center',
+    },
+    markerText: {
+      fontSize: theme.fontSizes.xs,
+      color: theme.colors.secondary['500'],
+      fontWeight: `${theme.fontWeights.normal}` as TextStyle['fontWeight'],
+      letterSpacing: Number(theme.letterSpacings.lg),
+    },
+    internalMarker: {
+      position: 'absolute',
+      bottom: -theme.sizes['5'],
+      transform: [{ translateX: -theme.sizes[2] }],
+      alignItems: 'center',
+    },
+    sliderWithInputRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      width: '100%',
+    },
+    inputRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    inputBox: {
+      alignSelf: 'flex-end',
+      minWidth: theme.sizes['12'],
+      maxWidth: theme.sizes['20'],
+    },
+    disabledTrack: {
+      backgroundColor: theme.colors.secondary['100'],
+    },
+    disabledHandle: {
+      backgroundColor: theme.colors.secondary['200'],
+      borderWidth: parseInt(theme.borderWidths['4'], 10),
+      borderColor: theme.colors.secondary['200'],
+    },
+    disabledMarkers: {
+      color: theme.colors.secondary['200'],
+    },
+  });
+};

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1,0 +1,394 @@
+import { useTheme } from 'native-base';
+import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { View, Text, PanResponder, Animated, LayoutChangeEvent } from 'react-native';
+
+import { SliderProps } from '../../types/slider';
+import { Input } from '../inputs';
+
+import { useSliderStyles } from './slider.styles';
+
+enum SliderHandle {
+  SINGLE = 'single',
+  LEFT = 'left',
+  RIGHT = 'right',
+}
+
+enum InputSubmitType {
+  MIN = 'min',
+  MAX = 'max',
+}
+
+const Slider = ({
+  value = 0,
+  step = 1,
+  lowerLimit = 0,
+  upperLimit = 100,
+  onValueChange,
+  isRange = false,
+  showEndMarkers = false,
+  internalMarkerStep,
+  showValueInput = false,
+  disabled = false,
+}: SliderProps) => {
+  const { sizes } = useTheme();
+  const handleSize = Number(sizes['5']);
+  const [trackLength, setTrackLength] = useState(0);
+
+  const styles = useSliderStyles();
+
+  const clamp = useCallback((val: number, min: number, max: number) => Math.min(Math.max(val, min), max), []);
+
+  const calculatePositionFromValue = useCallback(
+    (val: number) => trackLength > 0 ? ((val - lowerLimit) / (upperLimit - lowerLimit)) * trackLength : 0,
+    [trackLength, lowerLimit, upperLimit]
+  );
+
+  const calculateValueFromPosition = useCallback(
+    (pos: number) => trackLength > 0 ? lowerLimit + ((upperLimit - lowerLimit) * pos) / trackLength : lowerLimit,
+    [trackLength, lowerLimit, upperLimit]
+  );
+
+  const applyStep = useCallback((val: number) => step > 0 ? clamp(Math.round(val / step) * step, lowerLimit, upperLimit) : val,
+    [step, lowerLimit, upperLimit, clamp]
+  );
+  
+
+  const internalMarkers = useMemo(() => {
+    if (!internalMarkerStep || internalMarkerStep <= 0) return [];
+    const markers = [];
+    for (let i = lowerLimit + internalMarkerStep; i < upperLimit; i += internalMarkerStep) {
+      markers.push(i);
+    }
+    return markers;
+  }, [internalMarkerStep, lowerLimit, upperLimit]);
+
+  const initialRange: [number, number] =
+    Array.isArray(value) && isRange ? value : [lowerLimit, upperLimit];
+
+  const initialValue: number = typeof value === 'number' && !isRange ? value : lowerLimit;
+
+  const [range, setRange] = useState<[number, number]>(initialRange);
+  const [sliderValue, setSliderValue] = useState(initialValue);
+  const [inputMin, setInputMin] = useState(isRange ? `${initialRange[0]}` : `${initialValue}`);
+  const [inputMax, setInputMax] = useState(`${initialRange[1]}`);
+  const [isSliding, setIsSliding] = useState(true);
+  const [bubbleValue, setBubbleValue] = useState<number | null>(null);
+  const [activeHandle, setActiveHandle] = useState<SliderHandle | null>(null);
+
+  const rangeLeftPos = useRef(
+    new Animated.Value(calculatePositionFromValue(initialRange[0])),
+  ).current;
+  const rangeRightPos = useRef(
+    new Animated.Value(calculatePositionFromValue(initialRange[1])),
+  ).current;
+  const handlePosition = useRef(
+    new Animated.Value(calculatePositionFromValue(initialValue)),
+  ).current;
+
+  const lastLeft = useRef(0);
+  const lastRight = useRef(0);
+  const lastPosition = useRef(0);
+
+  useEffect(() => {
+    if (trackLength > 0) {
+      const left = calculatePositionFromValue(range[0]);
+      const right = calculatePositionFromValue(range[1]);
+      const pos = calculatePositionFromValue(sliderValue);
+
+      rangeLeftPos.setValue(left);
+      rangeRightPos.setValue(right);
+      handlePosition.setValue(pos);
+
+      lastLeft.current = left;
+      lastRight.current = right;
+      lastPosition.current = pos;
+    }
+  }, [trackLength]);
+
+  useEffect(() => {
+    if (trackLength <= 0) return;
+    if (isRange && Array.isArray(value)) {
+      const [left, right] = value;
+      const [currLeft, currRight] = range;
+
+      if (left !== currLeft || right !== currRight) {
+        const lPos = calculatePositionFromValue(left);
+        const rPos = calculatePositionFromValue(right);
+        rangeLeftPos.setValue(lPos);
+        rangeRightPos.setValue(rPos);
+        lastLeft.current = lPos;
+        lastRight.current = rPos;
+        setRange([left, right]);
+        setInputMin(`${left}`);
+        setInputMax(`${right}`);
+      }
+    } else if (!isRange && typeof value === 'number') {
+      if (value !== sliderValue) {
+        const stepped = applyStep(value);
+        const pos = calculatePositionFromValue(stepped);
+        handlePosition.setValue(pos);
+        lastPosition.current = pos;
+        setSliderValue(stepped);
+        setInputMin(`${stepped}`);
+      }
+    }
+  }, [trackLength, isRange, value]);
+
+  const handleSubmit = useCallback((type: InputSubmitType) => {
+    const input = type === InputSubmitType.MIN ? inputMin : inputMax;
+    const parsed = parseFloat(input); 
+    if (isNaN(parsed)) return;
+    const stepped = applyStep(parsed);
+
+    if (isRange) {
+      const clamped = type === InputSubmitType.MIN ? clamp(stepped, lowerLimit, range[1]) : clamp(stepped, range[0], upperLimit);
+      const newRange: [number, number] = type === InputSubmitType.MIN ? [clamped, range[1]] : [range[0], clamped];
+      const pos = calculatePositionFromValue(clamped);
+      if (type === InputSubmitType.MIN) { 
+        rangeLeftPos.setValue(pos); 
+        lastLeft.current = pos; 
+      }
+      else { 
+        rangeRightPos.setValue(pos); 
+        lastRight.current = pos; 
+      }
+      setRange(newRange); 
+      onValueChange?.(newRange);
+    } else {
+      const pos = calculatePositionFromValue(stepped);
+      handlePosition.setValue(pos); 
+      lastPosition.current = pos;
+      setSliderValue(stepped); 
+      setInputMin(`${stepped}`);
+      onValueChange?.(stepped);
+    }
+  }, [applyStep, inputMin, inputMax, isRange, range, lowerLimit, upperLimit]);
+  
+
+  const gestureStartX = useRef(0);
+  const createPanResponder = (
+    handleType: SliderHandle,
+    handleRef: Animated.Value,
+    lastRef: React.MutableRefObject<number>,
+    getCurrentRange?: () => [number, number],
+    updateRangeOrValue?: (val: number) => void
+  ) =>
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => !disabled,
+      onPanResponderGrant: () => { gestureStartX.current = lastRef.current; setIsSliding(true); setActiveHandle(handleType); },
+      onPanResponderMove: (_, g) => {
+        if (trackLength <= 0) return;
+        let newPos = clamp(gestureStartX.current + g.dx, 0, trackLength);
+        const stepped = applyStep(calculateValueFromPosition(newPos));
+        newPos = calculatePositionFromValue(stepped);
+
+        if (handleType === SliderHandle.LEFT && getCurrentRange) { 
+          const [, r] = getCurrentRange(); 
+          if (stepped > r) return; 
+        }
+        if (handleType === SliderHandle.RIGHT && getCurrentRange) { 
+          const [l] = getCurrentRange(); 
+          if (stepped < l) return;
+        }
+
+        if ((handleType === SliderHandle.LEFT || handleType === SliderHandle.SINGLE)) setInputMin('');
+        if (handleType === SliderHandle.RIGHT) setInputMax('');
+
+        handleRef.setValue(newPos); updateRangeOrValue?.(stepped); setBubbleValue(stepped);
+      },
+      onPanResponderRelease: (_, g) => {
+        if (trackLength <= 0) return;
+        const finalValue = applyStep(calculateValueFromPosition(clamp(gestureStartX.current + g.dx, 0, trackLength)));
+        const finalPos = calculatePositionFromValue(finalValue);
+        handleRef.setValue(finalPos); lastRef.current = finalPos; updateRangeOrValue?.(finalValue);
+        setBubbleValue(null); setActiveHandle(null); setIsSliding(false);
+      },
+    });
+
+  const singlePanResponder = useMemo(
+    () =>
+      createPanResponder(SliderHandle.SINGLE, handlePosition, lastPosition, undefined, stepped => {
+        setSliderValue(stepped);
+        onValueChange?.(stepped);
+      }),
+    [trackLength],
+  );
+
+  const leftPanResponder = useMemo(
+    () =>
+      createPanResponder(
+        SliderHandle.LEFT,
+        rangeLeftPos,
+        lastLeft,
+        () => range,
+        stepped => {
+          const updated: [number, number] = [stepped, range[1]];
+          setRange(updated);
+          onValueChange?.(updated);
+        },
+      ),
+    [trackLength],
+  );
+
+  const rightPanResponder = useMemo(
+    () =>
+      createPanResponder(
+        SliderHandle.RIGHT,
+        rangeRightPos,
+        lastRight,
+        () => range,
+        stepped => {
+          const updated: [number, number] = [range[0], stepped];
+          setRange(updated);
+          onValueChange?.(updated);
+        },
+      ),
+    [trackLength],
+  );
+
+  const renderBubble = (handle: SliderHandle, position: Animated.Value, value: number | null) => {
+    if (!isSliding || typeof value !== 'number' || activeHandle !== handle) {
+      return null;
+    }
+
+    return (
+      <Animated.View
+        pointerEvents={'none'}
+        style={[
+          styles.valueLabelWrapper,
+          {
+            left: Animated.add(position, new Animated.Value(handleSize / 2 - handleSize * 1.6)),
+            bottom: sizes['8'],
+          },
+        ]}
+      >
+        <View style={styles.valueLabel}>
+          <Text style={styles.valueLabelText}>{value}</Text>
+          <View style={styles.pointer} />
+        </View>
+      </Animated.View>
+    );
+  };
+
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    const width = e.nativeEvent.layout.width;
+    if (width > 0 && width !== trackLength) {
+      setTrackLength(width);
+    }
+  }, [trackLength]);
+  
+
+  return (
+    <View style={styles.container} onLayout={handleLayout}>
+      <View style={styles.sliderWithInputRow}>
+        <View style={{ flex: 1 }}>
+          {showValueInput && (
+            <View style={isRange && styles.inputRow}>
+              <View style={styles.inputBox}>
+                <Input
+                  value={inputMin}
+                  onChangeText={text => setInputMin(text)}
+                  onSubmitEditing={() => handleSubmit(InputSubmitType.MIN)}
+                  placeholder={`${lowerLimit}`}
+                  keyboardType="numeric"
+                  disabled={disabled}
+                  textAlign="center"
+                  numberOfLines={1}
+                  multiline={false}
+                />
+              </View>
+              {isRange && (
+                <View style={styles.inputBox}>
+                  <Input
+                    value={inputMax}
+                    onChangeText={text => setInputMax(text)}
+                    onSubmitEditing={() => handleSubmit(InputSubmitType.MAX)}
+                    placeholder={`${upperLimit}`}
+                    keyboardType="numeric"
+                    disabled={disabled}
+                    textAlign="center"
+                    numberOfLines={1}
+                    multiline={false}
+                  />
+                </View>
+              )}
+            </View>
+          )}
+
+          <View style={[styles.sliderLine, disabled && styles.disabledTrack]}>
+            <Animated.View
+              style={[
+                styles.sliderFilledLine,
+                {
+                  left: isRange ? rangeLeftPos : 0,
+                  width: isRange
+                    ? Animated.subtract(rangeRightPos, rangeLeftPos)
+                    : Animated.add(handlePosition, new Animated.Value(handleSize / 2)),
+                },
+                disabled && styles.disabledTrack,
+              ]}
+            />
+
+            {internalMarkers.map((mark, index) => {
+              const markerLeft = ((mark - lowerLimit) / (upperLimit - lowerLimit)) * trackLength;
+              return (
+                <View key={index} style={[styles.internalMarker, { left: markerLeft }]}>
+                  <Text style={[styles.markerText, disabled && styles.disabledMarkers]}>
+                    {mark}
+                  </Text>
+                </View>
+              );
+            })}
+
+            {renderBubble(SliderHandle.SINGLE, handlePosition, bubbleValue)}
+            {renderBubble(SliderHandle.LEFT, rangeLeftPos, bubbleValue)}
+            {renderBubble(SliderHandle.RIGHT, rangeRightPos, bubbleValue)}
+
+            {isRange ? (
+              <>
+                <Animated.View
+                  style={[
+                    styles.sliderHandle,
+                    disabled && styles.disabledHandle,
+                    { left: Animated.subtract(rangeLeftPos, handleSize / 2) },
+                  ]}
+                  {...leftPanResponder.panHandlers}
+                />
+                <Animated.View
+                  style={[
+                    styles.sliderHandle,
+                    disabled && styles.disabledHandle,
+                    { left: Animated.subtract(rangeRightPos, handleSize / 2) },
+                  ]}
+                  {...rightPanResponder.panHandlers}
+                />
+              </>
+            ) : (
+              <Animated.View
+                style={[
+                  styles.sliderHandle,
+                  disabled && styles.disabledHandle,
+                  { left: Animated.subtract(handlePosition, handleSize / 2) },
+                ]}
+                {...singlePanResponder.panHandlers}
+              />
+            )}
+          </View>
+
+          {showEndMarkers && (
+            <View style={styles.endMarkersRow}>
+              <Text style={[styles.markerText, disabled && styles.disabledMarkers]}>
+                {lowerLimit}
+              </Text>
+              <Text style={[styles.markerText, disabled && styles.disabledMarkers]}>
+                {upperLimit}
+              </Text>
+            </View>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default Slider;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export * from './auth';
 export * from './common';
 export * from './task';
 export * from './avatar';
+export * from './slider';
 export * from './alert';
 export * from './input';
 export * from './spinner';

--- a/src/types/slider.ts
+++ b/src/types/slider.ts
@@ -1,0 +1,12 @@
+export interface SliderProps {
+  disabled?: boolean;
+  internalMarkerStep?: number;
+  isRange?: boolean;
+  lowerLimit?: number;
+  onValueChange?: (val: number | [number, number]) => void;
+  showEndMarkers?: boolean;
+  showValueInput?: boolean;
+  step?: number;
+  upperLimit?: number;
+  value: number | [number, number];
+}


### PR DESCRIPTION
**## Description**
This pull request introduces a fully customized and theme-aware Slider component (issue #112), supporting both single-value and range selection modes. It is designed to be highly flexible and reusable across the app.
The component is built without any third-party dependencies, works across platforms, and adheres to NativeBase theming. It also includes advanced features like value bubbles, internal markers, and input field integration.

No new endpoints were added.

**Screenshots**

<img width="529" height="156" alt="Screenshot 2025-09-26 at 9 51 58 AM" src="https://github.com/user-attachments/assets/725ae4a6-2537-4b8b-b230-454986d7f521" />

<img width="497" height="100" alt="Screenshot 2025-09-26 at 9 53 57 AM" src="https://github.com/user-attachments/assets/4cc87b0a-db73-49c9-8709-1e616bdc1197" />

<img width="508" height="152" alt="Screenshot 2025-09-26 at 9 54 20 AM" src="https://github.com/user-attachments/assets/23f808f0-44bb-4346-9ac2-3b52573ff1f9" />


Manual Test Cases

Test 1: Single Value Slider

- Rendered with value={number}.
- ✅ Thumb moves and updates the value correctly.
- ✅ Input box shows and accepts the value properly.

Test 2: Range Slider

- Rendered with isRange={true} and value={[min, max]}.
- ✅ Both thumbs move separately within limits.
- ✅ Text inputs update values and stay in sync with the slider.

Test 3: Limits & Step

- Set lowerLimit, upperLimit, and step.
- ✅ Slider follows the limits and only changes in step size.

Test 4: Disabled Mode

- Rendered with disabled={true}.
- ✅ Slider looks dim and cannot be moved or edited.

Test 5: Markers & Bubbles

- Used internalMarkerStep and moved thumbs.
- ✅ Small tick marks appear on the track.
- ✅ Bubble above the thumb shows the current value while dragging.