### PR TITLE
chore: Enable iOS Preview Deployment Workflow for Pull Requests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,29 +73,29 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
-  # deploy_ios:
-  #   if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
-  #   needs: [build, release_notes_check]
-  #   runs-on: macos-14
-  #   timeout-minutes: 30
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+  deploy_ios:
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
+    needs: [check_version_number, release_notes_check]
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Deploy iOS Preview to TestFlight
-  #       uses: ./.github/actions/deploy_ios_preview
-  #       env:
-  #         MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
-  #         IOS_MATCH_REPOSITORY_URL: ${{ secrets.IOS_MATCH_REPOSITORY_URL }}
-  #         IOS_APPLE_ID: ${{ secrets.IOS_APPLE_ID }}
-  #         IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
-  #         IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
-  #         IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-  #         IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
-  #         IOS_APP_IDENTIFIER: ${{ secrets.IOS_APP_IDENTIFIER }}
-  #         IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
-  #         IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
-  #         IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
-  #         PR_NUMBER: ${{ github.event.pull_request.number }}
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         RELEASE_NOTES: ${{ needs.release-notes-check.outputs.release_notes }}
+      - name: Deploy iOS Preview to TestFlight
+        uses: ./.github/actions/deploy_ios_preview
+        env:
+          MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
+          IOS_MATCH_REPOSITORY_URL: ${{ secrets.IOS_MATCH_REPOSITORY_URL }}
+          IOS_APPLE_ID: ${{ secrets.IOS_APPLE_ID }}
+          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+          IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
+          IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
+          IOS_APP_IDENTIFIER: ${{ secrets.IOS_APP_IDENTIFIER }}
+          IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
+          IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
+          IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}

--- a/docs/release_notes/1.0.2.md
+++ b/docs/release_notes/1.0.2.md
@@ -1,0 +1,3 @@
+Enabled iOS preview deployment workflow for pull requests.
+The iOS deploy job will now build and upload IPA artifacts to TestFlight for PR previews.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Description
### Why this change is needed?

The iOS preview deployment workflow was previously commented out, which stopped IPA artifacts from being generated and also prevented TestFlight previews from being uploaded for PRs.
Re-enabling this ensures that:

- Every PR can automatically generate and upload an iOS IPA to TestFlight
- QA and reviewers can easily test iOS builds before merging
- The iOS deployment check reappears in the PR checks
- IPA artifacts are available in workflow runs for download and debugging
- This brings the iOS pipeline back to parity with Android and restores the expected CI/CD process.

### What changed?

- Re-enabled the deploy_ios job in .github/workflows/cd.yml (previously commented out)
- Updated workflow dependencies: switched from needs: [build, release_notes_check] → needs: [check_version_number, release_notes_check]
- Corrected release notes dependency key from release-notes-check → release_notes_check
- Bumped app version to 1.0.2 in package.json to satisfy version validation
- Added release notes for version 1.0.2
- No functional or code changes in the product — CI/CD workflow only

### API / Database changes:

- None

## Screenshots
<img width="1470" height="799" alt="Screenshot 2025-11-18 at 12 20 54 PM" src="https://github.com/user-attachments/assets/d5a45a01-6833-4cec-a334-1a5a0a619a89" />

## Tests

- Validated workflow syntax using GitHub Actions linter
- Ran the workflow on a test branch to ensure the deploy_ios job is triggered
- Confirmed deploy_ios runs only after check_version_number and release_notes_check
- Verified TestFlight upload step is executed in the deploy_ios_preview action
- Checked that IPA artifact is generated and available in workflow run artifacts
- Ensured version bump (1.0.2) satisfies version check and doesn’t block the workflow
- Reviewed logs for all steps to confirm no missing secrets or misconfigurations
