### PR TITLE
feat: migrate auth, dashboard, and profile to react-native-paper

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-native-config": "1.5.3",
     "react-native-error-boundary": "^1.2.4",
     "react-native-gesture-handler": "2.19.0",
+    "react-native-paper": "^5.14.5",
     "react-native-reanimated": "3.16.7",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "^3.34.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,7 +13,7 @@ import './translations';
 import DatadogConfig, { onDataDogSDKInitialized } from './services/datadog';
 import { PaperProvider } from 'react-native-paper';
 import { theme } from './theme';
-import { Icon,Text } from 'react-native-paper';
+
 const App = () => {
   Logger.initializeLoggers();
   const ErrorComponent = useCallback(() => <ErrorFallback />, []);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,6 @@ import { NativeBaseProvider } from 'native-base';
 import React, { useCallback } from 'react';
 import ErrorBoundary from 'react-native-error-boundary';
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
-
 import appTheme from './app-theme';
 import { ErrorFallback } from './components';
 import { AccountContextProvider, AuthContextProvider, TaskContextProvider } from './contexts';
@@ -12,13 +11,16 @@ import Logger from './logger/logger';
 import ApplicationNavigator from './navigators/application';
 import './translations';
 import DatadogConfig, { onDataDogSDKInitialized } from './services/datadog';
-
+import { PaperProvider } from 'react-native-paper';
+import { theme } from './theme';
+import { Icon,Text } from 'react-native-paper';
 const App = () => {
   Logger.initializeLoggers();
   const ErrorComponent = useCallback(() => <ErrorFallback />, []);
 
   return (
-    <NativeBaseProvider theme={appTheme}>
+    <PaperProvider theme={theme} >
+      <NativeBaseProvider theme={appTheme}>
       <ErrorBoundary
         onError={(e, stack) => Logger.error(`App Error: ${e} ${stack}`)}
         FallbackComponent={ErrorComponent}
@@ -36,6 +38,7 @@ const App = () => {
         </DatadogProvider>
       </ErrorBoundary>
     </NativeBaseProvider>
+    </PaperProvider>
   );
 };
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,7 +3,9 @@ import { DatadogProvider } from '@datadog/mobile-react-native';
 import { NativeBaseProvider } from 'native-base';
 import React, { useCallback } from 'react';
 import ErrorBoundary from 'react-native-error-boundary';
+import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
+
 import appTheme from './app-theme';
 import { ErrorFallback } from './components';
 import { AccountContextProvider, AuthContextProvider, TaskContextProvider } from './contexts';
@@ -11,7 +13,6 @@ import Logger from './logger/logger';
 import ApplicationNavigator from './navigators/application';
 import './translations';
 import DatadogConfig, { onDataDogSDKInitialized } from './services/datadog';
-import { PaperProvider } from 'react-native-paper';
 import { theme } from './theme';
 
 const App = () => {

--- a/src/screens/auth/auth-layout.tsx
+++ b/src/screens/auth/auth-layout.tsx
@@ -1,6 +1,6 @@
-import { useTheme } from 'native-base';
+import { useTheme,Text } from 'react-native-paper';
 import React, { PropsWithChildren } from 'react';
-import { Keyboard, Platform, TouchableWithoutFeedback, View, Text, ScrollView, KeyboardAvoidingView, StyleSheet, StatusBar } from 'react-native';
+import { Keyboard, Platform, TouchableWithoutFeedback, View, ScrollView, KeyboardAvoidingView, StyleSheet, StatusBar } from 'react-native';
 
 import ChangeApiUrlButton from './change-api-url/change-api-url';
 
@@ -15,7 +15,7 @@ const useAuthLayoutStyles = () => {
   return StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: theme.colors.primary['500'],
+      backgroundColor: theme.colors.primary,
     },
     flex: {
       flex: 1,
@@ -24,9 +24,12 @@ const useAuthLayoutStyles = () => {
       flexGrow: 1,
     },
     header: {
-      backgroundColor: theme.colors.primary['500'],
-      paddingTop: Platform.OS === 'android' ? (StatusBar.currentHeight || 24) + Number(theme.space['4']) : Number(theme.space['10']) + Number(theme.space['4']),
-      paddingBottom: Number(theme.space['4']),
+      backgroundColor: theme.colors.primary,
+      paddingTop:
+        Platform.OS === 'android'
+          ? (StatusBar.currentHeight || 24) + 16
+          : 44,
+      paddingBottom: 16,
       paddingHorizontal: '5%',
     },
     titleRow: {
@@ -39,24 +42,25 @@ const useAuthLayoutStyles = () => {
       paddingHorizontal: '5%',
     },
     title: {
-      fontSize: Number(theme.fontSizes['4xl']),
-      fontWeight: 'bold',
-      color: theme.colors.secondary['50'],
+      fontSize: 32,
+      fontWeight: '700',
+      color: theme.colors.surfaceVariant,
     },
     cardContainer: {
       flex: 1,
-      backgroundColor: theme.colors.white,
-      borderTopLeftRadius: Number(theme.radii['2xl']),
-      borderTopRightRadius: Number(theme.radii['2xl']),
+      backgroundColor: theme.colors.background,
+      borderTopLeftRadius: 24,
+      borderTopRightRadius: 24,
     },
     cardContent: {
       flex: 1,
-      paddingTop: Number(theme.space['6']),
-      paddingBottom: Number(theme.space['8']),
+      paddingTop: 24,
+      paddingBottom: 32,
       paddingHorizontal: '10%',
     },
   });
 };
+
 
 const AuthLayout: React.FC<PropsWithChildren<AuthLayoutProps>> = ({
   primaryTitle,
@@ -73,7 +77,7 @@ const AuthLayout: React.FC<PropsWithChildren<AuthLayoutProps>> = ({
             <View style={styles.header}>
               <View style={styles.titleRow}>
                 <View style={styles.titleContainer}>
-                  <Text style={styles.title}>{primaryTitle}</Text>
+                  <Text style={styles.title} >{primaryTitle}</Text>
                   <Text style={styles.title}>{secondaryTitle}</Text>
                 </View>
                 <ChangeApiUrlButton />

--- a/src/screens/auth/auth-layout.tsx
+++ b/src/screens/auth/auth-layout.tsx
@@ -1,6 +1,6 @@
-import { useTheme,Text } from 'react-native-paper';
 import React, { PropsWithChildren } from 'react';
 import { Keyboard, Platform, TouchableWithoutFeedback, View, ScrollView, KeyboardAvoidingView, StyleSheet, StatusBar } from 'react-native';
+import { useTheme,Text } from 'react-native-paper';
 
 import ChangeApiUrlButton from './change-api-url/change-api-url';
 

--- a/src/screens/auth/auth-layout.tsx
+++ b/src/screens/auth/auth-layout.tsx
@@ -48,7 +48,7 @@ const useAuthLayoutStyles = () => {
     },
     cardContainer: {
       flex: 1,
-      backgroundColor: theme.colors.background,
+      backgroundColor: theme.colors.surface,
       borderTopLeftRadius: 24,
       borderTopRightRadius: 24,
     },

--- a/src/screens/auth/change-api-url/change-api-url-modal.tsx
+++ b/src/screens/auth/change-api-url/change-api-url-modal.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import Config from 'react-native-config';
 import { Dialog, Portal, Text, useTheme, IconButton, TextInput, Button, Snackbar } from 'react-native-paper';
+import Close from 'react-native-template/assets/icons/close.svg';
 import { ModalProps } from 'react-native-template/src/components/modal/modal';
 import { useLocalStorage } from 'react-native-template/src/utils';
-import Close from 'react-native-template/assets/icons/close.svg';
+
 import { ChangeApiUrlStyles } from './change-api-url.style';
 const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose }) => {
   const localStorage = useLocalStorage();
-  const theme = useTheme()
-  const styles = ChangeApiUrlStyles()
+  const theme = useTheme();
+  const styles = ChangeApiUrlStyles();
 
   const [apiBaseUrl, setApiBaseUrl] = useState(Config.API_BASE_URL as string);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
@@ -58,7 +59,7 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
           <TextInput
             value={apiBaseUrl}
             onChangeText={text => {
-              setApiBaseUrl(text)
+              setApiBaseUrl(text);
             }}
             mode="outlined"
             autoCapitalize="none"
@@ -69,7 +70,7 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
         </Dialog.Content>
         <Dialog.Actions style={styles.ButtonSection}>
           <Button
-            mode='outlined'
+            mode="outlined"
             style={styles.button}
             onPress={handleModalClose}
             theme={{
@@ -80,7 +81,7 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
             Cancel
           </Button>
           <Button
-            mode='contained'
+            mode="contained"
             style={styles.button}
             onPress={handleSaveChanges}>
             Save Changes

--- a/src/screens/auth/change-api-url/change-api-url-modal.tsx
+++ b/src/screens/auth/change-api-url/change-api-url-modal.tsx
@@ -1,7 +1,6 @@
-import { Toast } from 'native-base';
 import React, { useEffect, useState } from 'react';
 import Config from 'react-native-config';
-import { Dialog, Portal, Text, useTheme, IconButton, TextInput, HelperText, Button, Snackbar } from 'react-native-paper';
+import { Dialog, Portal, Text, useTheme, IconButton, TextInput, Button, Snackbar } from 'react-native-paper';
 import { ModalProps } from 'react-native-template/src/components/modal/modal';
 import { useLocalStorage } from 'react-native-template/src/utils';
 import Close from 'react-native-template/assets/icons/close.svg';
@@ -10,7 +9,6 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
   const localStorage = useLocalStorage();
   const theme = useTheme()
   const styles = ChangeApiUrlStyles()
-  const [error, setError] = useState('');
 
   const [apiBaseUrl, setApiBaseUrl] = useState(Config.API_BASE_URL as string);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
@@ -61,17 +59,13 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
             value={apiBaseUrl}
             onChangeText={text => {
               setApiBaseUrl(text)
-              if (error) setError('');
             }}
             mode="outlined"
             autoCapitalize="none"
             autoCorrect={false}
             style={{ backgroundColor: theme.colors.surface }}
-            error={!!error}
           />
-          <HelperText type="error" visible={!!error}>
-            {error}
-          </HelperText>
+
         </Dialog.Content>
         <Dialog.Actions style={styles.ButtonSection}>
           <Button

--- a/src/screens/auth/change-api-url/change-api-url-modal.tsx
+++ b/src/screens/auth/change-api-url/change-api-url-modal.tsx
@@ -1,14 +1,20 @@
 import { Toast } from 'native-base';
 import React, { useEffect, useState } from 'react';
 import Config from 'react-native-config';
-import { FormControl, Input, Modal } from 'react-native-template/src/components';
+import { Dialog, Portal, Text, useTheme, IconButton, TextInput, HelperText, Button, Snackbar } from 'react-native-paper';
 import { ModalProps } from 'react-native-template/src/components/modal/modal';
 import { useLocalStorage } from 'react-native-template/src/utils';
-
+import Close from 'react-native-template/assets/icons/close.svg';
+import { ChangeApiUrlStyles } from './change-api-url.style';
 const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose }) => {
   const localStorage = useLocalStorage();
+  const theme = useTheme()
+  const styles = ChangeApiUrlStyles()
+  const [error, setError] = useState('');
 
   const [apiBaseUrl, setApiBaseUrl] = useState(Config.API_BASE_URL as string);
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+
 
   useEffect(() => {
     const loadApiBaseUrl = async () => {
@@ -22,9 +28,7 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
 
   const handleSaveChanges = async () => {
     if (!apiBaseUrl) {
-      Toast.show({
-        title: 'API Base URL can not be empty',
-      });
+      setSnackbarVisible(true);
       return;
     }
 
@@ -36,24 +40,68 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
   };
 
   return (
-    <Modal isModalOpen={isModalOpen} handleModalClose={handleModalClose}>
-      <Modal.Header title="Change Base API URL" onClose={handleModalClose} />
-      <Modal.Body>
-        <FormControl label="New Base API URL">
-          <Input
+    <Portal>
+      <Dialog visible={isModalOpen} onDismiss={handleModalClose} style={styles.dialog}>
+        <Dialog.Title style={{ marginBottom: 38 }}>
+          <Text variant="titleMedium"
+            style={styles.heading}  >
+            Change Base API URL
+          </Text>
+        </Dialog.Title>
+        <IconButton
+          icon={() => (
+            <Close width={26} height={26} fill={theme.colors.primary} />
+          )}
+          onPress={handleModalClose}
+          style={styles.close}
+        />
+        <Dialog.Content>
+          <Text style={styles.text}>New Base API URL</Text>
+          <TextInput
             value={apiBaseUrl}
-            onChangeText={e => {
-              setApiBaseUrl(e);
+            onChangeText={text => {
+              setApiBaseUrl(text)
+              if (error) setError('');
             }}
+            mode="outlined"
+            autoCapitalize="none"
+            autoCorrect={false}
+            style={{ backgroundColor: theme.colors.surface }}
+            error={!!error}
           />
-        </FormControl>
-      </Modal.Body>
-      <Modal.Footer
-        onCancel={handleModalClose}
-        onConfirm={handleSaveChanges}
-        confirmText="Save Changes"
-      />
-    </Modal>
+          <HelperText type="error" visible={!!error}>
+            {error}
+          </HelperText>
+        </Dialog.Content>
+        <Dialog.Actions style={styles.ButtonSection}>
+          <Button
+            mode='outlined'
+            style={styles.button}
+            onPress={handleModalClose}
+            theme={{
+              colors: {
+                outline: theme.colors.primary,
+              },
+            }}>
+            Cancel
+          </Button>
+          <Button
+            mode='contained'
+            style={styles.button}
+            onPress={handleSaveChanges}>
+            Save Changes
+          </Button>
+        </Dialog.Actions>
+
+      </Dialog>
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+      >
+        API Base URL cannot be empty
+      </Snackbar>
+
+    </Portal>
   );
 };
 

--- a/src/screens/auth/change-api-url/change-api-url.style.ts
+++ b/src/screens/auth/change-api-url/change-api-url.style.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from "react-native";
-import { useTheme } from "react-native-paper";
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
 export const ChangeApiUrlStyles = () => {
-    const theme = useTheme()
+    const theme = useTheme();
     return StyleSheet.create({
         close: {
             position: 'absolute',
@@ -16,22 +16,22 @@ export const ChangeApiUrlStyles = () => {
         },
         button: {
             borderRadius: 6,
-            paddingHorizontal:12
+            paddingHorizontal:12,
 
         },
         text:{
             color:theme.colors.primary,
             marginBottom:10,
-            fontWeight:'600'
+            fontWeight:'600',
         },
         heading:{
             color:theme.colors.primary,
             textAlign:'center',
-            marginBottom:43
+            marginBottom:43,
         },
         ButtonSection:{
             justifyContent:'center',
-            gap:24
-        }
-    })
-}
+            gap:24,
+        },
+    });
+};

--- a/src/screens/auth/change-api-url/change-api-url.style.ts
+++ b/src/screens/auth/change-api-url/change-api-url.style.ts
@@ -1,4 +1,3 @@
-import { Button } from "native-base";
 import { StyleSheet } from "react-native";
 import { useTheme } from "react-native-paper";
 export const ChangeApiUrlStyles = () => {
@@ -23,7 +22,7 @@ export const ChangeApiUrlStyles = () => {
         text:{
             color:theme.colors.primary,
             marginBottom:10,
-            fontWeight:600
+            fontWeight:'600'
         },
         heading:{
             color:theme.colors.primary,

--- a/src/screens/auth/change-api-url/change-api-url.style.ts
+++ b/src/screens/auth/change-api-url/change-api-url.style.ts
@@ -1,0 +1,38 @@
+import { Button } from "native-base";
+import { StyleSheet } from "react-native";
+import { useTheme } from "react-native-paper";
+export const ChangeApiUrlStyles = () => {
+    const theme = useTheme()
+    return StyleSheet.create({
+        close: {
+            position: 'absolute',
+            top: 8,
+            right: 8,
+            zIndex: 10,
+        },
+
+        dialog: {
+            borderRadius: 8,
+            backgroundColor: theme.colors.surface,
+        },
+        button: {
+            borderRadius: 6,
+            paddingHorizontal:12
+
+        },
+        text:{
+            color:theme.colors.primary,
+            marginBottom:10,
+            fontWeight:600
+        },
+        heading:{
+            color:theme.colors.primary,
+            textAlign:'center',
+            marginBottom:43
+        },
+        ButtonSection:{
+            justifyContent:'center',
+            gap:24
+        }
+    })
+}

--- a/src/screens/auth/change-api-url/change-api-url.tsx
+++ b/src/screens/auth/change-api-url/change-api-url.tsx
@@ -1,11 +1,8 @@
-import { useTheme } from 'native-base';
+import { useTheme, IconButton } from 'react-native-paper';
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Config from 'react-native-config';
 import GearIcon from 'react-native-template/assets/icons/gear.svg';
-import { Button } from 'react-native-template/src/components';
-import { ButtonKind } from 'react-native-template/src/types/button';
-
 import ChangeApiUrlModal from './change-api-url-modal';
 
 const useChangeApiUrlStyles = () => {
@@ -13,7 +10,7 @@ const useChangeApiUrlStyles = () => {
 
   return StyleSheet.create({
     buttonContainer: {
-      paddingTop: Number(theme.space['2']),
+      paddingTop: Number(2),
     },
   });
 };
@@ -34,9 +31,17 @@ const ChangeApiUrlButton = () => {
     isNonProdEnv && (
       <>
         <View style={styles.buttonContainer}>
-          <Button onClick={() => setIsChangeAPIUrlModalOpen(true)} kind={ButtonKind.LINK}>
-            <GearIcon width={24} height={24} fill={theme.colors.secondary[100]} />
-          </Button>
+          <IconButton
+            icon={() => (
+              <GearIcon
+                width={24}
+                height={24}
+                fill={theme.colors.secondaryContainer}
+              />
+            )}
+            size={24}
+            onPress={() => setIsChangeAPIUrlModalOpen(true)}
+          />
         </View>
         <ChangeApiUrlModal
           handleModalClose={() => setIsChangeAPIUrlModalOpen(false)}

--- a/src/screens/auth/change-api-url/change-api-url.tsx
+++ b/src/screens/auth/change-api-url/change-api-url.tsx
@@ -1,12 +1,12 @@
-import { useTheme, IconButton } from 'react-native-paper';
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Config from 'react-native-config';
+import { useTheme, IconButton } from 'react-native-paper';
 import GearIcon from 'react-native-template/assets/icons/gear.svg';
+
 import ChangeApiUrlModal from './change-api-url-modal';
 
 const useChangeApiUrlStyles = () => {
-  const theme = useTheme();
 
   return StyleSheet.create({
     buttonContainer: {

--- a/src/screens/auth/otp-verify/index.tsx
+++ b/src/screens/auth/otp-verify/index.tsx
@@ -1,12 +1,11 @@
-import { Toast } from 'native-base';
 import React from 'react';
 import { Alert } from 'react-native';
-
+import { Snackbar } from 'react-native-paper';
 import { MainScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';
 import useTimer from '../../../utils/use-timer.hook';
 import AuthLayout from '../auth-layout';
-
+import { useState } from 'react';
 import OTPForm from './otp-form';
 
 const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
@@ -16,6 +15,7 @@ const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
   const { startTimer, remainingSecondsStr, isResendEnabled } = useTimer({
     delayInMilliseconds: sendOTPDelayInMilliseconds,
   });
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
 
   const onError = (error: AsyncError) => {
     Alert.alert('Error', error.message);
@@ -26,9 +26,6 @@ const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
   };
 
   const onVerifyOTPSuccess = () => {
-    Toast.show({
-      title: 'OTP verified successfully',
-    });
   };
 
   return (
@@ -42,6 +39,17 @@ const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
         phoneNumber={phoneNumber}
         remainingSecondsStr={remainingSecondsStr}
       />
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+        duration={3000}
+        action={{
+          label: 'OK',
+          onPress: () => setSnackbarVisible(false),
+        }}
+      >
+        OTP verified successfully
+      </Snackbar>
     </AuthLayout>
   );
 };

--- a/src/screens/auth/otp-verify/index.tsx
+++ b/src/screens/auth/otp-verify/index.tsx
@@ -26,6 +26,7 @@ const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
   };
 
   const onVerifyOTPSuccess = () => {
+    setSnackbarVisible(true);
   };
 
   return (

--- a/src/screens/auth/otp-verify/index.tsx
+++ b/src/screens/auth/otp-verify/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { useState } from 'react';
 import { Alert } from 'react-native';
 import { Snackbar } from 'react-native-paper';
+
 import { MainScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';
 import useTimer from '../../../utils/use-timer.hook';
 import AuthLayout from '../auth-layout';
-import { useState } from 'react';
+
 import OTPForm from './otp-form';
 
 const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {

--- a/src/screens/auth/otp-verify/otp-form.styles.ts
+++ b/src/screens/auth/otp-verify/otp-form.styles.ts
@@ -1,17 +1,17 @@
-import { StyleSheet } from "react-native";
-import { useTheme } from 'react-native-paper'
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
 export const useOtpFormStyles = () => {
-    const theme = useTheme()
+    const theme = useTheme();
     return StyleSheet.create({
         containerOtp: {
             flexDirection: 'row',
             gap:12,
-            marginBottom:22
+            marginBottom:22,
         },
         input: {
             width: 68,
             textAlign: 'center',
-            backgroundColor:theme.colors.surface
+            backgroundColor:theme.colors.surface,
         },
         container: {
             flex: 1,
@@ -20,13 +20,13 @@ export const useOtpFormStyles = () => {
         label: {
             color:theme.colors.primary,
             marginTop:34,
-            marginBottom:12
+            marginBottom:12,
         },
         resendRow: {
             flexDirection: 'row',
             alignItems: 'center',
             flexWrap: 'wrap',
-            
+
         },
         resend: {
             color:theme.colors.primary,
@@ -35,7 +35,7 @@ export const useOtpFormStyles = () => {
             opacity: 0.5,
         },
          Button: {
-            borderRadius: 8
+            borderRadius: 8,
         },
-    })
-}
+    });
+};

--- a/src/screens/auth/otp-verify/otp-form.styles.ts
+++ b/src/screens/auth/otp-verify/otp-form.styles.ts
@@ -1,0 +1,40 @@
+import { StyleSheet } from "react-native";
+import { useTheme } from 'react-native-paper'
+export const useOtpFormStyles = () => {
+    const theme = useTheme()
+    return StyleSheet.create({
+        containerOtp: {
+            flexDirection: 'row',
+            gap:12,
+            marginBottom:22
+        },
+        input: {
+            width: 68,
+            textAlign: 'center',
+        },
+        container: {
+            flex: 1,
+            justifyContent: 'space-between',
+        },
+        label: {
+            color:theme.colors.primary,
+            marginTop:34,
+            marginBottom:12
+        },
+        resendRow: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            
+        },
+        resend: {
+            color:theme.colors.primary,
+        },
+        resendDisabled: {
+            opacity: 0.5,
+        },
+         Button: {
+            borderRadius: 8
+        },
+    })
+}

--- a/src/screens/auth/otp-verify/otp-form.styles.ts
+++ b/src/screens/auth/otp-verify/otp-form.styles.ts
@@ -11,6 +11,7 @@ export const useOtpFormStyles = () => {
         input: {
             width: 68,
             textAlign: 'center',
+            backgroundColor:theme.colors.surface
         },
         container: {
             flex: 1,

--- a/src/screens/auth/otp-verify/otp-form.tsx
+++ b/src/screens/auth/otp-verify/otp-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import { Text, Button } from 'react-native-paper';
 
 import { AuthOptions } from '../../../constants';

--- a/src/screens/auth/otp-verify/otp-form.tsx
+++ b/src/screens/auth/otp-verify/otp-form.tsx
@@ -1,12 +1,12 @@
-import { Box, Center, Container, Heading, HStack, Link, Text, VStack } from 'native-base';
 import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text, Button } from 'react-native-paper';
 
-import { Button, FormControl, OTPInput } from '../../../components';
 import { AuthOptions } from '../../../constants';
 import { AsyncError } from '../../../types';
-
 import useOTPForm from './otp-form-hook';
-
+import PaperOTPInput from './otp-input';
+import { useOtpFormStyles } from './otp-form.styles';
 interface OTPFormProps {
   countryCode: string;
   isResendEnabled: boolean;
@@ -33,51 +33,51 @@ const OTPForm: React.FC<OTPFormProps> = ({
     countryCode,
     phoneNumber,
   });
-
-  const handleSetOtp = (otp: string[]) => {
-    formik.setFieldValue('otp', otp);
-  };
+  const styles= useOtpFormStyles()
 
   return (
-    <Box flex={1} pb={4}>
-      <VStack space={6} flex={1} mb={8}>
-        <Container>
-          <Heading size="lg">Verify OTP</Heading>
-        </Container>
-        <Box mt={3}>
-          <FormControl label="Enter your otp sent to your mobile number">
-            <Center>
-              <OTPInput
-                length={AuthOptions.OTPLength}
-                otp={formik.values.otp}
-                setOtp={handleSetOtp}
-              />
-            </Center>
-          </FormControl>
+    <View style={styles.container}>
+      <View >
+        <Text variant="titleLarge">Verify OTP</Text>
 
-          <HStack flexWrap="wrap" alignItems="baseline" mt={2}>
-            <Text fontSize="xs">Didn't receive the OTP? </Text>
-            <Link
-              onPress={handleResendOTP}
-              _text={{
-                fontSize: 'xs',
-                color: isResendEnabled ? 'primary.500' : 'coolGray.600',
-              }}
-            >
-              {isResendEnabled ? 'Resend OTP' : `Resend OTP in 00:${remainingSecondsStr}`}
-            </Link>
-          </HStack>
-        </Box>
-      </VStack>
+        <Text variant="bodySmall" style={styles.label}>
+          Enter the OTP sent to your mobile number
+        </Text>
+
+        <PaperOTPInput
+          length={AuthOptions.OTPLength}
+          value={formik.values.otp}
+          onChange={(otp) => formik.setFieldValue('otp', otp)}
+        />
+
+        <View style={styles.resendRow}>
+          <Text variant="bodySmall">Didn't receive the OTP? </Text>
+          <Text
+            variant="bodySmall"
+            style={[
+              styles.resend,
+              !isResendEnabled && styles.resendDisabled,
+              
+            ]}
+            onPress={isResendEnabled ? handleResendOTP : undefined}
+          >
+            {isResendEnabled
+              ? 'Resend OTP'
+              : `Resend OTP in 00:${remainingSecondsStr}`}
+          </Text>
+        </View>
+      </View>
 
       <Button
-        isLoading={isVerifyOTPLoading}
-        onClick={() => formik.handleSubmit()}
+        mode="contained"
+        loading={isVerifyOTPLoading}
+        onPress={() => formik.handleSubmit()}
         disabled={!(formik.isValid && formik.dirty)}
+        style={styles.Button}
       >
         Verify OTP
       </Button>
-    </Box>
+    </View>
   );
 };
 

--- a/src/screens/auth/otp-verify/otp-form.tsx
+++ b/src/screens/auth/otp-verify/otp-form.tsx
@@ -4,9 +4,10 @@ import { Text, Button } from 'react-native-paper';
 
 import { AuthOptions } from '../../../constants';
 import { AsyncError } from '../../../types';
+
 import useOTPForm from './otp-form-hook';
-import PaperOTPInput from './otp-input';
 import { useOtpFormStyles } from './otp-form.styles';
+import PaperOTPInput from './otp-input';
 interface OTPFormProps {
   countryCode: string;
   isResendEnabled: boolean;
@@ -33,7 +34,7 @@ const OTPForm: React.FC<OTPFormProps> = ({
     countryCode,
     phoneNumber,
   });
-  const styles= useOtpFormStyles()
+  const styles = useOtpFormStyles();
 
   return (
     <View style={styles.container}>
@@ -57,7 +58,7 @@ const OTPForm: React.FC<OTPFormProps> = ({
             style={[
               styles.resend,
               !isResendEnabled && styles.resendDisabled,
-              
+
             ]}
             onPress={isResendEnabled ? handleResendOTP : undefined}
           >

--- a/src/screens/auth/otp-verify/otp-input.tsx
+++ b/src/screens/auth/otp-verify/otp-input.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { View, NativeSyntheticEvent, TextInputKeyPressEventData } from 'react-native';
 import { TextInput } from 'react-native-paper';
+
 import { useOtpFormStyles } from './otp-form.styles';
 interface PaperOTPInputProps {
     length: number;
@@ -34,7 +35,7 @@ const PaperOTPInput: React.FC<PaperOTPInputProps> = ({
             inputs.current[index - 1]?.focus();
         }
     };
-    const styles = useOtpFormStyles()
+    const styles = useOtpFormStyles();
 
     return (
     <View style={styles.containerOtp}>

--- a/src/screens/auth/otp-verify/otp-input.tsx
+++ b/src/screens/auth/otp-verify/otp-input.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { View, StyleSheet, NativeSyntheticEvent, TextInputKeyPressEventData } from 'react-native';
+import { View, NativeSyntheticEvent, TextInputKeyPressEventData } from 'react-native';
 import { TextInput } from 'react-native-paper';
 import { useOtpFormStyles } from './otp-form.styles';
 interface PaperOTPInputProps {

--- a/src/screens/auth/otp-verify/otp-input.tsx
+++ b/src/screens/auth/otp-verify/otp-input.tsx
@@ -1,0 +1,61 @@
+import React, { useRef } from 'react';
+import { View, StyleSheet, NativeSyntheticEvent, TextInputKeyPressEventData } from 'react-native';
+import { TextInput } from 'react-native-paper';
+import { useOtpFormStyles } from './otp-form.styles';
+interface PaperOTPInputProps {
+    length: number;
+    value: string[];
+    onChange: (otp: string[]) => void;
+}
+
+const PaperOTPInput: React.FC<PaperOTPInputProps> = ({
+    length,
+    value,
+    onChange,
+}) => {
+    const inputs = useRef<Array<React.ElementRef<typeof TextInput> | null>>([]);
+
+    const handleChange = (text: string, index: number) => {
+        const digit = text.replace(/[^0-9]/g, '').slice(-1);
+        const newOtp = [...value];
+        newOtp[index] = digit;
+        onChange(newOtp);
+
+        if (digit && index < length - 1) {
+            inputs.current[index + 1]?.focus();
+        }
+    };
+
+    const handleKeyPress = (
+        e: NativeSyntheticEvent<TextInputKeyPressEventData>,
+        index: number
+    ) => {
+        if (e.nativeEvent.key === 'Backspace' && !value[index] && index > 0) {
+            inputs.current[index - 1]?.focus();
+        }
+    };
+    const styles = useOtpFormStyles()
+
+    return (
+    <View style={styles.containerOtp}>
+      {Array.from({ length }).map((_, index) => (
+        <TextInput
+          key={index}
+          ref={(el: React.ElementRef<typeof TextInput> | null) => {
+            inputs.current[index] = el;
+          }}
+          mode="outlined"
+          keyboardType="number-pad"
+          maxLength={1}
+          value={value[index] || ''}
+          onChangeText={(text) => handleChange(text, index)}
+          onKeyPress={(e) => handleKeyPress(e, index)}
+          style={styles.input}
+          autoFocus={index === 0}
+        />
+      ))}
+    </View>
+    );
+};
+
+export default PaperOTPInput;

--- a/src/screens/auth/phone-auth/index.tsx
+++ b/src/screens/auth/phone-auth/index.tsx
@@ -3,6 +3,7 @@ import { Snackbar } from 'react-native-paper';
 
 import { AsyncError } from '../../../types';
 import AuthLayout from '../auth-layout';
+
 import PhoneAuthForm from './phone-auth-form';
 
 const PhoneAuth: React.FC = () => {

--- a/src/screens/auth/phone-auth/index.tsx
+++ b/src/screens/auth/phone-auth/index.tsx
@@ -1,28 +1,37 @@
-import { Toast } from 'native-base';
-import React from 'react';
+import React, { useState } from 'react';
+import { Snackbar } from 'react-native-paper';
 
 import { AsyncError } from '../../../types';
 import AuthLayout from '../auth-layout';
-
 import PhoneAuthForm from './phone-auth-form';
 
 const PhoneAuth: React.FC = () => {
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
   const onSuccess = () => {
-    Toast.show({
-      title: 'OTP sent successfully',
-    });
+    setSnackbarMessage('OTP sent successfully');
+    setSnackbarVisible(true);
   };
 
   const onError = (err: AsyncError) => {
-    Toast.show({
-      title: err.message,
-    });
+    setSnackbarMessage(err.message);
+    setSnackbarVisible(true);
   };
 
   return (
-    <AuthLayout primaryTitle="Better." secondaryTitle="">
-      <PhoneAuthForm onSuccess={onSuccess} onError={onError} />
-    </AuthLayout>
+    <>
+      <AuthLayout primaryTitle="Better." secondaryTitle="">
+        <PhoneAuthForm onSuccess={onSuccess} onError={onError} />
+      </AuthLayout>
+
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+      >
+        {snackbarMessage}
+      </Snackbar>
+    </>
   );
 };
 

--- a/src/screens/auth/phone-auth/phone-auth-form.styles.ts
+++ b/src/screens/auth/phone-auth/phone-auth-form.styles.ts
@@ -13,7 +13,7 @@ export const usePhoneAuthFormStyles = () => {
     Login: {
       flex: 1,
       marginBottom: 24,
-      gap:6
+      gap:6,
     },
 
     loginSpacing: {
@@ -33,7 +33,7 @@ export const usePhoneAuthFormStyles = () => {
     inputBox: {
       borderRadius: 8,
       flex:3,
-      justifyContent:'center'
+      justifyContent:'center',
     },
 
     errorStyle: {
@@ -58,7 +58,7 @@ export const usePhoneAuthFormStyles = () => {
       marginTop:8,
     },
     text:{
-      color:theme.colors.primary
+      color:theme.colors.primary,
     },
     checkBox:{
       flexDirection:'row',
@@ -70,6 +70,6 @@ export const usePhoneAuthFormStyles = () => {
         justifyContent: 'center',
         borderRadius: 4,
         minHeight: 56,
-    }
+    },
   });
 };

--- a/src/screens/auth/phone-auth/phone-auth-form.styles.ts
+++ b/src/screens/auth/phone-auth/phone-auth-form.styles.ts
@@ -1,20 +1,75 @@
-import { useTheme } from 'native-base';
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
 
 export const usePhoneAuthFormStyles = () => {
-  const { colors, radii } = useTheme();
+  const theme = useTheme();
 
-  return {
-    inputBox: {
-      borderRadius: radii.md,
+  return StyleSheet.create({
+    phoneAuthScreen: {
+      flex: 1,
+      paddingBottom: 16,
     },
+
+    Login: {
+      flex: 1,
+      marginBottom: 24,
+      gap:6
+    },
+
+    loginSpacing: {
+      marginBottom: 32,
+    },
+
+    Checkbox: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      marginTop: 16,
+    },
+
+    checkboxTextSpacing: {
+      marginLeft: 12,
+    },
+
+    inputBox: {
+      borderRadius: 8,
+      flex:3,
+      justifyContent:'center'
+    },
+
     errorStyle: {
-      borderColor: colors.danger[600],
+      borderColor: theme.colors.error,
       borderWidth: 1,
     },
+
     errorText: {
-      color: colors.danger[600],
+      color: theme.colors.error,
       fontSize: 14,
       marginTop: 4,
     },
-  };
+
+    Button: {
+      borderRadius: 8,
+    },
+
+    row: {
+      gap:9,
+      width:'100%',
+      flexDirection:'row',
+      marginTop:8,
+    },
+    text:{
+      color:theme.colors.primary
+    },
+    checkBox:{
+      flexDirection:'row',
+    },
+    menu:{
+        borderWidth: 1,
+        borderColor: theme.colors.outline,
+        paddingHorizontal: 8,
+        justifyContent: 'center',
+        borderRadius: 4,
+        minHeight: 56,
+    }
+  });
 };

--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -1,5 +1,5 @@
 import { Button, useTheme, TextInput, HelperText,Menu,Text} from 'react-native-paper';
-import { Platform, Linking, View,Pressable, ScrollView} from 'react-native';
+import { Linking, View,Pressable, ScrollView} from 'react-native';
 import React, { useState } from 'react';
 import CheckIcon from 'react-native-template/assets/icons/check.svg';
 import { CountrySelectOptions } from '../../../constants';
@@ -54,7 +54,7 @@ return (
 
 const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => {
   const themeColor = useThemeColor('primary.500');
-  const theme = useTheme()
+  const theme = useTheme();
   const styles = usePhoneAuthFormStyles();
   const { formik, isSendOTPLoading } = usePhoneAuthForm({
     onSendOTPSuccess: onSuccess,
@@ -107,6 +107,7 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
                 keyboardType="numeric"
                 placeholder={phoneNumberPlaceholder}
                 mode='outlined'
+                style={{backgroundColor:theme.colors.surface}}
               />
             </View>
           </View>

--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -1,13 +1,15 @@
-import { Button, useTheme, TextInput, HelperText,Menu,Text} from 'react-native-paper';
-import { Linking, View,Pressable, ScrollView} from 'react-native';
+import { Checkbox } from 'native-base';
 import React, { useState } from 'react';
+import { Linking, View,Pressable, ScrollView } from 'react-native';
+import { Button, useTheme, TextInput, HelperText,Menu,Text } from 'react-native-paper';
 import CheckIcon from 'react-native-template/assets/icons/check.svg';
+
 import { CountrySelectOptions } from '../../../constants';
 import { AsyncError, PhoneNumber } from '../../../types';
+
 import usePhoneAuthForm from './phone-auth-form-hook';
 import { usePhoneAuthFormStyles } from './phone-auth-form.styles';
-import { Checkbox } from 'native-base';
-import { useThemeColor } from 'react-native-template/src/utils';
+
 
 interface PhoneAuthFormProps {
   onSuccess: () => void;
@@ -20,8 +22,9 @@ const renderCountrySelectMenu = (
   onOpen: () => void,
   onClose: () => void,
   handleSelectChange: (value: string) => void,
+  styles: ReturnType<typeof usePhoneAuthFormStyles>,
 ) => {
-  const styles = usePhoneAuthFormStyles();
+
 return (
 <Menu
   visible={isOpen}
@@ -50,10 +53,9 @@ return (
     ))}
   </ScrollView>
 </Menu>
-)};
+);};
 
 const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => {
-  const themeColor = useThemeColor('primary.500');
   const theme = useTheme();
   const styles = usePhoneAuthFormStyles();
   const { formik, isSendOTPLoading } = usePhoneAuthForm({
@@ -89,12 +91,12 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
     <View style={styles.phoneAuthScreen}>
       <View style={styles.Login}>
         <View style={{ paddingBottom: 24 }}>
-          <Text variant='headlineMedium'>Login</Text>
+          <Text variant="headlineMedium">Login</Text>
         </View>
         <View>
           <Text style={styles.text}>Mobile Number</Text>
           <View style={styles.row}>
-            {renderCountrySelectMenu(formik, isOpen, onOpen, onClose, handleSelectChange)}
+            {renderCountrySelectMenu(formik, isOpen, onOpen, onClose, handleSelectChange,styles)}
             <View
               style={[
                 styles.inputBox,
@@ -106,8 +108,8 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
                 onChangeText={formik.handleChange('phoneNumber')}
                 keyboardType="numeric"
                 placeholder={phoneNumberPlaceholder}
-                mode='outlined'
-                style={{backgroundColor:theme.colors.surface}}
+                mode="outlined"
+                style={{ backgroundColor:theme.colors.surface }}
               />
             </View>
           </View>
@@ -126,12 +128,12 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
             onChange={setIsChecked}
             accessibilityLabel="Agree to privacy policy"
             value="agreePrivacyPolicy"
-            icon={<CheckIcon width={12} height={12} color={themeColor} />}
+            icon={<CheckIcon width={12} height={12} fill={theme.colors.primary} />}
             aria-label="Privacy Policy Checkbox"
             mt={0.5}
           />
 
-          <View style={{marginLeft:12}}>
+          <View style={{ marginLeft:12 }}>
             <Text >By continuing, you agree to our </Text>
             <Text
               style={{ color: theme.colors.primary, textDecorationLine: 'underline' }}
@@ -149,7 +151,7 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
 
 
       <Button
-        mode='contained'
+        mode="contained"
         disabled={!isChecked}
         loading={isSendOTPLoading}
         onPress={() => formik.handleSubmit()}

--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -1,28 +1,13 @@
-import {
-  VStack,
-  Container,
-  Heading,
-  HStack,
-  useDisclose,
-  Text,
-  Pressable,
-  Menu,
-  ScrollView,
-  Link,
-  Box,
-  Checkbox,
-} from 'native-base';
+import { Button, useTheme, TextInput, HelperText,Menu,Text} from 'react-native-paper';
+import { Platform, Linking, View,Pressable, ScrollView} from 'react-native';
 import React, { useState } from 'react';
 import CheckIcon from 'react-native-template/assets/icons/check.svg';
-import { FormControl, Input, Button } from 'react-native-template/src/components';
-import { ButtonKind } from 'react-native-template/src/types/button';
-import { useThemeColor } from 'react-native-template/src/utils';
-
 import { CountrySelectOptions } from '../../../constants';
 import { AsyncError, PhoneNumber } from '../../../types';
-
 import usePhoneAuthForm from './phone-auth-form-hook';
 import { usePhoneAuthFormStyles } from './phone-auth-form.styles';
+import { Checkbox } from 'native-base';
+import { useThemeColor } from 'react-native-template/src/utils';
 
 interface PhoneAuthFormProps {
   onSuccess: () => void;
@@ -35,51 +20,54 @@ const renderCountrySelectMenu = (
   onOpen: () => void,
   onClose: () => void,
   handleSelectChange: (value: string) => void,
-) => (
-  <Menu
-    isOpen={isOpen}
-    onOpen={onOpen}
-    onClose={onClose}
-    trigger={triggerProps => (
-      <Pressable
-        {...triggerProps}
-        borderWidth={1}
-        justifyContent="center"
-        borderColor={'warmGray.300'}
-        rounded="sm"
-        px={2}
-      >
-        <Text>{`${formik.values.country} (${formik.values.countryCode})`}</Text>
-      </Pressable>
-    )}
-  >
-    <ScrollView maxH={'200px'}>
-      {CountrySelectOptions.map(option => (
-        <Menu.Item
-          key={option.value}
-          onPress={() => {
-            handleSelectChange(option.value);
-            onClose();
-          }}
-        >
-          {option.label}
-        </Menu.Item>
-      ))}
-    </ScrollView>
-  </Menu>
-);
+) => {
+  const styles = usePhoneAuthFormStyles();
+return (
+<Menu
+  visible={isOpen}
+  onDismiss={onClose}
+  contentStyle={{ width: 110 }}
+  anchor={
+    <Pressable
+      onPress={onOpen}
+      style={styles.menu}
+    >
+      <Text>{`${formik.values.country} (${formik.values.countryCode})`}</Text>
+    </Pressable>
+  }
+>
+  <ScrollView >
+    {CountrySelectOptions.map(option => (
+      <Menu.Item
+        key={option.value}
+        title={option.label}
+        titleStyle={{ fontSize: 18 }}
+        onPress={() => {
+          handleSelectChange(option.value);
+          onClose();
+        }}
+      />
+    ))}
+  </ScrollView>
+</Menu>
+)};
 
 const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => {
   const themeColor = useThemeColor('primary.500');
-
+  const theme = useTheme()
   const styles = usePhoneAuthFormStyles();
   const { formik, isSendOTPLoading } = usePhoneAuthForm({
     onSendOTPSuccess: onSuccess,
     onError: onError,
   });
 
-  const { isOpen, onOpen, onClose } = useDisclose();
+
   const [isChecked, setIsChecked] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onOpen = () => setIsOpen(true);
+  const onClose = () => setIsOpen(false);
+
 
   const handleSelectChange = (value: string) => {
     const [countryCode, country] = value.split(', ');
@@ -98,36 +86,40 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
   }).getFormattedWithoutCountryCode();
 
   return (
-    <Box flex={1} pb={4}>
-      <VStack space={6} flex={1} mb={8}>
-        <Container>
-          <Heading size="lg">Login</Heading>
-        </Container>
-        <FormControl label={'Mobile Number'}>
-          <HStack space={2} width="100%">
+    <View style={styles.phoneAuthScreen}>
+      <View style={styles.Login}>
+        <View style={{ paddingBottom: 24 }}>
+          <Text variant='headlineMedium'>Login</Text>
+        </View>
+        <View>
+          <Text style={styles.text}>Mobile Number</Text>
+          <View style={styles.row}>
             {renderCountrySelectMenu(formik, isOpen, onOpen, onClose, handleSelectChange)}
-            <Box
-              flex={3}
-              justifyContent="center"
+            <View
               style={[
                 styles.inputBox,
                 formik.touched.phoneNumber && formik.errors.phoneNumber ? styles.errorStyle : {},
               ]}
             >
-              <Input
+              <TextInput
                 value={phoneNumber.getFormattedWithoutCountryCode()}
                 onChangeText={formik.handleChange('phoneNumber')}
                 keyboardType="numeric"
                 placeholder={phoneNumberPlaceholder}
+                mode='outlined'
               />
-            </Box>
-          </HStack>
-          {formik.touched.phoneNumber && formik.errors.phoneNumber ? (
-            <Text style={styles.errorText}>{formik.errors.phoneNumber}</Text>
-          ) : null}
-        </FormControl>
+            </View>
+          </View>
+          <HelperText
+            type="error"
+            visible={!!(formik.touched.phoneNumber && formik.errors.phoneNumber)}
+          >
+            {formik.errors.phoneNumber}
+          </HelperText>
 
-        <HStack alignItems="flex-start" space={2} mt={2}>
+        </View>
+
+        <View style={styles.Checkbox}>
           <Checkbox
             isChecked={isChecked}
             onChange={setIsChecked}
@@ -137,28 +129,34 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
             aria-label="Privacy Policy Checkbox"
             mt={0.5}
           />
-          <HStack flexWrap="wrap" alignItems="baseline" flex={1}>
-            <Text fontSize="sm">By continuing, you agree to our </Text>
-            <Link
-              _text={{ color: 'primary.500', underline: true, fontSize: 'sm' }}
-              href="https://jalantechnologies.github.io/react-native-template/"
-              isExternal
+
+          <View style={{marginLeft:12}}>
+            <Text >By continuing, you agree to our </Text>
+            <Text
+              style={{ color: theme.colors.primary, textDecorationLine: 'underline' }}
+              onPress={() =>
+                Linking.openURL(
+                  'https://jalantechnologies.github.io/react-native-template/'
+                )
+              }
             >
               Privacy Policy
-            </Link>
-          </HStack>
-        </HStack>
-      </VStack>
+            </Text>
+          </View>
+        </View>
+      </View>
+
 
       <Button
+        mode='contained'
         disabled={!isChecked}
-        isLoading={isSendOTPLoading}
-        onClick={() => formik.handleSubmit()}
-        kind={ButtonKind.CONTAINED}
+        loading={isSendOTPLoading}
+        onPress={() => formik.handleSubmit()}
+        style={styles.Button}
       >
         Send OTP
       </Button>
-    </Box>
+    </View>
   );
 };
 

--- a/src/screens/auth/registration/index.tsx
+++ b/src/screens/auth/registration/index.tsx
@@ -3,6 +3,7 @@ import { Snackbar } from 'react-native-paper';
 
 import { AsyncError } from '../../../types';
 import AuthLayout from '../auth-layout';
+
 import RegistrationForm from './registration-form';
 
 const RegistrationScreen: React.FC = () => {

--- a/src/screens/auth/registration/index.tsx
+++ b/src/screens/auth/registration/index.tsx
@@ -1,27 +1,37 @@
-import { Toast } from 'native-base';
-import React from 'react';
+import React, { useState } from 'react';
+import { Snackbar } from 'react-native-paper';
 
 import { AsyncError } from '../../../types';
 import AuthLayout from '../auth-layout';
-
 import RegistrationForm from './registration-form';
 
 const RegistrationScreen: React.FC = () => {
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
   const onSuccess = () => {
-    Toast.show({
-      title: 'Account Created Successfully',
-    });
+    setSnackbarMessage('Account Created Successfully');
+    setSnackbarVisible(true);
   };
 
   const onError = (err: AsyncError) => {
-    Toast.show({
-      title: err.message,
-    });
+    setSnackbarMessage(err.message);
+    setSnackbarVisible(true);
   };
+
   return (
-    <AuthLayout primaryTitle="Create" secondaryTitle="Account">
-      <RegistrationForm onError={onError} onSuccess={onSuccess} />
-    </AuthLayout>
+    <>
+      <AuthLayout primaryTitle="Create" secondaryTitle="Account">
+        <RegistrationForm onError={onError} onSuccess={onSuccess} />
+      </AuthLayout>
+
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+      >
+        {snackbarMessage}
+      </Snackbar>
+    </>
   );
 };
 

--- a/src/screens/auth/registration/registration-form.tsx
+++ b/src/screens/auth/registration/registration-form.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View} from 'react-native';
 import { Text, TextInput, Button, HelperText } from 'react-native-paper';
 import {useRegistrationStyles} from './registration.styles'
 import { AsyncError } from '../../../types';
 import useRegistrationForm from './registration-form-hook';
+import { background } from 'native-base/lib/typescript/theme/styled-system';
 
 interface RegistrationFormProps {
   onError: (error: AsyncError) => void;
@@ -35,6 +36,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ onSuccess, onError 
           value={formik.values.firstName}
           onChangeText={formik.handleChange('firstName')}
           error={!!formik.errors.firstName}
+          style={styles.textBox}
         />
         <HelperText type="error" visible={!!formik.errors.firstName}>
           {formik.errors.firstName}
@@ -49,6 +51,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ onSuccess, onError 
           value={formik.values.lastName}
           onChangeText={formik.handleChange('lastName')}
           error={!!formik.errors.lastName}
+          style={styles.textBox}
         />
         <HelperText type="error" visible={!!formik.errors.lastName}>
           {formik.errors.lastName}

--- a/src/screens/auth/registration/registration-form.tsx
+++ b/src/screens/auth/registration/registration-form.tsx
@@ -1,9 +1,8 @@
-import { Container, Heading, VStack } from 'native-base';
 import React from 'react';
-import { Button, FormControl, Input } from 'react-native-template/src/components';
-
+import { View, StyleSheet } from 'react-native';
+import { Text, TextInput, Button, HelperText } from 'react-native-paper';
+import {useRegistrationStyles} from './registration.styles'
 import { AsyncError } from '../../../types';
-
 import useRegistrationForm from './registration-form-hook';
 
 interface RegistrationFormProps {
@@ -17,33 +16,56 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ onSuccess, onError 
     onRegistrationSuccess: onSuccess,
   });
 
+  const styles = useRegistrationStyles()
+
   return (
-    <VStack space={4}>
-      <Container>
-        <Heading size="lg">New User Registration</Heading>
-        <Heading mt={2} size="xs">
-          Please fill the form to create an account
-        </Heading>
-      </Container>
-      <FormControl label={'First Name'} error={formik.errors.firstName}>
-        <Input
-          onChangeText={formik.handleChange('firstName')}
-          value={formik.values.firstName}
+    <View >
+      <View style={styles.header}>
+        <Text variant="titleLarge">New User Registration</Text>
+        <Text variant="bodyMedium" style={styles.subtitle}>
+          Please fill the form to create an {'\n'} account
+        </Text>
+      </View>
+
+      <View>
+        <Text style={styles.text}>First Name</Text>
+        <TextInput
           placeholder="First Name"
+          mode="outlined"
+          value={formik.values.firstName}
+          onChangeText={formik.handleChange('firstName')}
+          error={!!formik.errors.firstName}
         />
-      </FormControl>
-      <FormControl label={'Last Name'} error={formik.errors.lastName}>
-        <Input
-          onChangeText={formik.handleChange('lastName')}
-          value={formik.values.lastName}
+        <HelperText type="error" visible={!!formik.errors.firstName}>
+          {formik.errors.firstName}
+        </HelperText>
+      </View>
+
+      <View>
+        <Text style={styles.text}>Last Name</Text>
+        <TextInput
           placeholder="Last Name"
+          mode="outlined"
+          value={formik.values.lastName}
+          onChangeText={formik.handleChange('lastName')}
+          error={!!formik.errors.lastName}
         />
-      </FormControl>
-      <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
+        <HelperText type="error" visible={!!formik.errors.lastName}>
+          {formik.errors.lastName}
+        </HelperText>
+      </View>
+
+      <Button
+        mode="contained"
+        loading={isUpdateAccountLoading}
+        onPress={() => formik.handleSubmit()}
+        style={styles.Button}
+      >
         Create Account
       </Button>
-    </VStack>
+    </View>
   );
 };
 
 export default RegistrationForm;
+

--- a/src/screens/auth/registration/registration-form.tsx
+++ b/src/screens/auth/registration/registration-form.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View} from 'react-native';
+import { View } from 'react-native';
 import { Text, TextInput, Button, HelperText } from 'react-native-paper';
-import {useRegistrationStyles} from './registration.styles'
+
 import { AsyncError } from '../../../types';
+
 import useRegistrationForm from './registration-form-hook';
-import { background } from 'native-base/lib/typescript/theme/styled-system';
+import { useRegistrationStyles } from './registration.styles';
 
 interface RegistrationFormProps {
   onError: (error: AsyncError) => void;
@@ -17,7 +18,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ onSuccess, onError 
     onRegistrationSuccess: onSuccess,
   });
 
-  const styles = useRegistrationStyles()
+  const styles = useRegistrationStyles();
 
   return (
     <View >

--- a/src/screens/auth/registration/registration.styles.ts
+++ b/src/screens/auth/registration/registration.styles.ts
@@ -1,0 +1,27 @@
+import { StyleSheet } from "react-native";
+import {useTheme} from 'react-native-paper'
+export const useRegistrationStyles = () => {
+    const theme = useTheme()
+    return StyleSheet.create({
+        container: {
+            gap: 16,
+        },
+        header: {
+            marginVertical: 10,
+
+        },
+        subtitle: {
+            marginTop: 14,
+            opacity: 0.7,
+            marginBottom:20
+        },
+        Button: {
+            borderRadius: 8
+        },
+        text: {
+            color: theme.colors.primary,
+            paddingBottom: 8,
+            fontWeight:600
+        }
+    })
+}

--- a/src/screens/auth/registration/registration.styles.ts
+++ b/src/screens/auth/registration/registration.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from "react-native";
-import {useTheme} from 'react-native-paper'
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
 export const useRegistrationStyles = () => {
-    const theme = useTheme()
+    const theme = useTheme();
     return StyleSheet.create({
         container: {
             gap: 16,
@@ -13,18 +13,18 @@ export const useRegistrationStyles = () => {
         subtitle: {
             marginTop: 14,
             opacity: 0.7,
-            marginBottom:20
+            marginBottom:20,
         },
         Button: {
-            borderRadius: 8
+            borderRadius: 8,
         },
         text: {
             color: theme.colors.primary,
             paddingBottom: 8,
-            fontWeight:'600'
+            fontWeight:'600',
         },
         textBox:{
-            backgroundColor:theme.colors.surface
-        }
-    })
-}
+            backgroundColor:theme.colors.surface,
+        },
+    });
+};

--- a/src/screens/auth/registration/registration.styles.ts
+++ b/src/screens/auth/registration/registration.styles.ts
@@ -21,7 +21,10 @@ export const useRegistrationStyles = () => {
         text: {
             color: theme.colors.primary,
             paddingBottom: 8,
-            fontWeight:600
+            fontWeight:'600'
+        },
+        textBox:{
+            backgroundColor:theme.colors.surface
         }
     })
 }

--- a/src/screens/dashboard/task-section/index.tsx
+++ b/src/screens/dashboard/task-section/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { View, ScrollView, RefreshControl } from 'react-native';
 import { Text, Snackbar } from 'react-native-paper';
-import { useTranslation } from 'react-i18next';
 
 import { TaskOperation } from '../../../constants';
 import { useTaskContext } from '../../../contexts';

--- a/src/screens/dashboard/task-section/task-add-edit-modal.tsx
+++ b/src/screens/dashboard/task-section/task-add-edit-modal.tsx
@@ -10,12 +10,13 @@ import {
   TextInput,
   HelperText,
 } from 'react-native-paper';
+import Close from 'react-native-template/assets/icons/close.svg';
 
 import { TaskModal, TaskOperation } from '../../../constants';
 import { AsyncError, Nullable, Task } from '../../../types';
-import Close from 'react-native-template/assets/icons/close.svg';
+
 import useTaskAddEditForm from './task-add-edit-form-hook';
-import { taskModalStyles } from './task.style';
+import { useTaskModalStyles } from './task.style';
 
 interface TaskAddEditModalProps {
   isModalOpen: boolean;
@@ -35,7 +36,7 @@ const TaskAddEditModal: React.FC<TaskAddEditModalProps> = ({
   taskOperation,
 }) => {
   const theme = useTheme();
-  const styles = taskModalStyles();
+  const styles = useTaskModalStyles();
   const [submitted, setSubmitted] = React.useState(false);
 
   const handleModalClose = () => {

--- a/src/screens/dashboard/task-section/task-add-edit-modal.tsx
+++ b/src/screens/dashboard/task-section/task-add-edit-modal.tsx
@@ -1,11 +1,21 @@
-import { VStack } from 'native-base';
 import React from 'react';
-import { Button, FormControl, Input, Modal } from 'react-native-template/src/components';
+import { View } from 'react-native';
+import {
+  Dialog,
+  Portal,
+  IconButton,
+  Text,
+  useTheme,
+  Button,
+  TextInput,
+  HelperText,
+} from 'react-native-paper';
 
 import { TaskModal, TaskOperation } from '../../../constants';
 import { AsyncError, Nullable, Task } from '../../../types';
-
+import Close from 'react-native-template/assets/icons/close.svg';
 import useTaskAddEditForm from './task-add-edit-form-hook';
+import { taskModalStyles } from './task.style';
 
 interface TaskAddEditModalProps {
   isModalOpen: boolean;
@@ -21,10 +31,15 @@ const TaskAddEditModal: React.FC<TaskAddEditModalProps> = ({
   onTaskOperationComplete,
   onTaskOperationFailure,
   setModalOpen,
-  task,
+  task = null,
   taskOperation,
 }) => {
+  const theme = useTheme();
+  const styles = taskModalStyles();
+  const [submitted, setSubmitted] = React.useState(false);
+
   const handleModalClose = () => {
+    setSubmitted(false);
     setModalOpen(false);
   };
 
@@ -33,11 +48,12 @@ const TaskAddEditModal: React.FC<TaskAddEditModalProps> = ({
     onTaskOperationComplete(description);
   };
 
-  const { formik, isAddTaskLoading, isUpdateTaskLoading } = useTaskAddEditForm({
-    onTaskOperationSuccess,
-    onTaskOperationFailure,
-    task: taskOperation === TaskOperation.EDIT ? task : null,
-  });
+  const { formik, isAddTaskLoading, isUpdateTaskLoading } =
+    useTaskAddEditForm({
+      onTaskOperationSuccess,
+      onTaskOperationFailure,
+      task: taskOperation === TaskOperation.EDIT ? task : null,
+    });
 
   const modalHeading = () => {
     switch (taskOperation) {
@@ -73,40 +89,76 @@ const TaskAddEditModal: React.FC<TaskAddEditModalProps> = ({
   };
 
   return (
-    <Modal isModalOpen={isModalOpen} handleModalClose={handleModalClose} key={taskOperation}>
-      <Modal.Header title={modalHeading()} onClose={handleModalClose} />
-      <Modal.Body>
-        <VStack space={4} p={4}>
-          <FormControl label="Title" error={formik.touched.title ? formik.errors.title : ''}>
-            <Input
-              onChangeText={formik.handleChange('title')}
-              value={formik.values.title}
-              placeholder="Title"
-            />
-          </FormControl>
-          <FormControl
-            label="Description"
-            error={formik.touched.description ? formik.errors.description : ''}
-          >
-            <Input
-              onChangeText={formik.handleChange('description')}
-              value={formik.values.description}
-              placeholder="Description"
-            />
-          </FormControl>
-        </VStack>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button isLoading={isLoading()} onClick={() => formik.handleSubmit()}>
-          {buttonText()}
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  );
-};
+    <Portal>
+      <Dialog
+        visible={isModalOpen}
+        onDismiss={handleModalClose}
+        style={styles.dialog}
+      >
+        <Dialog.Title>
+          <Text variant="titleLarge" style={styles.heading}>
+            {modalHeading()}
+          </Text>
+        </Dialog.Title>
 
-TaskAddEditModal.defaultProps = {
-  task: null,
+        <IconButton
+          icon={() => (
+            <Close width={26} height={26} fill={theme.colors.primary} />
+          )}
+          onPress={handleModalClose}
+          style={styles.close}
+        />
+
+        <Dialog.Content>
+          <View>
+            <Text style={styles.text}>Title</Text>
+            <TextInput
+              mode="outlined"
+              placeholder="Title"
+              value={formik.values.title}
+              onChangeText={formik.handleChange('title')}
+              style={{ backgroundColor: theme.colors.surface }}
+              error={submitted && !!formik.errors.title}
+            />
+            <HelperText type="error" visible={submitted && !!formik.errors.title}>
+              {formik.errors.title}
+            </HelperText>
+
+            <Text style={styles.text}>Description</Text>
+            <TextInput
+              mode="outlined"
+              placeholder="Description"
+              value={formik.values.description}
+              onChangeText={formik.handleChange('description')}
+              multiline
+              style={{ backgroundColor: theme.colors.surface }}
+              error={submitted && !!formik.errors.description}
+            />
+            <HelperText
+              type="error"
+              visible={submitted && !!formik.errors.description}
+            >
+              {formik.errors.description}
+            </HelperText>
+          </View>
+        </Dialog.Content>
+
+        <Dialog.Actions>
+          <Button
+            mode="contained"
+            loading={isLoading()}
+            onPress={() => {
+              setSubmitted(true);
+              formik.handleSubmit();
+            }}
+            style={styles.button}
+          >
+            {buttonText()}
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
+  );
 };
 
 export default TaskAddEditModal;

--- a/src/screens/dashboard/task-section/task-delete-modal.tsx
+++ b/src/screens/dashboard/task-section/task-delete-modal.tsx
@@ -1,6 +1,6 @@
+import { t } from 'i18next';
 import React, { useState } from 'react';
 import { View } from 'react-native';
-import { t } from 'i18next';
 import {
   Dialog,
   Portal,
@@ -10,13 +10,12 @@ import {
   Button,
   Snackbar,
 } from 'react-native-paper';
-
-import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import Close from 'react-native-template/assets/icons/close.svg';
-
+import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import { useTaskContext } from 'react-native-template/src/contexts';
 import { AsyncError, Task } from 'react-native-template/src/types';
-import { taskModalStyles } from './task.style';
+
+import { useTaskModalStyles } from './task.style';
 
 interface TaskDeleteModalProps {
   handleModalClose: () => void;
@@ -30,7 +29,7 @@ const TaskDeleteModal: React.FC<TaskDeleteModalProps> = ({
   isModalOpen,
 }) => {
   const { deleteTask, isDeleteTaskLoading } = useTaskContext();
-  const styles = taskModalStyles();
+  const styles = useTaskModalStyles();
   const theme = useTheme();
 
   const [snackbar, setSnackbar] = useState<{

--- a/src/screens/dashboard/task-section/task-header.tsx
+++ b/src/screens/dashboard/task-section/task-header.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import AddIcon from 'react-native-template/assets/icons/add.svg';
-import { Text, useTheme, Button } from 'react-native-paper';
 import { View } from 'react-native';
+import { Text, useTheme, Button } from 'react-native-paper';
+import AddIcon from 'react-native-template/assets/icons/add.svg';
+
 import { useTaskStyles } from './task.style';
 interface TaskHeaderProps {
   onHeaderButtonPress: () => void;

--- a/src/screens/dashboard/task-section/task-header.tsx
+++ b/src/screens/dashboard/task-section/task-header.tsx
@@ -1,25 +1,36 @@
-import { HStack, Heading, useTheme } from 'native-base';
 import React from 'react';
 import AddIcon from 'react-native-template/assets/icons/add.svg';
-import { Button } from 'react-native-template/src/components';
-
+import { Text, useTheme, Button } from 'react-native-paper';
+import { View } from 'react-native';
+import { useTaskStyles } from './task.style';
 interface TaskHeaderProps {
   onHeaderButtonPress: () => void;
 }
 
 const TaskHeader: React.FC<TaskHeaderProps> = ({ onHeaderButtonPress }) => {
   const theme = useTheme();
+  const styles = useTaskStyles();
 
   return (
-    <HStack justifyContent="space-between" alignItems="center" px={4} py={2}>
-      <Heading size="lg">Tasks</Heading>
+    <View style={styles.header}>
+      <Text variant="headlineMedium">
+        Tasks
+      </Text>
       <Button
-        startEnhancer={<AddIcon width={16} height={16} fill={theme.colors.secondary[50]} />}
-        onClick={onHeaderButtonPress}
+        mode="contained"
+        style={styles.button}
+        icon={() => (
+          <AddIcon
+            width={16}
+            height={16}
+            fill={theme.colors.onPrimary}
+          />
+        )}
+        onPress={onHeaderButtonPress}
       >
         Add Task
       </Button>
-    </HStack>
+    </View>
   );
 };
 

--- a/src/screens/dashboard/task-section/task.style.ts
+++ b/src/screens/dashboard/task-section/task.style.ts
@@ -1,14 +1,95 @@
-import { useTheme } from 'native-base';
 import { StyleSheet } from 'react-native';
-
+import { useTheme } from 'react-native-paper'
+import { useMemo } from 'react';
 export const useTaskStyles = () => {
-  const theme = useTheme();
+  const theme = useTheme ();
 
-  return StyleSheet.create({
+  return useMemo(()=>
+  StyleSheet.create({
+    title:{
+     color:theme.colors.onPrimaryContainer
+    },
     container: {
       flexDirection: 'row',
-      gap: theme.space[4],
-      marginTop: theme.space[8],
+      gap: 16,
+      marginTop: 36,
     },
-  });
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+    },
+    button: {
+      borderRadius: 6,
+    },
+    taskScreen:{
+      flex: 1,
+      padding: 8,
+      backgroundColor: theme.colors.surface,
+    },
+    center:{
+      alignItems: 'center',
+      paddingVertical: 12,
+    }
+
+  }),[theme])
+   
+  
 };
+
+
+export const taskModalStyles = () => {
+  const theme = useTheme ();
+
+  return useMemo(()=>
+  StyleSheet.create({
+    dialog: {
+      borderRadius: 8,
+      backgroundColor: theme.colors.surface,
+    },
+    feild: {
+      rowGap: 1,
+      padding: 8,
+    },
+    button: {
+      borderRadius: 6,
+      paddingHorizontal: 6
+    },
+    heading:{
+      color:theme.colors.primary,
+      textAlign:'center',
+      paddingBottom:28
+    },
+    close: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    zIndex: 10,
+  },
+  deleteFooter:{
+    flexDirection:'row',
+    gap:16,
+    justifyContent:'center',
+    width: '100%',
+  },
+  deleteText:{
+    marginVertical:12,
+    alignItems:'center'
+
+  },
+  box:{
+    backgroundColor: theme.colors.surface,
+    marginTop:6
+  },
+  text:{
+    color:theme.colors.primary,
+    paddingBottom:8
+  }
+
+  }),[theme])
+  
+  
+  
+}

--- a/src/screens/dashboard/task-section/task.style.ts
+++ b/src/screens/dashboard/task-section/task.style.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from 'react-native';
-import { useTheme } from 'react-native-paper'
 import { useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
 export const useTaskStyles = () => {
-  const theme = useTheme ();
+  const theme = useTheme();
 
   return useMemo(()=>
   StyleSheet.create({
     title:{
-     color:theme.colors.onPrimaryContainer
+     color:theme.colors.onPrimaryContainer,
     },
     container: {
       flexDirection: 'row',
@@ -32,16 +32,16 @@ export const useTaskStyles = () => {
     center:{
       alignItems: 'center',
       paddingVertical: 12,
-    }
+    },
 
-  }),[theme])
-   
-  
+  }),[theme]);
+
+
 };
 
 
-export const taskModalStyles = () => {
-  const theme = useTheme ();
+export const useTaskModalStyles = () => {
+  const theme = useTheme();
 
   return useMemo(()=>
   StyleSheet.create({
@@ -55,12 +55,12 @@ export const taskModalStyles = () => {
     },
     button: {
       borderRadius: 6,
-      paddingHorizontal: 6
+      paddingHorizontal: 6,
     },
     heading:{
       color:theme.colors.primary,
       textAlign:'center',
-      paddingBottom:28
+      paddingBottom:28,
     },
     close: {
     position: 'absolute',
@@ -76,20 +76,20 @@ export const taskModalStyles = () => {
   },
   deleteText:{
     marginVertical:12,
-    alignItems:'center'
+    alignItems:'center',
 
   },
   box:{
     backgroundColor: theme.colors.surface,
-    marginTop:6
+    marginTop:6,
   },
   text:{
     color:theme.colors.primary,
-    paddingBottom:8
-  }
+    paddingBottom:8,
+  },
 
-  }),[theme])
-  
-  
-  
-}
+  }),[theme]);
+
+
+
+};

--- a/src/screens/dashboard/task-section/task.tsx
+++ b/src/screens/dashboard/task-section/task.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
+import { Card, Text, useTheme, Button } from 'react-native-paper';
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import EditIcon from 'react-native-template/assets/icons/edit.svg';
 import { Task } from 'react-native-template/src/types';
-import { Card, Text, useTheme, Button } from 'react-native-paper';
+
 import TaskDeleteModal from './task-delete-modal';
 import { useTaskStyles } from './task.style';
 
@@ -32,7 +33,7 @@ const TaskCard: React.FC<TaskProps> = ({ task, handleEditTask }) => {
   return (
     <>
       <Card mode="outlined" >
-        <Card.Title title={title} titleStyle={{ paddingVertical:16,color: theme.colors.onPrimaryContainer,fontWeight:'700' }} titleVariant='titleMedium' />
+        <Card.Title title={title} titleStyle={{ paddingVertical:16,color: theme.colors.onPrimaryContainer,fontWeight:'700' }} titleVariant="titleMedium" />
         <Card.Content>
           <Text>{description}</Text>
         </Card.Content>
@@ -52,7 +53,7 @@ const TaskCard: React.FC<TaskProps> = ({ task, handleEditTask }) => {
               Edit
             </Button>
             <Button
-              mode='text'
+              mode="text"
               textColor={theme.colors.error}
               icon={() => (
                 <DeleteIcon width={16} height={16} fill={theme.colors.error} />

--- a/src/screens/dashboard/task-section/task.tsx
+++ b/src/screens/dashboard/task-section/task.tsx
@@ -1,12 +1,9 @@
-import { Text, useTheme } from 'native-base';
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import EditIcon from 'react-native-template/assets/icons/edit.svg';
-import { Button, Card } from 'react-native-template/src/components';
 import { Task } from 'react-native-template/src/types';
-import { ButtonKind } from 'react-native-template/src/types/button';
-
+import { Card, Text, useTheme, Button } from 'react-native-paper';
 import TaskDeleteModal from './task-delete-modal';
 import { useTaskStyles } from './task.style';
 
@@ -34,27 +31,35 @@ const TaskCard: React.FC<TaskProps> = ({ task, handleEditTask }) => {
 
   return (
     <>
-      <Card>
-        <Card.Header title={title} />
+      <Card mode="outlined" >
+        <Card.Title title={title} titleStyle={{ paddingVertical:16,color: theme.colors.onPrimaryContainer,fontWeight:700 }} titleVariant='titleMedium' />
         <Card.Content>
           <Text>{description}</Text>
         </Card.Content>
         <Card.Actions>
           <View style={styles.container}>
             <Button
-              kind={ButtonKind.LINK}
-              startEnhancer={<EditIcon width={16} height={16} fill={theme.colors.primary[500]} />}
-              onClick={() => handleEditTask(task)}
+              mode="text"
+              icon={() => (
+                <EditIcon
+                  width={16}
+                  height={16}
+                  fill={theme.colors.primary}
+                />
+              )}
+              onPress={() => handleEditTask(task)}
             >
               Edit
             </Button>
-
             <Button
-              kind={ButtonKind.LINK}
-              startEnhancer={<DeleteIcon width={16} height={16} fill={theme.colors.danger[600]} />}
-              onClick={handleDeleteTask}
+              mode='text'
+              textColor={theme.colors.error}
+              icon={() => (
+                <DeleteIcon width={16} height={16} fill={theme.colors.error} />
+              )}
+              onPress={handleDeleteTask}
             >
-              <Text color={'danger.600'}> Delete</Text>
+              Delete
             </Button>
           </View>
         </Card.Actions>

--- a/src/screens/dashboard/task-section/task.tsx
+++ b/src/screens/dashboard/task-section/task.tsx
@@ -32,7 +32,7 @@ const TaskCard: React.FC<TaskProps> = ({ task, handleEditTask }) => {
   return (
     <>
       <Card mode="outlined" >
-        <Card.Title title={title} titleStyle={{ paddingVertical:16,color: theme.colors.onPrimaryContainer,fontWeight:700 }} titleVariant='titleMedium' />
+        <Card.Title title={title} titleStyle={{ paddingVertical:16,color: theme.colors.onPrimaryContainer,fontWeight:'700' }} titleVariant='titleMedium' />
         <Card.Content>
           <Text>{description}</Text>
         </Card.Content>

--- a/src/screens/profile/edit-profile/edit-profile.tsx
+++ b/src/screens/profile/edit-profile/edit-profile.tsx
@@ -8,17 +8,19 @@ import {
   Button,
   Snackbar,
 } from 'react-native-paper';
+
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';
 import ProfileLayout from '../profile-layout';
-import  {useStyles}  from './styles';
+
 import useProfileUpdateForm from './profile-update-form.hook';
+import  { useStyles }  from './styles';
 
 const EditProfile: React.FC<
   ProfileStackScreenProps<'EditProfile'>
 > = ({ navigation }) => {
   const { colors } = useTheme();
-  const styles = useStyles()
+  const styles = useStyles();
   const [snackbar, setSnackbar] = React.useState<{
     visible: boolean;
     message: string;
@@ -51,7 +53,7 @@ const EditProfile: React.FC<
   return (
     <ProfileLayout>
       <KeyboardAvoidingView
-        style={{ flex: 1,justifyContent:'space-between'}}
+        style={{ flex: 1,justifyContent:'space-between' }}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
       >

--- a/src/screens/profile/edit-profile/edit-profile.tsx
+++ b/src/screens/profile/edit-profile/edit-profile.tsx
@@ -1,20 +1,35 @@
-import { KeyboardAvoidingView, Toast, VStack } from 'native-base';
 import React from 'react';
-import { Platform } from 'react-native';
-import { Button, FormControl, Input } from 'react-native-template/src/components';
-
+import { View, Platform, KeyboardAvoidingView } from 'react-native';
+import {
+  HelperText,
+  TextInput,
+  useTheme,
+  Text,
+  Button,
+  Snackbar,
+} from 'react-native-paper';
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';
 import ProfileLayout from '../profile-layout';
-
+import  {useStyles}  from './styles';
 import useProfileUpdateForm from './profile-update-form.hook';
 
-const EditProfile: React.FC<ProfileStackScreenProps<'EditProfile'>> = ({ navigation }) => {
+const EditProfile: React.FC<
+  ProfileStackScreenProps<'EditProfile'>
+> = ({ navigation }) => {
+  const { colors } = useTheme();
+  const styles = useStyles()
+  const [snackbar, setSnackbar] = React.useState<{
+    visible: boolean;
+    message: string;
+  }>({ visible: false, message: '' });
+
   const onProfileUpdateSuccess = () => {
-    Toast.show({
-      title: 'Profile Updated',
-      description: 'Your profile has been updated successfully',
+    setSnackbar({
+      visible: true,
+      message: 'Profile updated successfully',
     });
+
     navigation.reset({
       index: 0,
       routes: [{ name: 'Home' }],
@@ -22,9 +37,9 @@ const EditProfile: React.FC<ProfileStackScreenProps<'EditProfile'>> = ({ navigat
   };
 
   const onProfileUpdateError = (err: AsyncError) => {
-    Toast.show({
-      title: 'Profile Update Failed',
-      description: err.message,
+    setSnackbar({
+      visible: true,
+      message: err.message,
     });
   };
 
@@ -36,36 +51,76 @@ const EditProfile: React.FC<ProfileStackScreenProps<'EditProfile'>> = ({ navigat
   return (
     <ProfileLayout>
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        flex={1}
+        style={{ flex: 1,justifyContent:'space-between'}}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
-        justifyContent={'space-between'}
       >
-        <VStack space={4}>
-          <FormControl error={formik.errors.firstName} label={'First Name'}>
-            <Input
-              onChangeText={formik.handleChange('firstName')}
-              placeholder={'First Name'}
+        <View style={styles.layout}>
+          <View>
+            <Text style={styles.text}>First Name</Text>
+            <TextInput
+              mode="outlined"
+              placeholder="First Name"
               value={formik.values.firstName}
+              onChangeText={formik.handleChange('firstName')}
+              style={{ backgroundColor: colors.surface }}
+              error={!!formik.errors.firstName}
             />
-          </FormControl>
+            <HelperText type="error" visible={!!formik.errors.firstName}>
+              {formik.errors.firstName}
+            </HelperText>
+          </View>
 
-          <FormControl error={formik.errors.lastName} label={'Last Name'}>
-            <Input
-              onChangeText={formik.handleChange('lastName')}
-              placeholder={'Last Name'}
+          <View>
+            <Text style={styles.text}>Last Name</Text>
+            <TextInput
+              mode="outlined"
+              placeholder="Last Name"
               value={formik.values.lastName}
+              onChangeText={formik.handleChange('lastName')}
+              style={{ backgroundColor: colors.surface }}
+              error={!!formik.errors.lastName}
             />
-          </FormControl>
+            <HelperText type="error" visible={!!formik.errors.lastName}>
+              {formik.errors.lastName}
+            </HelperText>
+          </View>
 
-          <FormControl label={'Phone Number'}>
-            <Input value={formik.values.phoneNumber} editable={false} disabled={true} />
-          </FormControl>
-        </VStack>
+          <View>
+            <Text style={styles.text}>Phone Number</Text>
+            <TextInput
+              mode="outlined"
+              value={formik.values.phoneNumber}
+              editable={false}
+              disabled
+              style={{ backgroundColor: colors.surfaceVariant }}
+            />
+            <HelperText
+              type="error"
+              visible={!!formik.errors.phoneNumber}
+            >
+              {formik.errors.phoneNumber}
+            </HelperText>
+          </View>
+        </View>
 
-        <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
+        <Button
+          mode="contained"
+          onPress={() => formik.handleSubmit()}
+          loading={isUpdateAccountLoading}
+          style={styles.Button}
+        >
           Save Changes
         </Button>
+
+        <Snackbar
+          visible={snackbar.visible}
+          onDismiss={() =>
+            setSnackbar({ visible: false, message: '' })
+          }
+        >
+          {snackbar.message}
+        </Snackbar>
       </KeyboardAvoidingView>
     </ProfileLayout>
   );

--- a/src/screens/profile/edit-profile/styles.ts
+++ b/src/screens/profile/edit-profile/styles.ts
@@ -12,7 +12,7 @@ export const useStyles = () => {
         text: {
             color: theme.colors.primary,
             marginBottom: 8,
-            fontWeight: 600
+            fontWeight: '600'
         },
         Button: {
             borderRadius: 6,

--- a/src/screens/profile/edit-profile/styles.ts
+++ b/src/screens/profile/edit-profile/styles.ts
@@ -1,0 +1,21 @@
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+
+export const useStyles = () => {
+    const theme = useTheme()
+
+    return StyleSheet.create({
+        layout: {
+            gap: 4
+        },
+        text: {
+            color: theme.colors.primary,
+            marginBottom: 8,
+            fontWeight: 600
+        },
+        Button: {
+            borderRadius: 6,
+        }
+    })
+};

--- a/src/screens/profile/edit-profile/styles.ts
+++ b/src/screens/profile/edit-profile/styles.ts
@@ -3,19 +3,19 @@ import { useTheme } from 'react-native-paper';
 
 
 export const useStyles = () => {
-    const theme = useTheme()
+    const theme = useTheme();
 
     return StyleSheet.create({
         layout: {
-            gap: 4
+            gap: 4,
         },
         text: {
             color: theme.colors.primary,
             marginBottom: 8,
-            fontWeight: '600'
+            fontWeight: '600',
         },
         Button: {
             borderRadius: 6,
-        }
-    })
+        },
+    });
 };

--- a/src/screens/profile/home/account-delete-modal.tsx
+++ b/src/screens/profile/home/account-delete-modal.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
+import { View } from 'react-native';
 import { Dialog, Portal, useTheme, IconButton, Text, Button } from 'react-native-paper';
-import { View} from 'react-native';
 import Close from 'react-native-template/assets/icons/close.svg';
-import { useStyles}  from './styles'
+import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
+
+import { useStyles }  from './styles';
 interface AccountDeleteModalProps {
   handleDeleteAccountPress: () => void;
   isDeleteAccountLoading: boolean;
@@ -18,7 +19,7 @@ const AccountDeleteModal: React.FC<AccountDeleteModalProps> = ({
   setIsModalOpen,
 }) => {
   const theme = useTheme();
-  const styles = useStyles()
+  const styles = useStyles();
 
   const handleModalClose = () => {
     setIsModalOpen(false);

--- a/src/screens/profile/home/account-delete-modal.tsx
+++ b/src/screens/profile/home/account-delete-modal.tsx
@@ -1,9 +1,9 @@
-import { Box, Text, useTheme } from 'native-base';
 import React from 'react';
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
-import { Button, Modal } from 'react-native-template/src/components';
-import { ButtonKind, ButtonColor } from 'react-native-template/src/types/button';
-
+import { Dialog, Portal, useTheme, IconButton, Text, Button } from 'react-native-paper';
+import { View} from 'react-native';
+import Close from 'react-native-template/assets/icons/close.svg';
+import { useStyles}  from './styles'
 interface AccountDeleteModalProps {
   handleDeleteAccountPress: () => void;
   isDeleteAccountLoading: boolean;
@@ -18,40 +18,65 @@ const AccountDeleteModal: React.FC<AccountDeleteModalProps> = ({
   setIsModalOpen,
 }) => {
   const theme = useTheme();
+  const styles = useStyles()
 
   const handleModalClose = () => {
     setIsModalOpen(false);
   };
 
   return (
-    <Modal isModalOpen={isModalOpen} handleModalClose={handleModalClose}>
-      <Modal.Header title="Delete Account" onClose={handleModalClose} />
-      <Modal.Body>
-        <Box alignItems="center">
-          <Text textAlign={'center'}>Are you sure you want to delete your account?</Text>
-        </Box>
-      </Modal.Body>
-      <Modal.Footer>
-        <Box flex={1} mr={2}>
-          <Button onClick={handleModalClose} kind={ButtonKind.OUTLINED}>
-            Cancel
-          </Button>
-        </Box>
-        <Box flex={1} ml={2}>
-          <Button
-            isLoading={isDeleteAccountLoading}
-            onClick={handleDeleteAccountPress}
-            kind={ButtonKind.CONTAINED}
-            color={ButtonColor.DANGER}
-            startEnhancer={
-              <DeleteIcon width={20} height={20} fill={theme.colors.secondary['50']} />
-            }
-          >
-            Delete
-          </Button>
-        </Box>
-      </Modal.Footer>
-    </Modal>
+    <Portal>
+      <Dialog visible={isModalOpen} onDismiss={handleModalClose} style={styles.dialog} >
+        <Dialog.Title>
+          <Text variant="titleLarge" style={styles.heading}>
+            Delete Account
+          </Text>
+        </Dialog.Title>
+        <IconButton
+          icon={() => (
+            <Close width={26} height={26} fill={theme.colors.primary} />
+          )}
+          onPress={handleModalClose}
+          style={styles.close}
+        />
+        <Dialog.Content>
+          <View style={styles.deleteText}>
+            <Text>
+              Are you sure you want to delete your account?
+            </Text>
+          </View>
+
+        </Dialog.Content>
+        <Dialog.Actions>
+          <View style={styles.deleteFooter}>
+            <Button
+              mode="outlined"
+              onPress={handleModalClose}
+              style={styles.button}
+              theme={{
+                colors: {
+                  outline: theme.colors.primary,
+                },
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              mode="contained"
+              onPress={handleDeleteAccountPress}
+              loading={isDeleteAccountLoading}
+              buttonColor={theme.colors.error}
+              style={styles.button}
+              icon={() => (
+                <DeleteIcon width={16} height={16} fill={theme.colors.onError} />
+              )}>
+
+              Delete
+            </Button>
+          </View>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
   );
 };
 

--- a/src/screens/profile/home/index.tsx
+++ b/src/screens/profile/home/index.tsx
@@ -1,50 +1,58 @@
-import { Box, Divider, Toast, useTheme, VStack } from 'native-base';
 import React, { useState } from 'react';
+import { View } from 'react-native';
+import { useTheme, Divider, Snackbar, Button } from 'react-native-paper';
+
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import LogoutIcon from 'react-native-template/assets/icons/logout.svg';
-import { Button } from 'react-native-template/src/components';
 
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
 import { useAccountContext, useAuthContext } from '../../../contexts';
 import { AsyncError } from '../../../types';
-import ProfileLayout from '../profile-layout';
 
+import ProfileLayout from '../profile-layout';
+import { useStyles } from './styles';
 import AccountDeleteModal from './account-delete-modal';
 import ProfileAction from './profile-action';
 import ProfileInfoSection from './profile-info-section';
 
-const Profile: React.FC<ProfileStackScreenProps<'Home'>> = ({ navigation }) => {
-  const theme = useTheme();
+const Profile: React.FC<
+  ProfileStackScreenProps<'Home'>
+> = ({ navigation }) => {
+  const { colors } = useTheme();
+  const styles = useStyles();
 
-  const [isAccountDeleteModalOpen, setIsAccountDeleteModalOpen] = useState(false);
+  const [isAccountDeleteModalOpen, setIsAccountDeleteModalOpen] =
+    useState(false);
 
-  const { deleteAccount, isDeleteAccountLoading, accountDetails } = useAccountContext();
+  const [snackbar, setSnackbar] = useState({
+    visible: false,
+    message: '',
+  });
+
+  const { deleteAccount, isDeleteAccountLoading, accountDetails } =
+    useAccountContext();
   const { logout } = useAuthContext();
 
   const handleAccountDeleteSuccess = () => {
     logout();
-    Toast.show({
-      title: 'Account Deleted',
-      description: 'Your account has been deleted successfully',
+    setSnackbar({
+      visible: true,
+      message: 'Your account has been deleted successfully',
     });
   };
 
   const handleAccountDeleteError = (err: AsyncError) => {
-    Toast.show({
-      title: 'Account Deletion Failed',
-      description: err.message,
+    setSnackbar({
+      visible: true,
+      message: err.message,
     });
   };
 
   const handleDeleteAccount = async () => {
     setIsAccountDeleteModalOpen(false);
     deleteAccount()
-      .then(() => {
-        handleAccountDeleteSuccess();
-      })
-      .catch((err: AsyncError) => {
-        handleAccountDeleteError(err);
-      });
+      .then(handleAccountDeleteSuccess)
+      .catch(handleAccountDeleteError);
   };
 
   const handleEditProfilePress = () => {
@@ -53,17 +61,26 @@ const Profile: React.FC<ProfileStackScreenProps<'Home'>> = ({ navigation }) => {
 
   return (
     <ProfileLayout>
-      <VStack w={'100%'} space={4} divider={<Divider />}>
+      <View style={styles.profileSpacing}>
         <ProfileInfoSection
           accountDetails={accountDetails}
           handleEditProfilePress={handleEditProfilePress}
         />
+
+        <Divider style={{ marginVertical: 12 }} />
+
         <ProfileAction
-          title={'Delete Account'}
-          icon={<DeleteIcon width={20} height={20} fill={theme.colors.primary['500']} />}
+          title="Delete Account"
+          icon={
+            <DeleteIcon
+              width={20}
+              height={20}
+              fill={colors.primary}
+            />
+          }
           onPress={() => setIsAccountDeleteModalOpen(true)}
         />
-      </VStack>
+      </View>
 
       <AccountDeleteModal
         handleDeleteAccountPress={handleDeleteAccount}
@@ -72,14 +89,31 @@ const Profile: React.FC<ProfileStackScreenProps<'Home'>> = ({ navigation }) => {
         setIsModalOpen={setIsAccountDeleteModalOpen}
       />
 
-      <Box w="50%" alignSelf="center" position="absolute" bottom={4}>
+      <View style={styles.buttonSpacing}>
         <Button
-          onClick={logout}
-          startEnhancer={<LogoutIcon width={20} height={20} fill={theme.colors.secondary['50']} />}
+          mode="contained"
+          onPress={logout}
+          style={styles.button}
+          icon={() => (
+            <LogoutIcon
+              width={20}
+              height={20}
+              fill={colors.onPrimary}
+            />
+          )}
         >
           Logout
         </Button>
-      </Box>
+      </View>
+
+      <Snackbar
+        visible={snackbar.visible}
+        onDismiss={() =>
+          setSnackbar({ visible: false, message: '' })
+        }
+      >
+        {snackbar.message}
+      </Snackbar>
     </ProfileLayout>
   );
 };

--- a/src/screens/profile/home/index.tsx
+++ b/src/screens/profile/home/index.tsx
@@ -1,19 +1,18 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import { useTheme, Divider, Snackbar, Button } from 'react-native-paper';
-
 import DeleteIcon from 'react-native-template/assets/icons/delete.svg';
 import LogoutIcon from 'react-native-template/assets/icons/logout.svg';
 
 import { ProfileStackScreenProps } from '../../../../@types/navigation';
 import { useAccountContext, useAuthContext } from '../../../contexts';
 import { AsyncError } from '../../../types';
-
 import ProfileLayout from '../profile-layout';
-import { useStyles } from './styles';
+
 import AccountDeleteModal from './account-delete-modal';
 import ProfileAction from './profile-action';
 import ProfileInfoSection from './profile-info-section';
+import { useStyles } from './styles';
 
 const Profile: React.FC<
   ProfileStackScreenProps<'Home'>

--- a/src/screens/profile/home/profile-action.tsx
+++ b/src/screens/profile/home/profile-action.tsx
@@ -1,24 +1,54 @@
-import { Pressable, HStack, Heading, IPressableProps, useTheme } from 'native-base';
 import React from 'react';
+import { View, Pressable } from 'react-native';
+import { Text, useTheme } from 'react-native-paper';
 import ChevronRightIcon from 'react-native-template/assets/icons/chevron-right.svg';
 
-interface ProfileActionProps extends IPressableProps {
+interface ProfileActionProps {
   title: string;
-  icon: Element;
+  icon: React.ReactNode;
+  onPress?: () => void;
 }
 
-const ProfileAction: React.FC<ProfileActionProps> = ({ title, icon, ...props }) => {
-  const theme = useTheme();
+const ProfileAction: React.FC<ProfileActionProps> = ({
+  title,
+  icon,
+  onPress,
+}) => {
+  const { colors } = useTheme();
 
   return (
-    <Pressable _pressed={{ bg: 'coolGray.200' }} py={2} {...props}>
-      <HStack justifyContent={'space-between'} alignItems={'center'}>
-        <HStack space={2}>
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => ({
+        paddingVertical: 12,
+        paddingHorizontal: 4,
+        backgroundColor: pressed ? colors.surfaceVariant : 'transparent',
+      })}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
           {icon}
-          <Heading size={'sm'}>{title}</Heading>
-        </HStack>
-        <ChevronRightIcon width={20} height={20} fill={theme.colors.primary['500']} />
-      </HStack>
+          <Text variant="titleMedium">{title}</Text>
+        </View>
+
+        <ChevronRightIcon
+          width={20}
+          height={20}
+          fill={colors.primary}
+        />
+      </View>
     </Pressable>
   );
 };

--- a/src/screens/profile/home/profile-info-section.tsx
+++ b/src/screens/profile/home/profile-info-section.tsx
@@ -1,11 +1,9 @@
-import { Box, Heading, Text, useTheme } from 'native-base';
 import React from 'react';
 import EditIcon from 'react-native-template/assets/icons/edit.svg';
-import { Avatar, Button } from 'react-native-template/src/components';
-import { ButtonKind, ButtonSize } from 'react-native-template/src/types/button';
-
+import { View } from 'react-native';
 import { Account, Nullable } from '../../../types';
-
+import { IconButton, Text, useTheme,Avatar } from 'react-native-paper';
+import { useStyles}  from './styles'
 interface ProfileInfoSectionProps {
   accountDetails: Nullable<Account>;
   handleEditProfilePress: () => void;
@@ -16,26 +14,26 @@ const ProfileInfoSection: React.FC<ProfileInfoSectionProps> = ({
   handleEditProfilePress,
 }) => {
   const theme = useTheme();
+  const styles = useStyles()
 
   return (
-    <Box alignItems="center">
-      <Box>
-        <Avatar initials={accountDetails?.initials()} />
-      </Box>
-      <Box
-        borderRadius="full"
-        p={1}
-        flexDirection="row"
-        alignItems="center"
-        justifyContent={'center'}
-      >
-        <Heading mr={2}>{accountDetails?.displayName()}</Heading>
-        <Button onClick={handleEditProfilePress} kind={ButtonKind.LINK} size={ButtonSize.COMPACT}>
-          <EditIcon width={20} height={20} fill={theme.colors.primary['500']} />
-        </Button>
-      </Box>
+    <View style={{ alignItems: "center" }} >
+      <View>
+        <Avatar.Text size={50} label={accountDetails?.initials()} style={styles.avatar} color={theme.colors.primary} />
+      </View>
+      <View style={styles.profile}>
+      
+        <Text variant='titleLarge'>{accountDetails?.displayName()}</Text>
+        <IconButton
+          icon={() => (
+            <EditIcon width={20} height={20} fill={theme.colors.primary} />
+          )}
+          size={20}
+          onPress={handleEditProfilePress}
+        />
+      </View>
       <Text>{accountDetails?.phoneNumber.getFormattedPhoneNumber()}</Text>
-    </Box>
+    </View>
   );
 };
 

--- a/src/screens/profile/home/profile-info-section.tsx
+++ b/src/screens/profile/home/profile-info-section.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import EditIcon from 'react-native-template/assets/icons/edit.svg';
 import { View } from 'react-native';
-import { Account, Nullable } from '../../../types';
 import { IconButton, Text, useTheme,Avatar } from 'react-native-paper';
-import { useStyles}  from './styles'
+import EditIcon from 'react-native-template/assets/icons/edit.svg';
+
+import { Account, Nullable } from '../../../types';
+
+
+import { useStyles }  from './styles';
 interface ProfileInfoSectionProps {
   accountDetails: Nullable<Account>;
   handleEditProfilePress: () => void;
@@ -14,16 +17,16 @@ const ProfileInfoSection: React.FC<ProfileInfoSectionProps> = ({
   handleEditProfilePress,
 }) => {
   const theme = useTheme();
-  const styles = useStyles()
+  const styles = useStyles();
 
   return (
-    <View style={{ alignItems: "center" }} >
+    <View style={{ alignItems: 'center' }} >
       <View>
         <Avatar.Text size={50} label={accountDetails?.initials()} style={styles.avatar} color={theme.colors.primary} />
       </View>
       <View style={styles.profile}>
-      
-        <Text variant='titleLarge'>{accountDetails?.displayName()}</Text>
+
+        <Text variant="titleLarge">{accountDetails?.displayName()}</Text>
         <IconButton
           icon={() => (
             <EditIcon width={20} height={20} fill={theme.colors.primary} />

--- a/src/screens/profile/home/styles.ts
+++ b/src/screens/profile/home/styles.ts
@@ -1,0 +1,63 @@
+import { profile } from 'console';
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+
+export const useStyles = () => {
+    const theme = useTheme()
+
+    return StyleSheet.create({
+        dialog: {
+      borderRadius: 8,
+      backgroundColor: theme.colors.surface,
+    },
+    button: {
+      borderRadius: 6,
+      paddingHorizontal: 6
+    },
+    heading:{
+      color:theme.colors.primary,
+      textAlign:'center',
+      paddingBottom:28
+    },
+    close: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    zIndex: 10,
+  },
+  deleteFooter:{
+    flexDirection:'row',
+    gap:16,
+    justifyContent:'center',
+    width: '100%',
+  },
+  deleteText:{
+    marginVertical:12,
+    alignItems:'center'
+
+  },
+  profile:{
+    borderRadius:"full",
+    padding:1,
+    flexDirection:'row',
+    alignItems:'center',
+    justifyContent:'center'
+  },
+  avatar:{
+    backgroundColor:theme.colors.secondaryContainer,
+
+  },
+  profileSpacing:{
+    width:'100%',
+    gap:4,
+  },
+  buttonSpacing:{
+    width:'50%',
+    alignSelf:'center',
+    position:'absolute',
+    bottom:10
+  }
+
+    })
+};

--- a/src/screens/profile/home/styles.ts
+++ b/src/screens/profile/home/styles.ts
@@ -3,7 +3,7 @@ import { useTheme } from 'react-native-paper';
 
 
 export const useStyles = () => {
-    const theme = useTheme()
+    const theme = useTheme();
 
     return StyleSheet.create({
         dialog: {
@@ -12,12 +12,12 @@ export const useStyles = () => {
     },
     button: {
       borderRadius: 6,
-      paddingHorizontal: 6
+      paddingHorizontal: 6,
     },
     heading:{
       color:theme.colors.primary,
       textAlign:'center',
-      paddingBottom:28
+      paddingBottom:28,
     },
     close: {
     position: 'absolute',
@@ -33,7 +33,7 @@ export const useStyles = () => {
   },
   deleteText:{
     marginVertical:12,
-    alignItems:'center'
+    alignItems:'center',
 
   },
   profile:{
@@ -41,7 +41,7 @@ export const useStyles = () => {
     padding:1,
     flexDirection:'row',
     alignItems:'center',
-    justifyContent:'center'
+    justifyContent:'center',
   },
   avatar:{
     backgroundColor:theme.colors.secondaryContainer,
@@ -55,8 +55,8 @@ export const useStyles = () => {
     width:'50%',
     alignSelf:'center',
     position:'absolute',
-    bottom:10
-  }
+    bottom:10,
+  },
 
-    })
+    });
 };

--- a/src/screens/profile/home/styles.ts
+++ b/src/screens/profile/home/styles.ts
@@ -1,4 +1,3 @@
-import { profile } from 'console';
 import { StyleSheet } from 'react-native';
 import { useTheme } from 'react-native-paper';
 
@@ -38,7 +37,7 @@ export const useStyles = () => {
 
   },
   profile:{
-    borderRadius:"full",
+    borderRadius:9999,
     padding:1,
     flexDirection:'row',
     alignItems:'center',

--- a/src/screens/profile/profile-layout.tsx
+++ b/src/screens/profile/profile-layout.tsx
@@ -1,11 +1,13 @@
-import { Box } from 'native-base';
 import React, { PropsWithChildren } from 'react';
-
+import { View} from 'react-native';
+import { useStyles}  from './styles'
 const ProfileLayout = ({ children }: PropsWithChildren) => {
+  const styles = useStyles()
+
   return (
-    <Box flex={1} bg={'white'} p={4}>
+    <View style={styles.profileLayout}>
       {children}
-    </Box>
+    </View>
   );
 };
 

--- a/src/screens/profile/profile-layout.tsx
+++ b/src/screens/profile/profile-layout.tsx
@@ -1,8 +1,9 @@
 import React, { PropsWithChildren } from 'react';
-import { View} from 'react-native';
-import { useStyles}  from './styles'
+import { View } from 'react-native';
+
+import { useStyles }  from './styles';
 const ProfileLayout = ({ children }: PropsWithChildren) => {
-  const styles = useStyles()
+  const styles = useStyles();
 
   return (
     <View style={styles.profileLayout}>

--- a/src/screens/profile/styles.ts
+++ b/src/screens/profile/styles.ts
@@ -3,14 +3,14 @@ import { useTheme } from 'react-native-paper';
 
 
 export const useStyles = () => {
-    const theme = useTheme()
+    const theme = useTheme();
 
     return StyleSheet.create({
 
         profileLayout: {
             flex: 1,
             backgroundColor: theme.colors.surface,
-            padding: 16
+            padding: 16,
         },
-    })
+    });
 };

--- a/src/screens/profile/styles.ts
+++ b/src/screens/profile/styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+
+export const useStyles = () => {
+    const theme = useTheme()
+
+    return StyleSheet.create({
+
+        profileLayout: {
+            flex: 1,
+            backgroundColor: theme.colors.surface,
+            padding: 16
+        },
+    })
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,164 @@
+import { MD3LightTheme, configureFonts } from 'react-native-paper';
+
+
+const ICOLORHUES = {
+  primary: {
+    '50': '#E6F0FF',
+    '100': '#CCE0FF',
+    '200': '#99C2FF',
+    '300': '#66A3FF',
+    '400': '#3385FF',
+    '500': '#007AFF',
+    '600': '#0066CC',
+    '700': '#0052A3',
+    '800': '#00438C',
+    '900': '#003D7A',
+  },
+  secondary: {
+    '50': '#FAFAFA',
+    '100': '#F5F5F5',
+    '200': '#E5E5E5',
+    '300': '#D4D4D4',
+    '400': '#A3A3A3',
+    '500': '#737373',
+    '600': '#525252',
+    '700': '#404040',
+    '800': '#262626',
+    '900': '#171717',
+  },
+  danger: {
+    '50': '#FEECEC',
+    '100': '#FFD6D6',
+    '200': '#FFADAD',
+    '300': '#FF8484',
+    '400': '#FF5C5C',
+    '500': '#FF3B30',
+    '600': '#E2332B',
+    '700': '#BF2A23',
+    '800': '#991F1A',
+    '900': '#731512',
+  },
+  warning: {
+    '50': '#FFF8E6',
+    '100': '#FFF0CC',
+    '200': '#FFE199',
+    '300': '#FFD166',
+    '400': '#FFC233',
+    '500': '#FFA500',
+    '600': '#E59400',
+    '700': '#CC8400',
+    '800': '#B37300',
+    '900': '#805100',
+  },
+  success: {
+    '50': '#EAFBE9',
+    '100': '#D2F6D1',
+    '200': '#A7E9C4',
+    '300': '#7CE268',
+    '400': '#51D733',
+    '500': '#4BB543',
+    '600': '#38922F',
+    '700': '#2B6E21',
+    '800': '#1B4A14',
+    '900': '#0C2607',
+  },
+  info: {
+    '50': '#E0FCFF',
+    '100': '#BEF8FD',
+    '200': '#87EAF2',
+    '300': '#54D1DB',
+    '400': '#38BEC9',
+    '500': '#2CB1BC',
+    '600': '#14919B',
+    '700': '#0E7C86',
+    '800': '#0A6C74',
+    '900': '#044E54',
+  },
+};
+
+
+const fontConfig = {
+  headlineLarge: {
+    fontSize: 28,
+    fontWeight: '600' as const,
+    lineHeight: 32,
+  },
+  headlineMedium: {
+    fontSize: 26,
+    fontWeight: '600' as const,
+    lineHeight: 32,
+  },
+  titleLarge: {
+    fontSize: 20,
+    fontWeight: '600' as const,
+    lineHeight: 24,
+  },
+  titleMedium: {
+    fontSize: 18,
+    fontWeight: '500' as const,
+    lineHeight: 22,
+  },
+  bodyLarge: {
+    fontSize: 20,
+    fontWeight: '500' as const,
+    lineHeight: 24,
+  },
+  bodyMedium: {
+    fontSize: 16,
+    fontWeight: '500' as const,
+    lineHeight: 20,
+  },
+};
+
+export const theme= {
+  ...MD3LightTheme,
+  myOwnProperty: true,
+  
+  colors: {
+    ...MD3LightTheme.colors,
+
+    primary: ICOLORHUES.primary['500'],
+    primaryContainer: ICOLORHUES.primary['100'],
+    onPrimary: '#FFFFFF',
+    onPrimaryContainer: ICOLORHUES.primary['900'],
+ 
+
+    secondary: ICOLORHUES.secondary['500'],
+    secondaryContainer: ICOLORHUES.secondary['200'],
+    onSecondary: '#FFFFFF',
+    onSecondaryContainer: ICOLORHUES.secondary['900'],
+
+    
+    error: ICOLORHUES.danger['500'],
+    errorContainer: ICOLORHUES.danger['100'],
+    onError: '#FFFFFF',
+    onErrorContainer: ICOLORHUES.danger['900'],
+
+    surface: '#FFFFFF', 
+    surfaceVariant: ICOLORHUES.secondary['50'],
+    onSurface: ICOLORHUES.secondary['900'],
+    onSurfaceVariant: ICOLORHUES.secondary['700'],
+    outline: ICOLORHUES.secondary['200'],
+    
+    success: ICOLORHUES.success['500'],
+    successContainer: ICOLORHUES.success['100'],
+    onSuccess: '#FFFFFF',
+    onSuccessContainer: ICOLORHUES.success['900'],
+    
+    warning: ICOLORHUES.warning['500'],
+    warningContainer: ICOLORHUES.warning['100'],
+    onWarning: '#000000',
+    onWarningContainer: ICOLORHUES.warning['900'],
+    
+    info: ICOLORHUES.info['500'],
+    infoContainer: ICOLORHUES.info['100'],
+    onInfo: '#FFFFFF',
+    onInfoContainer: ICOLORHUES.info['900'],
+  },
+  fonts: configureFonts({ config: fontConfig }),
+  customColors: ICOLORHUES,
+};
+
+
+export type AppTheme = typeof theme;
+

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -112,7 +112,7 @@ const fontConfig = {
 
 export const theme = {
   ...MD3LightTheme,
-  
+
   colors: {
     ...MD3LightTheme.colors,
 
@@ -120,35 +120,35 @@ export const theme = {
     primaryContainer: ICOLORHUES.primary['100'],
     onPrimary: '#FFFFFF',
     onPrimaryContainer: ICOLORHUES.primary['900'],
- 
+
 
     secondary: ICOLORHUES.secondary['500'],
     secondaryContainer: ICOLORHUES.secondary['200'],
     onSecondary: '#FFFFFF',
     onSecondaryContainer: ICOLORHUES.secondary['900'],
 
-    
+
     error: ICOLORHUES.danger['500'],
     errorContainer: ICOLORHUES.danger['100'],
     onError: '#FFFFFF',
     onErrorContainer: ICOLORHUES.danger['900'],
 
-    surface: '#FFFFFF', 
+    surface: '#FFFFFF',
     surfaceVariant: ICOLORHUES.secondary['50'],
     onSurface: ICOLORHUES.secondary['900'],
     onSurfaceVariant: ICOLORHUES.secondary['700'],
     outline: ICOLORHUES.secondary['200'],
-    
+
     success: ICOLORHUES.success['500'],
     successContainer: ICOLORHUES.success['100'],
     onSuccess: '#FFFFFF',
     onSuccessContainer: ICOLORHUES.success['900'],
-    
+
     warning: ICOLORHUES.warning['500'],
     warningContainer: ICOLORHUES.warning['100'],
     onWarning: '#000000',
     onWarningContainer: ICOLORHUES.warning['900'],
-    
+
     info: ICOLORHUES.info['500'],
     infoContainer: ICOLORHUES.info['100'],
     onInfo: '#FFFFFF',

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -110,9 +110,8 @@ const fontConfig = {
   },
 };
 
-export const theme= {
+export const theme = {
   ...MD3LightTheme,
-  myOwnProperty: true,
   
   colors: {
     ...MD3LightTheme.colors,

--- a/src/theme/useAppTheme.ts
+++ b/src/theme/useAppTheme.ts
@@ -1,4 +1,5 @@
 import { useTheme } from 'react-native-paper';
+
 import type { AppTheme } from './index';
 
 export const useAppTheme = () => {

--- a/src/theme/useAppTheme.ts
+++ b/src/theme/useAppTheme.ts
@@ -1,0 +1,6 @@
+import { useTheme } from 'react-native-paper';
+import type { AppTheme } from './index';
+
+export const useAppTheme = () => {
+  return useTheme<AppTheme>();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@callstack/react-theme-provider@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "@callstack/react-theme-provider@npm:3.0.9"
+  dependencies:
+    deepmerge: ^3.2.0
+    hoist-non-react-statics: ^3.3.0
+  peerDependencies:
+    react: ">=16.3.0"
+  checksum: f888ef0b8f993d393a9d49864f75b04b5cf7259e72f290ec570fc5e314315f75c979b03b391243a72578ab55db4ffcdd4dc9dc1a2f8ec2b516cabb958971a85e
+  languageName: node
+  linkType: hard
+
 "@datadog/mobile-react-native-session-replay@npm:^2.8.0":
   version: 2.14.0
   resolution: "@datadog/mobile-react-native-session-replay@npm:2.14.0"
@@ -5444,7 +5456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -5476,13 +5488,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-string@npm:^1.9.0":
+"color-string@npm:^1.6.0, color-string@npm:^1.9.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
   dependencies:
     color-name: ^1.0.0
     simple-swizzle: ^0.2.2
   checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.2":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: ^1.9.3
+    color-string: ^1.6.0
+  checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
   languageName: node
   linkType: hard
 
@@ -5876,6 +5898,13 @@ __metadata:
   version: 2.2.1
   resolution: "deepmerge@npm:2.2.1"
   checksum: 284b71065079e66096229f735a9a0222463c9ca9ee9dda7d5e9a0545bf254906dbc7377e3499ca3b2212073672b1a430d80587993b43b87d8de17edc6af649a8
+  languageName: node
+  linkType: hard
+
+"deepmerge@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "deepmerge@npm:3.3.0"
+  checksum: 4322195389e0170a0443c07b36add19b90249802c4b47b96265fdc5f5d8beddf491d5e50cbc5bfd65f85ccf76598173083863c202f5463b3b667aca8be75d5ac
   languageName: node
   linkType: hard
 
@@ -10672,6 +10701,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-paper@npm:^5.14.5":
+  version: 5.14.5
+  resolution: "react-native-paper@npm:5.14.5"
+  dependencies:
+    "@callstack/react-theme-provider": ^3.0.9
+    color: ^3.1.2
+    use-latest-callback: ^0.2.3
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-safe-area-context: "*"
+  checksum: f986937ebeb2cdea338d384dfc7814d2c0dbe3e8cd3645ce720832b78f588eccf3fc490bf1afb942a9d6046cd842984c011316c4d9c2fabf59a38ae1a47fccb3
+  languageName: node
+  linkType: hard
+
 "react-native-reanimated@npm:3.16.7":
   version: 3.16.7
   resolution: "react-native-reanimated@npm:3.16.7"
@@ -10815,6 +10859,7 @@ __metadata:
     react-native-config: 1.5.3
     react-native-error-boundary: ^1.2.4
     react-native-gesture-handler: 2.19.0
+    react-native-paper: ^5.14.5
     react-native-reanimated: 3.16.7
     react-native-safe-area-context: 4.10.9
     react-native-screens: ^3.34.0
@@ -12359,7 +12404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-latest-callback@npm:^0.2.1":
+"use-latest-callback@npm:^0.2.1, use-latest-callback@npm:^0.2.3":
   version: 0.2.6
   resolution: "use-latest-callback@npm:0.2.6"
   peerDependencies:


### PR DESCRIPTION
## Overview
This PR introduces the initial phase of the React Native Paper migration. It sets up the Paper theme and migrates the Auth, Dashboard, and Profile screens away from NativeBase and custom UI components, aligning them with the new design system foundation.

## Changes
**React Native Paper Setup**

- Added React Native Paper and configured the application theme
- Wrapped the app with PaperProvider
- Mapped existing design system colors and typography to Paper theme tokens

## Screen Migration
Migrated the following screens to React Native Paper components:

- Auth Screens
 change-api-url
 otp-verify
phone-auth
 registration
auth-layout

- DashBoard
 task
 task-delete-modal
 task-header
  task-add-edit-modal

- Profile
profile-layout
account delete-modal
profile-info-section
edit-profile

- Replaced custom UI components with React Native Paper equivalents
- Removed NativeBase usage from the above screens
- Preserved existing layouts, flows, and screen behavior

### Verification
loom video for ios version testing-https://www.loom.com/share/d407caa7fca449abb50dd4f2fc6c89cf

Note: The phone-auth-form currently retains the NativeBase checkbox due to an icon rendering issue with React Native Paper’s checkbox component. This will be addressed in a follow-up PR.

