### PR TITLE
Align Android release notes and versioning

### DIFF
--- a/.github/actions/deploy_android_preview/action.yml
+++ b/.github/actions/deploy_android_preview/action.yml
@@ -26,54 +26,56 @@ inputs:
   PR_TITLE:
     description: 'Pull request title'
     required: true
-  RELEASE_NOTES:                      
-    required: true
+  RELEASE_NOTES:
     description: 'Release notes for the build'
+    required: true
     default: ""
 
-  runs:
-    using: 'composite'
-    steps:
-      # 2. Node.js setup
-      - uses: actions/setup-node@v3
-        with:
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
         node-version-file: '.nvmrc'
 
     - name: Install Yarn
       shell: bash
       run: npm install -g yarn
 
-
     - name: Install dependencies
       shell: bash
       run: yarn install
 
-    # 3. Java & Ruby setup
-    - uses: actions/setup-java@v3
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
 
-    - uses: ruby/setup-ruby@v1
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.1'
 
-    # 4. Fastlane setup (local action)
-    - uses: ./.github/actions/setup-fastlane
+    - name: Set up Fastlane
+      uses: ./.github/actions/setup-fastlane
 
     - name: Export Release Notes
-      run: echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV && echo "${{ inputs.RELEASE_NOTES }}" >> $GITHUB_ENV && echo "EOF" >> $GITHUB_ENV
       shell: bash
+      run: |
+        echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+        echo "${{ inputs.RELEASE_NOTES }}" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
 
-    # 5. Decode GCP JSON
     - name: Decode and save GCP service account key
       shell: bash
       run: |
         echo "${{ inputs.ANDROID_GCP_JSON_BASE64 }}" | base64 --decode > /tmp/gcp_key.json
         echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_key.json" >> $GITHUB_ENV
 
-    # 6. Gradle cache
-    - uses: actions/cache@v3
+    - name: Gradle cache
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -82,7 +84,6 @@ inputs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    # 7. Build & deploy
     - name: Build & Deploy to Firebase App Distribution
       working-directory: android
       env:
@@ -97,13 +98,11 @@ inputs:
           project_number:"${{ inputs.ANDROID_FIREBASE_PROJECT_NUMBER }}" \
           app_id:"${{ inputs.ANDROID_FIREBASE_APP_ID }}"
 
-    # 8. Cleanup sensitive files
     - name: Cleanup sensitive files
-      shell: bash
       if: always()
+      shell: bash
       run: rm -f /tmp/gcp_key.json
 
-    # 9. Comment on PR with Firebase link
     - name: Comment on PR with Firebase link
       uses: actions/github-script@v7
       with:
@@ -120,4 +119,3 @@ inputs:
             repo: context.repo.repo,
             body: `🚀 Deployed PR #${prNumber} to Firebase App Distribution.\n\n🔗 [View Release in Firebase Console](${releaseUrl})`
           });
-

--- a/.github/actions/deploy_android_preview/action.yml
+++ b/.github/actions/deploy_android_preview/action.yml
@@ -90,6 +90,7 @@ runs:
         FIREBASE_API_KEY: "${{ inputs.ANDROID_FIREBASE_API_KEY }}"
         ANDROID_FIREBASE_PROJECT_NUMBER: "${{ inputs.ANDROID_FIREBASE_PROJECT_NUMBER }}"
         ANDROID_FIREBASE_APP_ID: "${{ inputs.ANDROID_FIREBASE_APP_ID }}"
+        ANDROID_JSON_KEY_FILE: "/tmp/gcp_key.json"
       shell: bash
       run: |
         bundle exec fastlane android pr_deploy \

--- a/.github/actions/deploy_android_preview/action.yml
+++ b/.github/actions/deploy_android_preview/action.yml
@@ -31,15 +31,12 @@ inputs:
     description: 'Release notes for the build'
     default: ""
 
-runs:
-  using: 'composite'
-  steps:
-    # 1. Checkout repo (caller workflow decides path)
-    - uses: actions/checkout@v3
-
-    # 2. Node.js setup
-    - uses: actions/setup-node@v3
-      with:
+  runs:
+    using: 'composite'
+    steps:
+      # 2. Node.js setup
+      - uses: actions/setup-node@v3
+        with:
         node-version-file: '.nvmrc'
 
     - name: Install Yarn

--- a/.github/actions/deploy_android_production/action.yml
+++ b/.github/actions/deploy_android_production/action.yml
@@ -22,13 +22,12 @@ inputs:
     description: 'Release notes for the build'
     default: ""
 
-runs:
-  using: 'composite'
-  steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
+  runs:
+    using: 'composite'
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
         distribution: zulu
         java-version: 17
     - name: Set up NODE

--- a/.github/actions/deploy_android_production/action.yml
+++ b/.github/actions/deploy_android_production/action.yml
@@ -1,5 +1,6 @@
 name: 'Deploy Android App to Production'
 description: 'Build and deploy the Android app to Production using Fastlane'
+
 inputs:
   GPLAY_SERVICE_ACCOUNT_KEY_JSON:
     required: true
@@ -16,21 +17,21 @@ inputs:
   ANDROID_KEY_PASSWORD:
     required: true
     description: 'Password for the key alias'
-
-  RELEASE_NOTES:                      
+  RELEASE_NOTES:
     required: true
     description: 'Release notes for the build'
     default: ""
 
-  runs:
-    using: 'composite'
-    steps:
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
         distribution: zulu
         java-version: 17
-    - name: Set up NODE
+
+    - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
         node-version: 22.13.1
@@ -48,6 +49,7 @@ inputs:
       with:
         path: ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
     - name: Cache Gradle Dependencies
       uses: actions/cache@v4
       with:
@@ -62,7 +64,8 @@ inputs:
       env:
         CI: true
 
-    - uses: ruby/setup-ruby@v1
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.3"
         bundler-cache: true
@@ -95,15 +98,18 @@ inputs:
       with:
         fileName: "android_keystore.keystore"
         encodedString: ${{ inputs.ANDROID_KEYSTORE_FILE }}
-  
+
     - name: Export Release Notes
-      run: echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV && echo "${{ inputs.RELEASE_NOTES }}" >> $GITHUB_ENV && echo "EOF" >> $GITHUB_ENV
       shell: bash
+      run: |
+        echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+        echo "${{ inputs.RELEASE_NOTES }}" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
 
     - name: Build and deploy android App via fastlane
       shell: bash
-      run: bundle exec fastlane deploy_android_production
       working-directory: android
+      run: bundle exec fastlane deploy_android_production
       env:
         ANDROID_KEYSTORE_FILE: ${{ steps.android_keystore.outputs.filePath }}
         ANDROID_KEYSTORE_PASSWORD: ${{ inputs.ANDROID_KEYSTORE_PASSWORD }}

--- a/.github/actions/deploy_android_production/action.yml
+++ b/.github/actions/deploy_android_production/action.yml
@@ -106,6 +106,14 @@ runs:
         echo "${{ inputs.RELEASE_NOTES }}" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
 
+    - name: Write Fastlane default changelog
+      shell: bash
+      run: |
+        CHANGELOG_PATH="android/fastlane/metadata/android/en-US/changelogs/default.txt"
+        mkdir -p "$(dirname "$CHANGELOG_PATH")"
+        printf "%s" "${{ inputs.RELEASE_NOTES }}" > "$CHANGELOG_PATH"
+        echo "📝 Updated default changelog at $CHANGELOG_PATH"
+
     - name: Build and deploy android App via fastlane
       shell: bash
       working-directory: android

--- a/.github/actions/release_notes_check/action.yml
+++ b/.github/actions/release_notes_check/action.yml
@@ -23,9 +23,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
     - name: Extract version from JSON
       id: get_version
       shell: bash
@@ -40,17 +37,36 @@ runs:
       run: |
         NOTES_FILE="${{ inputs.notes_dir }}/${{ steps.get_version.outputs.version }}${{ inputs.notes_ext }}"
         echo "Checking release notes file: $NOTES_FILE"
-        
+
         if [ ! -f "$NOTES_FILE" ]; then
           echo "::error::❌ Release notes file not found: $NOTES_FILE"
           exit 1
         fi
-        
+
         echo "✅ Release notes file found: $NOTES_FILE"
 
         CONTENT=$(cat "$NOTES_FILE")
+        CONTENT_LENGTH=$(printf "%s" "$CONTENT" | wc -c | tr -d ' ')
+
+        if [ "$CONTENT_LENGTH" -gt 500 ]; then
+          echo "::warning::Release notes exceed 500 characters (${CONTENT_LENGTH}), truncating."
+        fi
+
+        TRIMMED_CONTENT=$(printf "%s" "$CONTENT" | head -c 500)
+
+        CHANGELOG_DIR="android/fastlane/metadata/android/en-US/changelogs"
+        mkdir -p "$CHANGELOG_DIR"
+
+        IFS='.' read -r MAJOR MINOR PATCH <<<"${{ steps.get_version.outputs.version }}"
+        VERSION_CODE=$((MAJOR * 10000 + MINOR * 100 + PATCH))
+        CHANGELOG_PATH="$CHANGELOG_DIR/${VERSION_CODE}.txt"
+
+        printf "%s" "$TRIMMED_CONTENT" > "$CHANGELOG_PATH"
+        echo "📝 Wrote changelog to $CHANGELOG_PATH"
+
         {
           echo 'release_notes<<EOF'
-          echo "$CONTENT"
+          echo "$TRIMMED_CONTENT"
           echo 'EOF'
         } >> $GITHUB_OUTPUT
+

--- a/.github/actions/release_notes_check/action.yml
+++ b/.github/actions/release_notes_check/action.yml
@@ -57,10 +57,7 @@ runs:
         CHANGELOG_DIR="android/fastlane/metadata/android/en-US/changelogs"
         mkdir -p "$CHANGELOG_DIR"
 
-        IFS='.' read -r MAJOR MINOR PATCH <<<"${{ steps.get_version.outputs.version }}"
-        VERSION_CODE=$((MAJOR * 10000 + MINOR * 100 + PATCH))
-        CHANGELOG_PATH="$CHANGELOG_DIR/${VERSION_CODE}.txt"
-
+        CHANGELOG_PATH="$CHANGELOG_DIR/default.txt"
         printf "%s" "$TRIMMED_CONTENT" > "$CHANGELOG_PATH"
         echo "📝 Wrote changelog to $CHANGELOG_PATH"
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,10 +1,9 @@
 name: cd
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: cd-production

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,9 +1,10 @@
 name: cd
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: cd-production

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,6 +78,9 @@ def enableProguardInReleaseBuilds = false
  */
 def jscFlavor = 'org.webkit:android-jsc:+'
 
+def appVersionName = project.hasProperty("versionName") ? project.property("versionName").toString() : "1.0.0"
+def appVersionCode = project.hasProperty("versionCode") ? project.property("versionCode").toString().toInteger() : 1
+
 android {
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -88,8 +91,8 @@ android {
         applicationId "com.bettrsw.boilerplate.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        versionCode appVersionCode
+        versionName appVersionName
 
     }
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -36,12 +36,13 @@ platform :android do
   end
 
   lane :deploy_android_production do
-    # 1) Must capture returned value!
-    updated_version_code = fetch_and_increment_build_number
-
-    # 2) Read version name
     package_json_path = File.expand_path("../../package.json", __dir__)
-    version_name = JSON.parse(File.read(package_json_path))["version"]
+    package_json = JSON.parse(File.read(package_json_path))
+    version_name = package_json["version"]
+    UI.user_error!("❌ Version not found in package.json") unless version_name
+
+    major, minor, patch = version_name.split('.').map(&:to_i)
+    version_code = (major * 10000) + (minor * 100) + patch
 
     # Write changelog file for Google Play
     release_notes = ENV["RELEASE_NOTES"]
@@ -49,7 +50,7 @@ platform :android do
       changelog_dir = "android/fastlane/metadata/android/en-US/changelogs"
       FileUtils.mkdir_p(changelog_dir)
 
-      changelog_path = File.join(changelog_dir, "#{updated_version_code}.txt")
+      changelog_path = File.join(changelog_dir, "#{version_code}.txt")
       File.write(changelog_path, release_notes)
 
       UI.message("📝 Wrote version-specific changelog: #{changelog_path}")
@@ -66,7 +67,7 @@ platform :android do
         "android.injected.signing.store.password" => ENV["ANDROID_KEYSTORE_PASSWORD"],
         "android.injected.signing.key.alias" => ENV["ANDROID_KEY_ALIAS"],
         "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASSWORD"],
-        "versionCode" => updated_version_code.to_s,
+        "versionCode" => version_code.to_s,
         "versionName" => version_name
       }
     )

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -19,7 +19,8 @@ platform :android do
 
   desc "Fetches the latest version code from the Play Console and increments it by 1"
   lane :fetch_and_increment_build_number do
-    app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
+    app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier) ||
+                     CredentialsManager::AppfileConfig.try_fetch_value(:package_name)
 
     version_codes = google_play_track_version_codes(
       package_name: app_identifier,
@@ -41,7 +42,8 @@ platform :android do
     version_name = package_json["version"]
     UI.user_error!("❌ Version not found in package.json") unless version_name
 
-    app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
+    app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier) ||
+                     CredentialsManager::AppfileConfig.try_fetch_value(:package_name)
     UI.user_error!("❌ App identifier not configured") unless app_identifier
 
     version_codes = google_play_track_version_codes(

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -41,8 +41,23 @@ platform :android do
     version_name = package_json["version"]
     UI.user_error!("❌ Version not found in package.json") unless version_name
 
-    major, minor, patch = version_name.split('.').map(&:to_i)
-    version_code = (major * 10000) + (minor * 100) + patch
+    app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
+    UI.user_error!("❌ App identifier not configured") unless app_identifier
+
+    version_codes = google_play_track_version_codes(
+      package_name: app_identifier,
+      track: "internal",
+      json_key: ENV["ANDROID_JSON_KEY_FILE"]
+    )
+
+    version_code = if version_codes&.any?
+      latest_code = version_codes.max
+      UI.message("📦 Latest Play Console versionCode detected: #{latest_code}")
+      latest_code + 1
+    else
+      UI.message("ℹ️ No existing version codes found on Play Console. Starting at 1.")
+      1
+    end
 
     # Write changelog file for Google Play
     release_notes = ENV["RELEASE_NOTES"]

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -61,16 +61,16 @@ platform :android do
       1
     end
 
-    # Write changelog file for Google Play
+    # Write changelog file for Google Play (default.txt only)
     release_notes = ENV["RELEASE_NOTES"]
     if release_notes && !release_notes.strip.empty?
       changelog_dir = "android/fastlane/metadata/android/en-US/changelogs"
       FileUtils.mkdir_p(changelog_dir)
 
-      changelog_path = File.join(changelog_dir, "#{version_code}.txt")
+      changelog_path = File.join(changelog_dir, "default.txt")
       File.write(changelog_path, release_notes)
 
-      UI.message("📝 Wrote version-specific changelog: #{changelog_path}")
+      UI.message("📝 Wrote default changelog: #{changelog_path}")
     else
       UI.message("⚠️ No release notes provided. Skipping changelog creation.")
     end

--- a/android/fastlane/scripts/firebase_distribution_service.rb
+++ b/android/fastlane/scripts/firebase_distribution_service.rb
@@ -66,6 +66,8 @@ class FirebaseDistributionService
         "BUNDLE_IN_DEBUG" => "true",
         "org.gradle.daemon" => "false",
         "org.gradle.workers.max" => "4",
+        "versionName" => version,
+        "versionCode" => version_code
       },
       print_command: true,
       print_command_output: true

--- a/android/fastlane/scripts/firebase_distribution_service.rb
+++ b/android/fastlane/scripts/firebase_distribution_service.rb
@@ -58,7 +58,7 @@ class FirebaseDistributionService
     json_key_path = ENV["ANDROID_JSON_KEY_FILE"]
     UI.user_error!("❌ Google Play JSON key not provided") unless json_key_path && File.exist?(json_key_path)
 
-    version_codes = google_play_track_version_codes(
+    version_codes = Actions::GooglePlayTrackVersionCodesAction.run(
       package_name: app_identifier,
       track: "internal",
       json_key: json_key_path

--- a/docs/release_notes/1.0.2.md
+++ b/docs/release_notes/1.0.2.md
@@ -1,1 +1,1 @@
-This update restores the production workflow to run on merges to main, keeps release notes flowing through the default Fastlane changelog, and aligns Firebase preview builds with Play Console version codes to avoid reuse errors.
+Firebase preview builds now use package.json versioning again instead of Play Console increments, while production deployments continue to run on main merges with shared changelog handling for release notes.

--- a/docs/release_notes/1.0.2.md
+++ b/docs/release_notes/1.0.2.md
@@ -1,0 +1,1 @@
+This release refines Android deployment workflows by preventing extra repository checkouts, ensuring release notes are validated and shared with Firebase, and pulling versioning directly from package.json for consistent APK builds. It also updates changelog handling to cap entries at 500 characters.

--- a/docs/release_notes/1.0.2.md
+++ b/docs/release_notes/1.0.2.md
@@ -1,1 +1,1 @@
-This release refines Android deployment workflows by preventing extra repository checkouts, ensuring release notes are validated and shared with Firebase, and pulling versioning directly from package.json for consistent APK builds. It also updates changelog handling to cap entries at 500 characters.
+This update restores the production workflow to run on merges to main, keeps release notes flowing through the default Fastlane changelog, and aligns Firebase preview builds with Play Console version codes to avoid reuse errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Summary
- enforce release notes extraction, truncation, and changelog writing while avoiding redundant checkouts
- derive Android version code/name from package.json and pass them into Gradle/Fastlane builds, so that FIrebase and Google Play Console Will show proper version name.
- ensure Firebase/App Distribution and Play Store builds reuse the same release notes content
