### PR TITLE
[WIP]Add iOS release notes support for deployments

### DIFF
--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -38,31 +38,10 @@ inputs:
     required: false
     description: 'Pull request number for PR-specific builds'
 
-runs:
+  runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v3
-
-    - name: Write iOS changelog from release notes
-      shell: bash
-      run: |
-        CHANGELOG_PATH="ios/fastlane/changelog.txt"
-
-        if [ -z "${RELEASE_NOTES}" ]; then
-          echo "::error::Release notes are missing; ensure release_notes_check ran and passed."
-          exit 1
-        fi
-
-        echo "Populating $CHANGELOG_PATH with release notes"
-        mkdir -p "$(dirname "$CHANGELOG_PATH")"
-        printf "%s" "$RELEASE_NOTES" > "$CHANGELOG_PATH"
-
-        if [ ! -s "$CHANGELOG_PATH" ]; then
-          echo "::error::Release notes file at $CHANGELOG_PATH is empty after write."
-          exit 1
-        fi
-
-        echo "✅ Wrote release notes to $CHANGELOG_PATH"
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -38,7 +38,7 @@ inputs:
     required: false
     description: 'Pull request number for PR-specific builds'
 
-  runs:
+runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v3

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -43,6 +43,27 @@ runs:
   steps:
     - uses: actions/checkout@v3
 
+    - name: Write iOS changelog from release notes
+      shell: bash
+      run: |
+        CHANGELOG_PATH="ios/fastlane/changelog.txt"
+
+        if [ -z "${RELEASE_NOTES}" ]; then
+          echo "::error::Release notes are missing; ensure release_notes_check ran and passed."
+          exit 1
+        fi
+
+        echo "Populating $CHANGELOG_PATH with release notes"
+        mkdir -p "$(dirname "$CHANGELOG_PATH")"
+        printf "%s" "$RELEASE_NOTES" > "$CHANGELOG_PATH"
+
+        if [ ! -s "$CHANGELOG_PATH" ]; then
+          echo "::error::Release notes file at $CHANGELOG_PATH is empty after write."
+          exit 1
+        fi
+
+        echo "✅ Wrote release notes to $CHANGELOG_PATH"
+
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -41,7 +41,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v3
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -38,7 +38,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v3
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -40,6 +40,27 @@ runs:
   steps:
     - uses: actions/checkout@v3
 
+    - name: Write iOS changelog from release notes
+      shell: bash
+      run: |
+        CHANGELOG_PATH="ios/fastlane/changelog.txt"
+
+        if [ -z "${RELEASE_NOTES}" ]; then
+          echo "::error::Release notes are missing; ensure release_notes_check ran and passed."
+          exit 1
+        fi
+
+        echo "Populating $CHANGELOG_PATH with release notes"
+        mkdir -p "$(dirname "$CHANGELOG_PATH")"
+        printf "%s" "$RELEASE_NOTES" > "$CHANGELOG_PATH"
+
+        if [ ! -s "$CHANGELOG_PATH" ]; then
+          echo "::error::Release notes file at $CHANGELOG_PATH is empty after write."
+          exit 1
+        fi
+
+        echo "✅ Wrote release notes to $CHANGELOG_PATH"
+
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -35,31 +35,10 @@ inputs:
     required: true
     description: 'SSH private key for Match repo'
 
-runs:
+  runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v3
-
-    - name: Write iOS changelog from release notes
-      shell: bash
-      run: |
-        CHANGELOG_PATH="ios/fastlane/changelog.txt"
-
-        if [ -z "${RELEASE_NOTES}" ]; then
-          echo "::error::Release notes are missing; ensure release_notes_check ran and passed."
-          exit 1
-        fi
-
-        echo "Populating $CHANGELOG_PATH with release notes"
-        mkdir -p "$(dirname "$CHANGELOG_PATH")"
-        printf "%s" "$RELEASE_NOTES" > "$CHANGELOG_PATH"
-
-        if [ ! -s "$CHANGELOG_PATH" ]; then
-          echo "::error::Release notes file at $CHANGELOG_PATH is empty after write."
-          exit 1
-        fi
-
-        echo "✅ Wrote release notes to $CHANGELOG_PATH"
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -35,7 +35,7 @@ inputs:
     required: true
     description: 'SSH private key for Match repo'
 
-  runs:
+runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v3

--- a/.github/actions/release_notes_check/action.yml
+++ b/.github/actions/release_notes_check/action.yml
@@ -48,6 +48,11 @@ runs:
         CONTENT=$(cat "$NOTES_FILE")
         CONTENT_LENGTH=$(printf "%s" "$CONTENT" | wc -c | tr -d ' ')
 
+        if [ "$CONTENT_LENGTH" -eq 0 ]; then
+          echo "::error::❌ Release notes file is empty: $NOTES_FILE"
+          exit 1
+        fi
+
         if [ "$CONTENT_LENGTH" -gt 500 ]; then
           echo "::warning::Release notes exceed 500 characters (${CONTENT_LENGTH}), truncating."
         fi

--- a/.github/actions/release_notes_check/action.yml
+++ b/.github/actions/release_notes_check/action.yml
@@ -61,6 +61,18 @@ runs:
         printf "%s" "$TRIMMED_CONTENT" > "$CHANGELOG_PATH"
         echo "📝 Wrote changelog to $CHANGELOG_PATH"
 
+        IOS_METADATA_DIR="ios/fastlane/metadata/default"
+        mkdir -p "$IOS_METADATA_DIR"
+
+        IOS_RELEASE_NOTES_PATH="$IOS_METADATA_DIR/release_notes.txt"
+        printf "%s" "$TRIMMED_CONTENT" > "$IOS_RELEASE_NOTES_PATH"
+        echo "🍏 Wrote iOS release notes to $IOS_RELEASE_NOTES_PATH"
+
+        IOS_EN_METADATA_DIR="ios/fastlane/metadata/en-US"
+        mkdir -p "$IOS_EN_METADATA_DIR"
+        printf "%s" "$TRIMMED_CONTENT" > "$IOS_EN_METADATA_DIR/release_notes.txt"
+        echo "🍏 Wrote localized iOS release notes to $IOS_EN_METADATA_DIR/release_notes.txt"
+
         {
           echo 'release_notes<<EOF'
           echo "$TRIMMED_CONTENT"

--- a/.github/actions/release_notes_check/action.yml
+++ b/.github/actions/release_notes_check/action.yml
@@ -73,6 +73,11 @@ runs:
         printf "%s" "$TRIMMED_CONTENT" > "$IOS_EN_METADATA_DIR/release_notes.txt"
         echo "🍏 Wrote localized iOS release notes to $IOS_EN_METADATA_DIR/release_notes.txt"
 
+        IOS_CHANGELOG_PATH="ios/fastlane/changelog.txt"
+        mkdir -p "$(dirname "$IOS_CHANGELOG_PATH")"
+        printf "%s" "$TRIMMED_CONTENT" > "$IOS_CHANGELOG_PATH"
+        echo "🍏 Wrote iOS changelog to $IOS_CHANGELOG_PATH"
+
         {
           echo 'release_notes<<EOF'
           echo "$TRIMMED_CONTENT"

--- a/.github/actions/release_notes_check/action.yml
+++ b/.github/actions/release_notes_check/action.yml
@@ -1,6 +1,5 @@
 name: Release Notes Check
-description: Checks if release notes file exists for the current version and outputs the content.
-
+description: Checks if release notes exist for current version and distributes to Android/iOS metadata
 inputs:
   version_file:
     description: 'Path to the version file (default: package.json)'
@@ -14,12 +13,13 @@ inputs:
     description: 'Release notes file extension (default: .md)'
     required: false
     default: '.md'
-
 outputs:
   release_notes:
     description: 'Content of the release notes file'
-    value: ${{ steps.check_notes.outputs.release_notes }}
-
+    value: ${{ steps.process_notes.outputs.release_notes }}
+  version:
+    description: 'Extracted version number'
+    value: ${{ steps.get_version.outputs.version }}
 runs:
   using: "composite"
   steps:
@@ -28,64 +28,110 @@ runs:
       shell: bash
       run: |
         VERSION=$(jq -r .version < "${{ inputs.version_file }}")
-        echo "Extracted version: $VERSION"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "✅ Extracted version: $VERSION"
 
-    - name: Check for release notes file
-      id: check_notes
+    - name: Validate and Process Release Notes
+      id: process_notes
       shell: bash
       run: |
         NOTES_FILE="${{ inputs.notes_dir }}/${{ steps.get_version.outputs.version }}${{ inputs.notes_ext }}"
-        echo "Checking release notes file: $NOTES_FILE"
-
+        echo "🔍 Checking: $NOTES_FILE"
+        
+        # Validate file exists and is not empty
         if [ ! -f "$NOTES_FILE" ]; then
-          echo "::error::❌ Release notes file not found: $NOTES_FILE"
+          echo "::error::Release notes file not found: $NOTES_FILE"
+          echo "::error::Expected format: docs/release_notes/<version>.md"
+          echo "::error::Example: docs/release_notes/1.2.0.md"
           exit 1
         fi
-
-        echo "✅ Release notes file found: $NOTES_FILE"
-
-        CONTENT=$(cat "$NOTES_FILE")
-        CONTENT_LENGTH=$(printf "%s" "$CONTENT" | wc -c | tr -d ' ')
-
-        if [ "$CONTENT_LENGTH" -eq 0 ]; then
-          echo "::error::❌ Release notes file is empty: $NOTES_FILE"
+        
+        if [ ! -s "$NOTES_FILE" ]; then
+          echo "::error::Release notes file is empty: $NOTES_FILE"
           exit 1
         fi
-
-        if [ "$CONTENT_LENGTH" -gt 500 ]; then
-          echo "::warning::Release notes exceed 500 characters (${CONTENT_LENGTH}), truncating."
+        
+        # Read and clean content (remove leading/trailing whitespace, Windows line endings)
+        CONTENT=$(cat "$NOTES_FILE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -d '\r')
+        
+        if [ -z "$CONTENT" ]; then
+          echo "::error::Release notes contain only whitespace"
+          exit 1
         fi
-
-        TRIMMED_CONTENT=$(printf "%s" "$CONTENT" | head -c 500)
-
-        CHANGELOG_DIR="android/fastlane/metadata/android/en-US/changelogs"
-        mkdir -p "$CHANGELOG_DIR"
-
-        CHANGELOG_PATH="$CHANGELOG_DIR/default.txt"
-        printf "%s" "$TRIMMED_CONTENT" > "$CHANGELOG_PATH"
-        echo "📝 Wrote changelog to $CHANGELOG_PATH"
-
-        IOS_METADATA_DIR="ios/fastlane/metadata/default"
-        mkdir -p "$IOS_METADATA_DIR"
-
-        IOS_RELEASE_NOTES_PATH="$IOS_METADATA_DIR/release_notes.txt"
-        printf "%s" "$TRIMMED_CONTENT" > "$IOS_RELEASE_NOTES_PATH"
-        echo "🍏 Wrote iOS release notes to $IOS_RELEASE_NOTES_PATH"
-
-        IOS_EN_METADATA_DIR="ios/fastlane/metadata/en-US"
-        mkdir -p "$IOS_EN_METADATA_DIR"
-        printf "%s" "$TRIMMED_CONTENT" > "$IOS_EN_METADATA_DIR/release_notes.txt"
-        echo "🍏 Wrote localized iOS release notes to $IOS_EN_METADATA_DIR/release_notes.txt"
-
-        IOS_CHANGELOG_PATH="ios/fastlane/changelog.txt"
-        mkdir -p "$(dirname "$IOS_CHANGELOG_PATH")"
-        printf "%s" "$TRIMMED_CONTENT" > "$IOS_CHANGELOG_PATH"
-        echo "🍏 Wrote iOS changelog to $IOS_CHANGELOG_PATH"
-
+        
+        # Check character limits (TestFlight = 4000 chars, App Store = 4000 chars)
+        CHAR_COUNT=${#CONTENT}
+        echo "✅ Valid release notes found ($CHAR_COUNT chars)"
+        
+        if [ $CHAR_COUNT -gt 4000 ]; then
+          echo "::warning::Release notes exceed 4000 characters ($CHAR_COUNT). May be truncated by Apple."
+        fi
+        
+        # Set output for GitHub Actions
+        EOF_MARKER=$(echo "$CONTENT" | sha256sum | cut -c1-8)
         {
-          echo 'release_notes<<EOF'
-          echo "$TRIMMED_CONTENT"
-          echo 'EOF'
+          echo "release_notes<<EOF_${EOF_MARKER}"
+          echo "$CONTENT"
+          echo "EOF_${EOF_MARKER}"
         } >> $GITHUB_OUTPUT
-
+        
+        echo "📝 Release notes preview (first 200 chars):"
+        echo "$CONTENT" | head -c 200
+        echo ""
+        echo "..."
+        
+        # --- ANDROID DISTRIBUTION ---
+        echo ""
+        echo "🤖 === ANDROID SETUP ==="
+        ANDROID_DIR="android/fastlane/metadata/android/en-US/changelogs"
+        mkdir -p "$ANDROID_DIR"
+        echo "$CONTENT" > "$ANDROID_DIR/default.txt"
+        
+        if [ -f "$ANDROID_DIR/default.txt" ]; then
+          echo "✅ Created: $ANDROID_DIR/default.txt"
+        else
+          echo "::error::Failed to create Android changelog"
+          exit 1
+        fi
+        
+        # --- iOS DISTRIBUTION ---
+        echo ""
+        echo "🍏 === iOS SETUP ==="
+        
+        # 1. Create changelog.txt for TestFlight (preview/PR builds)
+        IOS_DIR="ios/fastlane"
+        mkdir -p "$IOS_DIR"
+        echo "$CONTENT" > "$IOS_DIR/changelog.txt"
+        
+        if [ -f "$IOS_DIR/changelog.txt" ]; then
+          echo "✅ Created: $IOS_DIR/changelog.txt (for TestFlight)"
+        else
+          echo "::error::Failed to create iOS changelog.txt"
+          exit 1
+        fi
+        
+        # 2. Create release_notes.txt for App Store (production builds)
+        IOS_METADATA_DIR="ios/fastlane/metadata/en-US"
+        mkdir -p "$IOS_METADATA_DIR"
+        echo "$CONTENT" > "$IOS_METADATA_DIR/release_notes.txt"
+        
+        if [ -f "$IOS_METADATA_DIR/release_notes.txt" ]; then
+          echo "✅ Created: $IOS_METADATA_DIR/release_notes.txt (for App Store)"
+        else
+          echo "::error::Failed to create iOS release_notes.txt"
+          exit 1
+        fi
+        
+        # 3. Optional: Multi-language support
+        # Uncomment if your app supports multiple languages
+        # for lang in hi-IN de-DE fr-FR es-ES; do
+        #   LANG_DIR="ios/fastlane/metadata/$lang"
+        #   mkdir -p "$LANG_DIR"
+        #   cp "$IOS_METADATA_DIR/release_notes.txt" "$LANG_DIR/"
+        #   echo "✅ Created: $LANG_DIR/release_notes.txt"
+        # done
+        
+        echo ""
+        echo "✅ === DISTRIBUTION COMPLETE ==="
+        echo "📱 Android: Ready for Play Store"
+        echo "📱 iOS: Ready for TestFlight + App Store"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,6 +48,17 @@ jobs:
           notes_dir: 'docs/release_notes'
           notes_ext: '.md'
 
+      - name: Upload release notes artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-${{ github.run_id }}
+          path: |
+            android/fastlane/metadata/android/en-US/changelogs/default.txt
+            ios/fastlane/changelog.txt
+            ios/fastlane/metadata/default/release_notes.txt
+            ios/fastlane/metadata/en-US/release_notes.txt
+          if-no-files-found: error
+
   deploy_android:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     needs: [check_version_number, release_notes_check]
@@ -89,6 +100,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Download release notes artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes-${{ github.run_id }}
+          path: .
 
       - name: Deploy iOS Preview to TestFlight
         uses: ./.github/actions/deploy_ios_preview

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -75,3 +75,5 @@ jobs:
           IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
           IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
           IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
+        env:
+          RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,6 +27,17 @@ jobs:
           notes_dir: 'docs/release_notes'
           notes_ext: '.md'
 
+      - name: Upload release notes artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-${{ github.run_id }}
+          path: |
+            android/fastlane/metadata/android/en-US/changelogs/default.txt
+            ios/fastlane/changelog.txt
+            ios/fastlane/metadata/default/release_notes.txt
+            ios/fastlane/metadata/en-US/release_notes.txt
+          if-no-files-found: error
+
   deploy_android:
     runs-on: ubuntu-latest
     needs: [release_notes_check]
@@ -60,6 +71,12 @@ jobs:
     steps:
       - name: Checkout (app)
         uses: actions/checkout@v3
+
+      - name: Download release notes artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes-${{ github.run_id }}
+          path: .
 
       - name: Deploy iOS app to App Store
         uses: ./.github/actions/deploy_ios_production

--- a/docs/release_notes/1.0.11.md
+++ b/docs/release_notes/1.0.11.md
@@ -1,0 +1,4 @@
+# 1.0.11
+
+- Documented the release-notes workflow so Android and iOS deployments consistently pick up the right changelog content.
+- Bumped the project version to match the new release notes guidance.

--- a/docs/release_notes/README.md
+++ b/docs/release_notes/README.md
@@ -1,0 +1,24 @@
+# Release notes workflow
+
+Release notes for both Android and iOS are sourced from this folder and must match the version in `package.json`.
+
+## How to add release notes
+1. Update the app version in `package.json`.
+2. Create a Markdown file named after the version inside `docs/release_notes` (for example, `1.0.11.md`).
+3. Use the following format:
+   ```md
+   # <version>
+
+   - Short bullet(s) explaining the user-facing changes in this release.
+   - Prefer concise, complete sentences.
+   ```
+
+## Why this matters
+- CI uses `release_notes_check` to fail the build if the notes file for the current version is missing.
+- The Android pipeline copies these notes into the Google Play changelog.
+- The iOS pipelines reuse the same notes for TestFlight previews and App Store submissions.
+
+## Tips
+- Keep the most important user-facing updates at the top of the list.
+- Avoid internal-only details unless they affect users or testers.
+- If there are no notable changes, explicitly state that (e.g., `- Maintenance and dependency updates only`).

--- a/ios/fastlane/changelog.txt
+++ b/ios/fastlane/changelog.txt
@@ -1,0 +1,1 @@
+This is a test changelog, for version: 1.0.11

--- a/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,1 @@
+This is a test release note, for version: 1.0.11

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -20,7 +20,11 @@ def ios_deploy_preview!(options = {})
   apple_id = options.fetch(:apple_id)
   username = options.fetch(:username)
   team_id = options.fetch(:team_id)
-  release_notes = ENV["RELEASE_NOTES"]&.strip
+  changelog_path = File.expand_path('../changelog.txt', __dir__)
+  UI.user_error!("❌ Release notes file not found at: #{changelog_path}. Ensure release_notes_check has populated changelog.txt") unless File.exist?(changelog_path)
+
+  release_notes = File.read(changelog_path).strip
+  UI.user_error!("❌ Release notes file at #{changelog_path} is empty. Please provide release notes before building.") if release_notes.empty?
 
   package_json_path = File.expand_path('../../../package.json', __dir__)
   package_json = JSON.parse(File.read(package_json_path))

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -159,11 +159,13 @@ def ios_deploy_preview!(options = {})
                         end
 
     upload_to_testflight(
-      changelog: changelog_message,
+      changelog: "This is a test changelog",
+      skip_waiting_for_build_processing: false,
       distribute_external: false,
       username: username,
       apple_id: apple_id,
-      app_identifier: app_identifier
+      app_identifier: app_identifier,
+                        
     )
   rescue => e
     # In case of failure, cleanup any temp IPA directories

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -20,6 +20,7 @@ def ios_deploy_preview!(options = {})
   apple_id = options.fetch(:apple_id)
   username = options.fetch(:username)
   team_id = options.fetch(:team_id)
+  release_notes = ENV["RELEASE_NOTES"]&.strip
 
   package_json_path = File.expand_path('../../../package.json', __dir__)
   package_json = JSON.parse(File.read(package_json_path))
@@ -146,9 +147,15 @@ def ios_deploy_preview!(options = {})
       rm -rf temp_payload
     BASH
   # Upload the build to TestFlight (internal only) with a changelog indicating the PR number.
-  begin  
+  begin
+    changelog_message = if release_notes && !release_notes.empty?
+                          release_notes
+                        else
+                          "PR ##{pr_number} Build - automated upload"
+                        end
+
     upload_to_testflight(
-      changelog: "PR ##{pr_number} Build - automated upload",
+      changelog: changelog_message,
       distribute_external: false,
       username: username,
       apple_id: apple_id,

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -15,6 +15,7 @@ def ios_deploy_production!(options = {})
   keychain_name = options.fetch(:keychain_name)
   keychain_password = options.fetch(:keychain_password)
   team_id = options.fetch(:team_id)
+  release_notes = ENV["RELEASE_NOTES"]&.strip
 
   package_json_path = File.expand_path('../../../package.json', __dir__)
   package_json = JSON.parse(File.read(package_json_path))
@@ -115,10 +116,14 @@ def ios_deploy_production!(options = {})
   # Upload IPA to App Store (for distribution)
   upload_to_app_store(
     skip_screenshots: true,
-    skip_metadata: true,
+    skip_metadata: false,
     skip_app_version_update: true,
     force: true,
     precheck_include_in_app_purchases: false,
+    metadata_path: "fastlane/metadata",
+    release_notes: {
+      'default' => release_notes && !release_notes.empty? ? release_notes : "Production release for version #{marketing_version}"
+    }
   )
 end
 

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -15,7 +15,11 @@ def ios_deploy_production!(options = {})
   keychain_name = options.fetch(:keychain_name)
   keychain_password = options.fetch(:keychain_password)
   team_id = options.fetch(:team_id)
-  release_notes = ENV["RELEASE_NOTES"]&.strip
+  changelog_path = File.expand_path('../changelog.txt', __dir__)
+  UI.user_error!("❌ Release notes file not found at: #{changelog_path}. Ensure release_notes_check has populated changelog.txt") unless File.exist?(changelog_path)
+
+  release_notes = File.read(changelog_path).strip
+  UI.user_error!("❌ Release notes file at #{changelog_path} is empty. Please provide release notes before building.") if release_notes.empty?
 
   package_json_path = File.expand_path('../../../package.json', __dir__)
   package_json = JSON.parse(File.read(package_json_path))
@@ -47,6 +51,12 @@ def ios_deploy_production!(options = {})
     issuer_id: issuer_id,
     key_content: api_key_b64,
     is_key_content_base64: true,
+  )
+
+  set_changelog(
+    app_identifier: app_identifier,
+    version: marketing_version,
+    changelog: release_notes
   )
 
   UI.message("🧾 Setting iOS marketing version from package.json: #{marketing_version}")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Summary
- extend release notes check to prepare iOS metadata alongside Android changelogs
- pass release notes into iOS preview and production deploy workflows
- surface release notes in Fastlane iOS preview and production lanes for TestFlight and App Store uploads

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693676d15a688329be151399be1502cc)