### PR TITLE
Add release notes support for IOS preview builds.

### DIFF
--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -113,6 +113,7 @@ runs:
       run: |
         CHANGELOG_PATH="ios/fastlane/changelog.txt"
         mkdir -p "$(dirname "$CHANGELOG_PATH")"
+        echo "RELEASE NOTES: ${{ inputs.RELEASE_NOTES }}"
         printf "%s" "${{ inputs.RELEASE_NOTES }}" > "$CHANGELOG_PATH"
         echo "📝 Wrote iOS changelog to $CHANGELOG_PATH"
         
@@ -161,6 +162,7 @@ runs:
         IOS_DEV_EMAIL: ${{ inputs.IOS_DEV_EMAIL }}
         FASTLANE_USER: ${{ inputs.IOS_DEV_EMAIL }}
         PR_NUMBER: ${{ inputs.PR_NUMBER }}
+        RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
     
     - name: Upload .ipa artifact
       uses: actions/upload-artifact@v4

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -162,6 +162,7 @@ runs:
           IOS_APP_IDENTIFIER: ${{ inputs.IOS_APP_IDENTIFIER }}
           IOS_APP_STORE_TEAM_ID: ${{ inputs.IOS_APP_STORE_TEAM_ID }}
           IOS_DEV_EMAIL: ${{ inputs.IOS_DEV_EMAIL }}
+          RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
 
     - name: Upload Xcode build logs
       if: failure()

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        
       - name: Compare package.json versions
         run: |
           # Fetch the main branch package.json
@@ -36,6 +37,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
       - name: Check release notes
         id: check
         uses: ./.github/actions/release_notes_check
@@ -51,10 +53,12 @@ jobs:
     steps:
       - name: Checkout (root for actions)
         uses: actions/checkout@v4
+
       - name: Checkout (app code)
         uses: actions/checkout@v4
         with:
           path: app
+
       - name: Inject Doppler Preview Secrets
         uses: ./.github/actions/inject_doppler_secrets
         with:
@@ -62,6 +66,7 @@ jobs:
           doppler_project: react-native-template
           doppler_environment: preview
           working_directory: app
+
       - name: Deploy android app to Firebase App Distribution
         uses: ./.github/actions/deploy_android_preview
         with:
@@ -83,6 +88,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Inject Doppler Preview Secrets
         uses: ./.github/actions/inject_doppler_secrets
         with:
@@ -90,6 +96,7 @@ jobs:
           doppler_project: react-native-template
           doppler_environment: preview
           working_directory: "."
+
       - name: Deploy iOS Preview to TestFlight
         uses: ./.github/actions/deploy_ios_preview
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     branches:
-      - vikram/feat/add-ios-release-notes  
+      - main  
 
 concurrency:
   group: cd

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
       - name: Check release notes
         id: check
         uses: ./.github/actions/release_notes_check
@@ -30,6 +31,7 @@ jobs:
     steps:
       - name: Checkout (app)
         uses: actions/checkout@v4
+
       - name: Inject Doppler Production Secrets
         uses: ./.github/actions/inject_doppler_secrets
         with:
@@ -37,6 +39,7 @@ jobs:
           doppler_project: react-native-template
           doppler_environment: production
           working_directory: .
+
       - name: Deploy Android app to Play Store
         id: deploy_android_production
         uses: ./.github/actions/deploy_android_production
@@ -55,6 +58,7 @@ jobs:
     steps:
       - name: Checkout (app)
         uses: actions/checkout@v4
+        
       - name: Inject Doppler Production Secrets
         uses: ./.github/actions/inject_doppler_secrets
         with:
@@ -62,6 +66,7 @@ jobs:
           doppler_project: react-native-template
           doppler_environment: production
           working_directory: . 
+          
       - name: Deploy iOS app to App Store
         uses: ./.github/actions/deploy_ios_production
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     branches:
-      - main  
+      - vikram/feat/add-ios-release-notes  
 
 concurrency:
   group: cd

--- a/docs/release_notes/1.0.14.md
+++ b/docs/release_notes/1.0.14.md
@@ -3,3 +3,4 @@ v1.0.14
 - Added suitable comments in ios preview deploy
 - enhanced ios cleanup preview
 - created release notes helper script
+- added testing group

--- a/docs/release_notes/1.0.14.md
+++ b/docs/release_notes/1.0.14.md
@@ -1,0 +1,3 @@
+What's new?
+v1.0.14
+- Added release notes support for IOS

--- a/docs/release_notes/1.0.14.md
+++ b/docs/release_notes/1.0.14.md
@@ -1,5 +1,5 @@
-What's new?
 v1.0.14
 - Added release notes support for IOS
 - Added suitable comments in ios preview deploy
 - enhanced ios cleanup preview
+- created release notes helper script

--- a/docs/release_notes/1.0.14.md
+++ b/docs/release_notes/1.0.14.md
@@ -1,3 +1,4 @@
 What's new?
 v1.0.14
 - Added release notes support for IOS
+- Added suitable comments

--- a/docs/release_notes/1.0.14.md
+++ b/docs/release_notes/1.0.14.md
@@ -3,4 +3,4 @@ v1.0.14
 - Added suitable comments in ios preview deploy
 - enhanced ios cleanup preview
 - created release notes helper script
-- added testing group
+- added testing group on apple store connect

--- a/docs/release_notes/1.0.14.md
+++ b/docs/release_notes/1.0.14.md
@@ -1,4 +1,5 @@
 What's new?
 v1.0.14
 - Added release notes support for IOS
-- Added suitable comments
+- Added suitable comments in ios preview deploy
+- enhanced ios cleanup preview

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -36,6 +36,7 @@ platform :ios do
       apple_id: ENV["IOS_APPLE_ID"],
       username: ENV["FASTLANE_USER"],
       team_id: ENV["IOS_APP_STORE_TEAM_ID"]
+      release_notes: ENV["RELEASE_NOTES"]
     )
   end
   # Removes any Preview builds uploaded via pr_deploy for this PR.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -35,7 +35,7 @@ platform :ios do
       keychain_password: ENV["IOS_KEYCHAIN_PASSWORD"],
       apple_id: ENV["IOS_APPLE_ID"],
       username: ENV["FASTLANE_USER"],
-      team_id: ENV["IOS_APP_STORE_TEAM_ID"]
+      team_id: ENV["IOS_APP_STORE_TEAM_ID"],
       release_notes: ENV["RELEASE_NOTES"]
     )
   end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -67,7 +67,8 @@ platform :ios do
       api_key_b64: ENV["IOS_APP_STORE_CONNECT_API_KEY_B64"],
       keychain_name: "ios.keychain",
       keychain_password: ENV["IOS_KEYCHAIN_PASSWORD"],
-      team_id: ENV["IOS_APP_STORE_TEAM_ID"]
+      team_id: ENV["IOS_APP_STORE_TEAM_ID"],
+      release_notes: ENV["RELEASE_NOTES"]
     )
   end
 end

--- a/ios/fastlane/changelog.txt
+++ b/ios/fastlane/changelog.txt
@@ -1,4 +1,1 @@
-What's New?
-This is latest release notes for test
-- Add release notes support for IOS in fastlane
-- Fixed and added Doppler Secret Injection for IOS
+This is a default changelog for IOS

--- a/ios/fastlane/scripts/ios_cleanup_preview.rb
+++ b/ios/fastlane/scripts/ios_cleanup_preview.rb
@@ -39,7 +39,7 @@ require 'fastlane_core/ui/ui'
 # =============================================================================
 
 def ios_cleanup_preview!(pr_number:, app_identifier:, api_key_id:, issuer_id:, api_key_b64:)
-  UI = FastlaneCore::UI
+  UI = FastlaneCore::UI unless defined?(UI)
   
   # ---------------------------------------------------------------------------
   # Normalize PR number to match build number format

--- a/ios/fastlane/scripts/ios_cleanup_preview.rb
+++ b/ios/fastlane/scripts/ios_cleanup_preview.rb
@@ -2,6 +2,7 @@ require 'spaceship'
 require 'base64'
 require 'fastlane'
 require 'fastlane_core/ui/ui'
+UI = FastlaneCore::UI unless defined?(UI)
 
 # =============================================================================
 # iOS Preview Build Cleanup
@@ -39,8 +40,7 @@ require 'fastlane_core/ui/ui'
 # =============================================================================
 
 def ios_cleanup_preview!(pr_number:, app_identifier:, api_key_id:, issuer_id:, api_key_b64:)
-  UI = FastlaneCore::UI unless defined?(UI)
-  
+
   # ---------------------------------------------------------------------------
   # Normalize PR number to match build number format
   # ---------------------------------------------------------------------------

--- a/ios/fastlane/scripts/ios_cleanup_preview.rb
+++ b/ios/fastlane/scripts/ios_cleanup_preview.rb
@@ -3,58 +3,202 @@ require 'base64'
 require 'fastlane'
 require 'fastlane_core/ui/ui'
 
+# =============================================================================
+# iOS Preview Build Cleanup
+# =============================================================================
+#
+# PURPOSE:
+# Cleans up old TestFlight preview builds for a specific Pull Request before
+# deploying a new build. This prevents build accumulation and keeps TestFlight
+# organized.
+#
+# BUILD NUMBER FORMAT:
+# Preview builds use format: <PR_NUMBER><YYMMDDHHMM>
+# Example: PR 42 on 2025-12-17 10:58 UTC → 422512171058
+# - First digits: PR number (e.g., "42")
+# - Last 10 digits: Timestamp in YYMMDDHHMM format
+#
+# MATCHING LOGIC:
+# This script identifies PR builds by checking if the build number STARTS with
+# the PR number. For example:
+# - PR #42 → Matches builds: 422512171058, 422512180930, etc.
+# - PR #123 → Matches builds: 1232512171058, 1232512180930, etc.
+#
+# CLEANUP ACTIONS:
+# 1. Expires the build (removes from TestFlight distribution)
+# 2. Attempts deletion if supported by the API
+#
+# LIMITATIONS:
+# - App Store Connect API doesn't support direct filtering by build number
+# - Must fetch builds and filter client-side (limited to 50 most recent)
+# - Some builds cannot be deleted, only expired
+#
+# USAGE:
+# Called automatically from ios_deploy_preview! before each new build upload
+#
+# =============================================================================
+
 def ios_cleanup_preview!(pr_number:, app_identifier:, api_key_id:, issuer_id:, api_key_b64:)
-  # Decode API key
-  decoded_key = Base64.decode64(api_key_b64)
-
-  # Authenticate using App Store Connect API
-  token = Spaceship::ConnectAPI::Token.create(
-    key_id: api_key_id,
-    issuer_id: issuer_id,
-    key: decoded_key
-  )
-  Spaceship::ConnectAPI.token = token
-
+  UI = FastlaneCore::UI
+  
+  # ---------------------------------------------------------------------------
+  # Normalize PR number to match build number format
+  # ---------------------------------------------------------------------------
+  # Remove any non-numeric characters from PR number (e.g., "#42" → "42")
+  pr_digits = pr_number.to_s.gsub(/[^0-9]/, '')
+  
+  if pr_digits.empty?
+    UI.error("❌ Invalid PR number '#{pr_number}' - contains no digits")
+    return
+  end
+  
+  UI.message("🔍 Looking for builds matching PR ##{pr_number} (starts with: #{pr_digits})")
+  
+  # ---------------------------------------------------------------------------
+  # Authenticate with App Store Connect API
+  # ---------------------------------------------------------------------------
+  begin
+    # Decode base64-encoded API key
+    decoded_key = Base64.decode64(api_key_b64)
+    
+    # Create authentication token
+    token = Spaceship::ConnectAPI::Token.create(
+      key_id: api_key_id,
+      issuer_id: issuer_id,
+      key: decoded_key
+    )
+    
+    Spaceship::ConnectAPI.token = token
+    UI.success("✅ Authenticated with App Store Connect")
+  rescue => e
+    UI.error("❌ Authentication failed: #{e.message}")
+    return
+  end
+  
+  # ---------------------------------------------------------------------------
+  # Find the app in App Store Connect
+  # ---------------------------------------------------------------------------
   app = Spaceship::ConnectAPI::App.find(app_identifier)
-  FastlaneCore::UI.user_error!("App '#{app_identifier}' not found!") unless app
-
-  # Only fetch builds that match the PR number in build version
-  # NOTE: App Store Connect API does not allow direct substring filtering on build number
-  #       so we still fetch builds for the app but keep limit low
-  builds = app.get_builds(limit: 50) # reduced limit for speed
-
-  builds.select { |b| b.version.to_s.end_with?(".#{pr_number}") }.each do |build|
-    FastlaneCore::UI.message("Found old build #{build.version} (#{build.id}) for PR ##{pr_number}")
+  UI.user_error!("❌ App '#{app_identifier}' not found in App Store Connect") unless app
+  
+  UI.success("✅ Found app: #{app.name} (#{app_identifier})")
+  
+  # ---------------------------------------------------------------------------
+  # Fetch and filter builds
+  # ---------------------------------------------------------------------------
+  # NOTE: App Store Connect API doesn't support server-side filtering by build number,
+  # so we must fetch builds and filter client-side. Limiting to 50 most recent builds
+  # for performance - older builds are unlikely to conflict anyway.
+  
+  begin
+    UI.message("📦 Fetching recent builds (limit: 50)...")
+    builds = app.get_builds(limit: 50)
+    
+    if builds.nil? || builds.empty?
+      UI.message("ℹ️ No builds found for this app")
+      return
+    end
+    
+    UI.message("📊 Found #{builds.count} total builds")
+  rescue => e
+    UI.error("❌ Failed to fetch builds: #{e.message}")
+    return
+  end
+  
+  # ---------------------------------------------------------------------------
+  # Filter builds matching this PR's build number pattern
+  # ---------------------------------------------------------------------------
+  # Build numbers for this PR start with pr_digits followed by timestamp
+  # Example: PR 42 → build numbers like 422512171058, 422512180930, etc.
+  
+  matching_builds = builds.select do |build|
+    build_number = build.version.to_s
+    
+    # Check if build number starts with PR digits
+    # This matches the format: <PR_NUMBER><YYMMDDHHMM>
+    starts_with_pr = build_number.start_with?(pr_digits)
+    
+    # Additional validation: ensure the build number has the expected length
+    # PR digits + 10 timestamp digits = total length
+    # Allow up to 18 chars (App Store limit) in case of truncation
+    expected_min_length = pr_digits.length + 10
+    valid_length = build_number.length >= expected_min_length && build_number.length <= 18
+    
+    starts_with_pr && valid_length
+  end
+  
+  if matching_builds.empty?
+    UI.message("✨ No existing builds found for PR ##{pr_number}")
+    return
+  end
+  
+  UI.message("🎯 Found #{matching_builds.count} build(s) to clean up for PR ##{pr_number}")
+  
+  # ---------------------------------------------------------------------------
+  # Clean up each matching build
+  # ---------------------------------------------------------------------------
+  matching_builds.each do |build|
+    build_version = build.version
+    build_id = build.id
+    
+    UI.message("🧹 Processing build: #{build_version} (ID: #{build_id})")
+    
     begin
-      build = Spaceship::ConnectAPI::Build.get(build_id: build.id)
-
-      unless build
-        FastlaneCore::UI.error("Build with ID #{build.id} not found.")
+      # Fetch fresh build data to ensure we have latest state
+      fresh_build = Spaceship::ConnectAPI::Build.get(build_id: build_id)
+      
+      unless fresh_build
+        UI.error("⚠️ Build #{build_id} not found (may have been deleted already)")
         next
       end
-
-      # Expire older builds
+      
+      # ---------------------------------------------------------------------------
+      # Step 1: Expire the build
+      # ---------------------------------------------------------------------------
+      # Expiring removes the build from TestFlight distribution
+      # This is the primary cleanup action and is always supported
+      
       begin
-        build.expire!
-        FastlaneCore::UI.success("Expired build #{build.id}")
+        fresh_build.expire!
+        UI.success("✅ Expired build #{build_version} (#{build_id})")
       rescue => e
-        FastlaneCore::UI.error("Failed to expire build #{build.id}: #{e.message}")
+        # Some builds may already be expired or in a state that prevents expiration
+        if e.message.include?("already expired") || e.message.include?("invalid state")
+          UI.message("ℹ️ Build #{build_id} already expired or cannot be expired")
+        else
+          UI.error("❌ Failed to expire build #{build_id}: #{e.message}")
+        end
       end
-
-      # Delete older builds if possible
-      if build.respond_to?(:delete!)
+      
+      # ---------------------------------------------------------------------------
+      # Step 2: Attempt to delete the build (if supported)
+      # ---------------------------------------------------------------------------
+      # Not all builds can be deleted via API - depends on build state and timing
+      # This is a best-effort operation
+      
+      if fresh_build.respond_to?(:delete!)
         begin
-          build.delete!
-          FastlaneCore::UI.success("Deleted build #{build.id}")
+          fresh_build.delete!
+          UI.success("🗑️ Deleted build #{build_version} (#{build_id})")
         rescue => e
-          FastlaneCore::UI.error("Failed to delete build #{build.id}: #{e.message}")
+          # Deletion may fail for various reasons (build in review, timing, etc.)
+          UI.message("ℹ️ Could not delete build #{build_id}: #{e.message}")
+          UI.message("   Build has been expired and will not appear in TestFlight")
         end
       else
-        FastlaneCore::UI.message("API does not support deleting this build — expired only.")
+        UI.message("ℹ️ Build #{build_id} can only be expired (deletion not supported)")
       end
-
+      
     rescue => e
-      FastlaneCore::UI.error("Error handling build #{build.id}: #{e.message}")
+      UI.error("❌ Error processing build #{build_id}: #{e.message}")
+      next
     end
   end
+  
+  UI.success("✅ Cleanup complete for PR ##{pr_number}")
+  
+rescue => e
+  UI.error("❌ Cleanup failed: #{e.message}")
+  UI.error(e.backtrace.join("\n")) if FastlaneCore::Globals.verbose?
+  # Don't raise - cleanup failure shouldn't block new build upload
 end

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -6,6 +6,7 @@ def ios_deploy_preview!(options = {})
   require 'base64'
   require 'json'
   require 'fastlane'
+  require_relative 'release_notes_helper'
 
   # ---------------------------------------------------------------------------
   # Required inputs
@@ -209,7 +210,11 @@ def ios_deploy_preview!(options = {})
 
   UI.message("🚀 RELEASE NOTES FOUND FROM ENVIRONMENT: #{release_notes}")
     
-  testflight_changelog = release_notes || "PR ##{pr_number} (Build #{next_build}) - Automated preview"
+  testflight_changelog = build_testflight_changelog(
+    release_notes,
+    pr_number: pr_number,
+    build_number: next_build
+  )
 
   UI.message("🚀 FINAL RELEASE NOTES: #{testflight_changelog}")
 

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -261,7 +261,6 @@ def ios_deploy_preview!(options = {})
       apple_id: apple_id,
       app_identifier: app_identifier,
       skip_waiting_for_build_processing: false,
-      distribute_external: false
     )
     UI.success("✅ TestFlight upload complete! Build: #{next_build}")
   rescue => e

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -22,6 +22,7 @@ def ios_deploy_preview!(options = {})
   apple_id          = options.fetch(:apple_id)
   username          = options.fetch(:username)
   team_id           = options.fetch(:team_id)
+  release_notes     = options.fetch(:release_notes)
 
   # ---------------------------------------------------------------------------
   # Version (from package.json)
@@ -202,6 +203,15 @@ def ios_deploy_preview!(options = {})
     rm -rf temp_payload
     echo "✅ IPA ready"
   BASH
+  # ---------------------------------------------------------------------------
+  # TestFlight changelog
+  # ---------------------------------------------------------------------------
+
+  UI.message("🚀 RELEASE NOTES FOUND FROM ENVIRONMENT: #{release_notes}")
+    
+  testflight_changelog = release_notes || "PR ##{pr_number} (Build #{next_build}) - Automated preview"
+
+  UI.message("🚀 FINAL RELEASE NOTES: #{testflight_changelog}")
 
   # ---------------------------------------------------------------------------
   # Upload to TestFlight
@@ -210,6 +220,7 @@ def ios_deploy_preview!(options = {})
     UI.message('☁️ Uploading to TestFlight...')
     upload_to_testflight(
       ipa: ipa_path,
+      changelog: testflight_changelog,
       username: username,
       apple_id: apple_id,
       app_identifier: app_identifier,

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -258,7 +258,6 @@ def ios_deploy_preview!(options = {})
       distribute_external: true,                 # send to external testers
       groups: ["External Testers", "Tester"],    # <-- project-specific, see comment
       notify_external_testers: true,             # send email/notification
-      submit_beta_review: true                   # trigger Beta App Review when needed
     )
     UI.success("✅ TestFlight upload complete! Build: #{next_build}")
   rescue => e

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -216,6 +216,10 @@ def ios_deploy_preview!(options = {})
   # ---------------------------------------------------------------------------
   # Upload to TestFlight
   # ---------------------------------------------------------------------------
+
+  # External testers see the "What to Test" section with your changelog. 
+  # Internal testers don't get this feature by design from Apple
+  # So make sure External Testing is enabled on the Apple Store Connect for the project
   begin
     UI.message('☁️ Uploading to TestFlight...')
     upload_to_testflight(
@@ -225,7 +229,9 @@ def ios_deploy_preview!(options = {})
       apple_id: apple_id,
       app_identifier: app_identifier,
       skip_waiting_for_build_processing: false,
-      distribute_external: false
+      distribute_external: true,  
+      groups: ["External Testers", "Tester"],  
+      notify_external_testers: true
     )
     UI.success("✅ TestFlight upload complete! Build: #{next_build}")
   rescue => e

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -256,7 +256,7 @@ def ios_deploy_preview!(options = {})
       # Distribution
       skip_waiting_for_build_processing: false,  # wait so changelog can be attached
       distribute_external: true,                 # send to external testers
-      groups: ["External Testers", "Tester"],    # <-- project-specific, see comment
+      groups: ["External Testers"],    # <-- project-specific, see comment
       notify_external_testers: true,             # send email/notification
     )
     UI.success("✅ TestFlight upload complete! Build: #{next_build}")

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -243,35 +243,6 @@ def ios_deploy_preview!(options = {})
   #      * Contact Information (name, phone, email)
   #      * Demo Account (if app requires login)
   #      * Notes for reviewer (optional)
-  #
-  # 4. Export Compliance:
-  #    - Add 'ITSAppUsesNonExemptEncryption' to Info.plist to skip encryption questions
-  #    - Or manually answer compliance questions in App Store Connect after upload
-  #
-  # COMMON ERRORS & SOLUTIONS:
-  # - "Beta App Description is missing": Fill in App Information section in TestFlight
-  # - "Export compliance required": Set ITSAppUsesNonExemptEncryption in Info.plist
-  # - "No external groups found": Create at least one external testing group
-  # - Changelog not visible: Ensure distribute_external is true and group name matches exactly
-  #
-  # GROUP NAMES:
-  # - Must match EXACTLY as shown in App Store Connect (case-sensitive)
-  # - Current groups: ["External Testers", "Tester"]
-  # - "External Testers" = external group (sees changelog)
-  # - "Tester" = internal group (no changelog visibility)
-  #
-  # WORKFLOW:
-  # 1. Build uploads to TestFlight
-  # 2. Apple processes build (2-5 minutes)
-  # 3. If first external build: Goes to Beta App Review (24-48 hours)
-  # 4. After approval: External testers receive notification with changelog
-  # 5. Subsequent builds: Automatically distributed (no review needed)
-  #
-  # REAL-WORLD USAGE:
-  # - Use external testing for: QA team, stakeholders, PR previews
-  # - Use internal testing for: Dev team quick tests (no changelog needed)
-  # - PR-based builds: Changelog shows PR number, timestamp, and changes
-  #
   # REFERENCES:
   # - fastlane docs: https://docs.fastlane.tools/actions/upload_to_testflight/
   # - Apple TestFlight: https://developer.apple.com/testflight/
@@ -285,9 +256,7 @@ def ios_deploy_preview!(options = {})
       apple_id: apple_id,
       app_identifier: app_identifier,
       skip_waiting_for_build_processing: false,
-      distribute_external: true,  # Enable external distribution for changelog visibility
-      groups: ["External Testers", "Tester"],  # Distribute to both groups (only External sees changelog)
-      notify_external_testers: true  # Send email notification to external testers
+      distribute_external: false
     )
     UI.success("✅ TestFlight upload complete! Build: #{next_build}")
   rescue => e

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -113,12 +113,16 @@ def ios_deploy_production!(options = {})
     "(latest App Store build for this version: #{latest_store_build || 'none'})"
   )
 
+  # increment_build_number(
+  #   xcodeproj: 'Boilerplate.xcodeproj',
+  #   build_number: final_build.to_s
+  # )
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
-    build_number: final_build.to_s
+    build_number: 1
   )
 
-    # ---------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------
   # Release notes (App Store "What's New")
   # ---------------------------------------------------------------------------
   app_store_release_notes = build_app_store_release_notes(release_notes)

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -119,7 +119,7 @@ def ios_deploy_production!(options = {})
   # )
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
-    build_number: 3
+    build_number: 4
   )
 
   # ---------------------------------------------------------------------------
@@ -225,16 +225,27 @@ def ios_deploy_production!(options = {})
   # ---------------------------------------------------------------------------
   # Upload IPA to App Store Connect
   # ---------------------------------------------------------------------------
+  # EXPECTATION (per project):
+  #   - Default language folder exists: ios/fastlane/metadata/en-US/
+  #   - This script will overwrite release_notes.txt for each release.
+  #   - All other metadata (description, URLs, screenshots) is managed manually
+  #     in App Store Connect.
   UI.message('☁️ Uploading IPA to App Store Connect...')
   upload_to_app_store(
-    app_identifier: app_identifier,
-    skip_screenshots: true,
-    skip_metadata: false,
-    metadata_path: File.join(__dir__, '..', 'metadata'),         
-    skip_app_version_update: true,
-    force: true,
+    api_key: api_key,                                   # generic: comes from CI/env
+    app_identifier: app_identifier,                    # per‑project
+    ipa: ipa_path,                                     # built above
+
+    # Use only localized metadata folder; everything else can be edited in ASC UI
+    metadata_path: File.join(__dir__, '..', 'metadata'),
+    skip_screenshots: true,                            # screenshots managed in ASC
+    skip_metadata: false,                              # so release_notes.txt is read
+    skip_app_version_update: false,                    # create/update version entry
+    submit_for_review: false,                          # let teams decide how to submit
+    force: true,                                       # no HTML preview
     precheck_include_in_app_purchases: false
   )
+
 
   UI.success("✅ Production upload complete! Version #{marketing_version} (#{final_build})")
 ensure

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -18,6 +18,7 @@ def ios_deploy_production!(options = {})
   keychain_name     = options.fetch(:keychain_name)
   keychain_password = options.fetch(:keychain_password)
   team_id           = options.fetch(:team_id)
+  release_notes     = options.fetch(:release_notes)
 
   # ---------------------------------------------------------------------------
   # Version from package.json

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -119,7 +119,7 @@ def ios_deploy_production!(options = {})
   # )
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
-    build_number: 2
+    build_number: 3
   )
 
   # ---------------------------------------------------------------------------

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -113,13 +113,9 @@ def ios_deploy_production!(options = {})
     "(latest App Store build for this version: #{latest_store_build || 'none'})"
   )
 
-  # increment_build_number(
-  #   xcodeproj: 'Boilerplate.xcodeproj',
-  #   build_number: final_build.to_s
-  # )
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
-    build_number: 4
+    build_number: final_build.to_s
   )
 
   # ---------------------------------------------------------------------------

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -119,7 +119,7 @@ def ios_deploy_production!(options = {})
   # )
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
-    build_number: 1
+    build_number: 2
   )
 
   # ---------------------------------------------------------------------------

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -3,8 +3,10 @@ UI = FastlaneCore::UI unless defined?(UI)
 
 def ios_deploy_production!(options = {})
   require 'base64'
+  require 'fileutils'
   require 'json'
   require 'fastlane'
+  require_relative 'release_notes_helper'
 
   # ---------------------------------------------------------------------------
   # Inputs
@@ -115,6 +117,22 @@ def ios_deploy_production!(options = {})
     xcodeproj: 'Boilerplate.xcodeproj',
     build_number: final_build.to_s
   )
+
+    # ---------------------------------------------------------------------------
+  # Release notes (App Store "What's New")
+  # ---------------------------------------------------------------------------
+  app_store_release_notes = build_app_store_release_notes(release_notes)
+  release_notes_path = File.join(
+    __dir__,
+    '..',
+    'metadata',
+    'en-US',
+    'release_notes.txt'
+  )
+  FileUtils.mkdir_p(File.dirname(release_notes_path))
+  File.write(release_notes_path, app_store_release_notes)
+  UI.message("📝 Wrote App Store release notes: #{release_notes_path}")
+
 
   # ---------------------------------------------------------------------------
   # Build IPA for production

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -229,7 +229,8 @@ def ios_deploy_production!(options = {})
   upload_to_app_store(
     app_identifier: app_identifier,
     skip_screenshots: true,
-    skip_metadata: true,         
+    skip_metadata: false,
+    metadata_path: File.join(__dir__, '..', 'metadata'),         
     skip_app_version_update: true,
     force: true,
     precheck_include_in_app_purchases: false

--- a/ios/fastlane/scripts/release_notes_helper.rb
+++ b/ios/fastlane/scripts/release_notes_helper.rb
@@ -1,0 +1,32 @@
+require 'fastlane_core/ui/ui'
+UI = FastlaneCore::UI unless defined?(UI)
+
+def normalize_release_notes(raw_notes)
+  notes = raw_notes.to_s.strip
+  notes.empty? ? nil : notes
+end
+
+def build_app_store_release_notes(raw_notes)
+  notes = normalize_release_notes(raw_notes)
+  return notes if notes
+
+  UI.message('⚠️ No release notes provided. Using default App Store release notes.')
+  'Bug fixes and performance improvements.'
+end
+
+def build_testflight_changelog(raw_notes, pr_number:, build_number:)
+  notes = normalize_release_notes(raw_notes)
+  return "PR ##{pr_number} (Build #{build_number}) - Automated preview" unless notes
+
+  return notes if notes.match?(/what to test/i)
+
+  <<~CHANGELOG.strip
+    What's New
+    #{notes}
+
+    What to Test
+    - Exercise core user flows (login, navigation, critical transactions)
+    - Validate the changes listed above
+    - Watch for regressions or crashes
+  CHANGELOG
+end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
This PR is to add release notes support like android, for the IOS.

Release notes wrote by developers under `docs/release_notes` will be fetched and passed along with fastlane, 
so that it can be sent to:
- Testflight (For Preview Builds)

using fastlane scripts.
