### PR TITLE
Fix production Android workflow inputs and bump version 1.0.5

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -38,10 +38,10 @@ jobs:
         uses: ./.github/actions/deploy_android_production
         with:
           GPLAY_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.GPLAY_SERVICE_ACCOUNT_KEY_JSON }}
-          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          ANDROID_KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
 
   # deploy-ios:

--- a/docs/release_notes/1.0.5.md
+++ b/docs/release_notes/1.0.5.md
@@ -1,0 +1,4 @@
+## 1.0.5
+
+- Fix Android production workflow inputs to use correct keystore parameter names.
+- Ensure release process aligns with updated action requirements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Summary
- update the production Android workflow to use the input names expected by the deploy action
- bump the app version to 1.0.5 and add release notes for the release

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ece96b7148329a0f7514bb52bce2c)