### PR TITLE
feat: add release notes support for IOS production builds.

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -121,6 +121,7 @@ Additional rules enforced by `release_notes_check` in both CD workflows:
 
 - The release note file for the current version **must exist**, cannot be empty, and must be **≤ 500 characters**. The version is read from `package.json`.
 - The validated content is emitted as a workflow output and written to `android/fastlane/metadata/android/en-US/changelogs/default.txt` for downstream Fastlane steps.
+- As well as the content of the release notes is given as an output and then set as an ENV variable, so that workflows and fastlane scripts can use them to pass along with the builds.
 - Production runs also write `{versionCode}.txt` beside the default file using the Play Console version code that is fetched and incremented during the run.
 
 ---
@@ -201,6 +202,7 @@ To provide parity with Android preview builds by shipping an iOS TestFlight buil
   - Build the IPA (App Store export) and post-process (Hermes bitcode stripping and re-signing).
   - Read release notes from:
     - `docs/release_notes/{version}.md` → injected into `ios/fastlane/changelog.txt`.
+    - as well as set as an ENV and used in fastlane ruby script using ios/fastlane/scripts/release_notes_helper script
   - Upload the IPA to **TestFlight** with:
     - “What to Test” populated from `changelog.txt`.
     - Internal-only distribution (preview groups).
@@ -258,6 +260,7 @@ To automate iOS App Store submissions with consistent versioning, build numbers,
   - Read `version` from `package.json` and set the marketing version in `Boilerplate.xcodeproj`.
   - Compute the next `build_number` by encoding the marketing version ("1.0.13" → 10013, "1.2.5" → 10205) and update the Xcode project.
   - Use `match` (readonly) and a production keychain for signing.
+  - Script reads release notes from release_notes argument and writes content in fastlane/metadata/en-US/release_notes.txt file using release notes helper script, so that it will be passed with the build.
   - Build a release IPA with App Store export options.
   - Upload the IPA to **App Store Connect** via `upload_to_app_store`, skipping screenshots and most metadata because the changelog is handled explicitly.
 

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -44,8 +44,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v3
-
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -41,8 +41,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v3
-
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     branches:
-      - vikram/feat/add-ios-production-releasenotes  
+      - main  
 
 concurrency:
   group: cd

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     branches:
-      - main  
+      - vikram/feat/add-ios-production-releasenotes  
 
 concurrency:
   group: cd

--- a/docs/release_notes/1.0.15.md
+++ b/docs/release_notes/1.0.15.md
@@ -1,2 +1,3 @@
 v1.0.15
 - Add release support for IOS production builds
+- Updated fastlane ios production script with suitable comments 

--- a/docs/release_notes/1.0.15.md
+++ b/docs/release_notes/1.0.15.md
@@ -1,3 +1,4 @@
 v1.0.15
 - Add release support for IOS production builds
-- Updated fastlane ios production script with suitable comments 
+- Updated fastlane ios production script with suitable comments-
+- Prevented the IOS production deploy action from re-checking out the repo

--- a/docs/release_notes/1.0.15.md
+++ b/docs/release_notes/1.0.15.md
@@ -1,0 +1,2 @@
+v1.0.15
+- Add release support for IOS production builds

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -131,7 +131,11 @@ def ios_deploy_production!(options = {})
   )
   FileUtils.mkdir_p(File.dirname(release_notes_path))
   File.write(release_notes_path, app_store_release_notes)
-  UI.message("📝 Wrote App Store release notes: #{release_notes_path}")
+
+  written_content = File.read(release_notes_path)
+  UI.message("📝 Wrote App Store release notes at: #{release_notes_path}")
+  UI.message("📝 Written content for release notes: #{written_content}")
+
 
 
   # ---------------------------------------------------------------------------
@@ -226,21 +230,26 @@ def ios_deploy_production!(options = {})
   #   - This script will overwrite release_notes.txt for each release.
   #   - All other metadata (description, URLs, screenshots) is managed manually
   #     in App Store Connect.
+  # Ensure the app has at least one released version; Apple ignores “What’s New” for the very first version, 
+  # and Fastlane logs Skipping 'release_notes'... this is the first version of the app.
+
   UI.message('☁️ Uploading IPA to App Store Connect...')
   upload_to_app_store(
-    api_key: api_key,                                   # generic: comes from CI/env
-    app_identifier: app_identifier,                    # per‑project
-    ipa: ipa_path,                                     # built above
-
-    # Use only localized metadata folder; everything else can be edited in ASC UI
+    api_key: api_key,
+    app_identifier: app_identifier,
+    ipa: ipa_path,
     metadata_path: File.join(__dir__, '..', 'metadata'),
-    skip_screenshots: true,                            # screenshots managed in ASC
-    skip_metadata: false,                              # so release_notes.txt is read
-    skip_app_version_update: false,                    # create/update version entry
-    submit_for_review: false,                          # let teams decide how to submit
-    force: true,                                       # no HTML preview
-    precheck_include_in_app_purchases: false
+    skip_screenshots: true,
+    skip_metadata: false,
+    skip_app_version_update: false,
+    submit_for_review: false,
+    force: true,
+    release_notes: {                         # optional override
+      'default' => app_store_release_notes,  # used for en-US if no specific key
+      'en-US'   => app_store_release_notes
+    }
   )
+
 
 
   UI.success("✅ Production upload complete! Version #{marketing_version} (#{final_build})")

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -113,9 +113,13 @@ def ios_deploy_production!(options = {})
     "(latest App Store build for this version: #{latest_store_build || 'none'})"
   )
 
+  # increment_build_number(
+  #   xcodeproj: 'Boilerplate.xcodeproj',
+  #   build_number: final_build.to_s
+  # )
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
-    build_number: final_build.to_s
+    build_number: 1
   )
 
   # ---------------------------------------------------------------------------

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -115,10 +115,18 @@ def ios_deploy_production!(options = {})
     "(latest App Store build for this version: #{latest_store_build || 'none'})"
   )
 
+  # For production, use the following increment logic, comment it out when testing any changes to this script.
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
     build_number: base_build.to_s
   )
+
+  # Uncomment this method ans use the hardcoded build numbers to test any changes to production, so it will 
+  # separate actual production build and test production builds
+  # increment_build_number(
+  #   xcodeproj: 'Boilerplate.xcodeproj',
+  #   build_number: 1
+  # )
 
   # ---------------------------------------------------------------------------
   # Release notes (App Store "What's New")

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -244,6 +244,7 @@ def ios_deploy_production!(options = {})
     skip_app_version_update: false,
     submit_for_review: false,
     force: true,
+    precheck_include_in_app_purchases: false,
     release_notes: {                         # optional override
       'default' => app_store_release_notes,  # used for en-US if no specific key
       'en-US'   => app_store_release_notes

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -100,6 +100,7 @@ def ios_deploy_production!(options = {})
       platform: 'ios',
       api_key: api_key
     )
+    
   rescue StandardError => e
     UI.important("⚠️ Could not fetch App Store build number for #{marketing_version}: #{e.message}")
     nil
@@ -108,18 +109,15 @@ def ios_deploy_production!(options = {})
   latest_int = latest_store_build.to_i
   final_build = base_build <= latest_int ? latest_int + 1 : base_build
 
+  #Currently we are using base_build, to differentiate the build numbers of production and testflight app
   UI.message(
-    "📈 Using PRODUCTION build number: #{final_build} " \
+    "📈 Using PRODUCTION build number: #{base_build} " \
     "(latest App Store build for this version: #{latest_store_build || 'none'})"
   )
 
-  # increment_build_number(
-  #   xcodeproj: 'Boilerplate.xcodeproj',
-  #   build_number: final_build.to_s
-  # )
   increment_build_number(
     xcodeproj: 'Boilerplate.xcodeproj',
-    build_number: 1
+    build_number: base_build.to_s
   )
 
   # ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Description
This PR is to add release notes / changelog support for ios production builds using fastlane.

`release_notes_check` action will check for release notes under the path `docs/release_notes/x.y.z.md`, check for the length and if it is empty. If release notes for current version are not available, then whole workflow run will fail.

Same action will extract the content of the release notes and gives as an output, which then is written to respective IOS and android changelogs folders as well as the content is set as ENV variables, so it can be used in fastlane scripts easily.

Fastlane script `ios_deploy_production` takes the content of release notes, and writes it to the release notes file of the IOS fastlane folder, which then is fetched by the fastlane and passed to apple store connect.

## Tests

- Manually run the workflows, and tested if fastlane is fetching the correct release notes and passing the release notes to apple store connect.
- Release notes are being fetched via fastlane.

<img width="1264" height="305" alt="image" src="https://github.com/user-attachments/assets/865b8548-8366-43af-adc4-76b206c3ee75" />

<img width="1264" height="307" alt="image" src="https://github.com/user-attachments/assets/e15e04c0-beed-4ecd-8d63-9e4c5c90826b" />

- Its skipping the release notes, means release notes are being fetched but apple store connect is not accepting it, as this is the first version of the app, means app should has at least one released version. Which is a project-specific constraint.
