### PR TITLE
fix: pod boost dependency version mismatch

### DIFF
--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -92,6 +92,8 @@ runs:
       working-directory: ios
       shell: bash
       run: |
+        pod repo update
+        bundle exec pod update boost --no-repo-update
         bundle exec pod install
 
     - name: Set up SSH for Match


### PR DESCRIPTION
## Description
_This Pull Request fixes the **Pod Boost dependency** version mismatch between the `ios/Podfile.lock` and `node_modules/react-native/third-party-podspecs/boost.podspec`._
- `pod repo update` command updates the **local CocoaPods spec** repository to fetch the latest available pod definitions.
- `bundle exec pod repo update boost --no-repo-update` updates only the **Boost dependency** to match the version defined in the React Native podspec, without refreshing all podspecs
- `bundle exec pod  install` - Installs all pods based on the updated `Podfile.lock`, ensuring a clean and synchronized dependency setup.

## Screenshots
_NA_
