### PR TITLE
feat: Add clear OTP delivery failure message

### DIFF
--- a/src/screens/auth/otp-verify/index.tsx
+++ b/src/screens/auth/otp-verify/index.tsx
@@ -1,6 +1,7 @@
 import { Toast } from 'native-base';
 import React from 'react';
 import { Alert } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 import { MainScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';
@@ -11,14 +12,25 @@ import OTPForm from './otp-form';
 
 const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
   const { countryCode, phoneNumber } = route.params;
+  const { t } = useTranslation();
   const sendOTPDelayInMilliseconds = 60_000;
 
-  const { startTimer, remainingSecondsStr, isResendEnabled } = useTimer({
+  const { isResendEnabled, remainingSecondsStr, startTimer } = useTimer({
     delayInMilliseconds: sendOTPDelayInMilliseconds,
   });
 
   const onError = (error: AsyncError) => {
-    Alert.alert('Error', error.message);
+    const message = error.message?.toLowerCase() ?? '';
+    const isOTPDeliveryError =
+      message.includes('unable to create record') ||
+      message.includes('authenticate') ||
+      message.includes('twilio') ||
+      message.includes('sms');
+
+    const fallbackMessage = error.message ?? t('error:somethingWrong');
+    const errorMessage = isOTPDeliveryError ? t('error:otpDeliveryFailure') : fallbackMessage;
+
+    Alert.alert('Error', errorMessage);
   };
 
   const onResendOTPSuccess = () => {

--- a/src/screens/auth/otp-verify/index.tsx
+++ b/src/screens/auth/otp-verify/index.tsx
@@ -1,7 +1,7 @@
 import { Toast } from 'native-base';
 import React from 'react';
-import { Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { Alert } from 'react-native';
 
 import { MainScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';

--- a/src/screens/auth/phone-auth/index.tsx
+++ b/src/screens/auth/phone-auth/index.tsx
@@ -1,5 +1,6 @@
 import { Toast } from 'native-base';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { AsyncError } from '../../../types';
 import AuthLayout from '../auth-layout';
@@ -7,6 +8,8 @@ import AuthLayout from '../auth-layout';
 import PhoneAuthForm from './phone-auth-form';
 
 const PhoneAuth: React.FC = () => {
+  const { t } = useTranslation();
+
   const onSuccess = () => {
     Toast.show({
       title: 'OTP sent successfully',
@@ -14,8 +17,18 @@ const PhoneAuth: React.FC = () => {
   };
 
   const onError = (err: AsyncError) => {
+    const message = err.message?.toLowerCase() ?? '';
+    const isOTPDeliveryError =
+      message.includes('unable to create record') ||
+      message.includes('authenticate') ||
+      message.includes('twilio') ||
+      message.includes('sms');
+
+    const fallbackMessage = err.message ?? t('error:somethingWrong');
+    const errorMessage = isOTPDeliveryError ? t('error:otpDeliveryFailure') : fallbackMessage;
+
     Toast.show({
-      title: err.message,
+      title: errorMessage,
     });
   };
 

--- a/src/translations/resources/en/error.json
+++ b/src/translations/resources/en/error.json
@@ -1,5 +1,6 @@
 {
   "oops": "Oops",
-  "somethingWrong": "Something Went Wrong.",
-  "phoneValidation": "Please enter a valid phone number"
+  "otpDeliveryFailure": "Our system is facing challenge to deliver OTP to you at the moment, and the team has been notified. We recommend you to come back and try again later",
+  "phoneValidation": "Please enter a valid phone number",
+  "somethingWrong": "Something Went Wrong."
 }


### PR DESCRIPTION
## Description
This PR improves the user experience during OTP delivery failures by showing a clear, helpful message instead of the confusing backend error (“unable to create record: authenticate”).
The same message will appear for both the initial “Send OTP” and “Resend OTP” flows.

## Why this change is needed?

- The backend currently returns an unclear message that users don’t understand.
- Users were stuck without guidance when OTP delivery failed (e.g., Twilio outage or suspension).

## Changes made:

- Added a new translation key: error.otpDeliveryFailure under i18n
- Updated phone-auth/index.tsx and otp-verify/index.tsx to detect OTP delivery failure errors and show the friendly message
- Kept fallback to error.somethingWrong for unknown errors
- Applied the same logic to both Send and Resend OTP flows

## API / Database Changes:

- None

## Screenshots
### Before
<img width="1392" height="759" alt="Screenshot 2025-11-07 at 3 08 13 PM" src="https://github.com/user-attachments/assets/3f16f678-f707-494c-a3f0-70be82b227ae" />

### After
#### Android version:
<img width="1406" height="760" alt="Screenshot 2025-11-07 at 3 10 11 PM" src="https://github.com/user-attachments/assets/92fd612b-9795-49ac-a955-6189e6fdbf70" />

#### iOS version:

<img width="1381" height="767" alt="Screenshot 2025-11-07 at 4 03 13 PM" src="https://github.com/user-attachments/assets/bb125e12-5e12-4b9b-9703-a13b2eb8746f" />


## Tests
### Manual Testing
Click Send OTP on the login screen → now getting a clear error message instead of the confusing one ("unable to create record: authenticate").