### PR TITLE
Feat/react native paper setup

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 
 ENVIRONMENT=development
 # This is a permanent preview URL from: https://github.com/jalantechnologies/flask-react-template
-API_BASE_URL=http://localhost:8080/api
+API_BASE_URL=https://preview.flask-react-template.platform.bettrhq.com/api
 
 DD_APPLICATION_ID=6755ccc7-0bf2-443e-bd4e-8df82d66f19d
 DD_CLIENT_TOKEN=pubad56f120eb0de2c58f2c976eac4d292c

--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 
 ENVIRONMENT=development
 # This is a permanent preview URL from: https://github.com/jalantechnologies/flask-react-template
-API_BASE_URL=https://preview.flask-react-template.platform.bettrhq.com/api
+API_BASE_URL=http://localhost:8080/api
 
 DD_APPLICATION_ID=6755ccc7-0bf2-443e-bd4e-8df82d66f19d
 DD_CLIENT_TOKEN=pubad56f120eb0de2c58f2c976eac4d292c

--- a/docs/release_notes/1.0.17.md
+++ b/docs/release_notes/1.0.17.md
@@ -1,0 +1,5 @@
+v1.0.17
+- Added React Native Paper as the core UI component library
+- Introduced a custom MD3 theme with centralized colors and typography
+- Migrated auth screens from NativeBase to React Native Paper
+- Removed legacy custom components from authentication screens

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {
@@ -39,6 +39,7 @@
     "react-native-config": "1.5.3",
     "react-native-error-boundary": "^1.2.4",
     "react-native-gesture-handler": "2.19.0",
+    "react-native-paper": "^5.14.5",
     "react-native-reanimated": "3.16.7",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "^3.34.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import { DatadogProvider } from '@datadog/mobile-react-native';
 import { NativeBaseProvider } from 'native-base';
 import React, { useCallback } from 'react';
 import ErrorBoundary from 'react-native-error-boundary';
+import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 
 import appTheme from './app-theme';
@@ -12,13 +13,15 @@ import Logger from './logger/logger';
 import ApplicationNavigator from './navigators/application';
 import './translations';
 import DatadogConfig, { onDataDogSDKInitialized } from './services/datadog';
+import { theme } from './theme';
 
 const App = () => {
   Logger.initializeLoggers();
   const ErrorComponent = useCallback(() => <ErrorFallback />, []);
 
   return (
-    <NativeBaseProvider theme={appTheme}>
+    <PaperProvider theme={theme} >
+      <NativeBaseProvider theme={appTheme}>
       <ErrorBoundary
         onError={(e, stack) => Logger.error(`App Error: ${e} ${stack}`)}
         FallbackComponent={ErrorComponent}
@@ -36,6 +39,7 @@ const App = () => {
         </DatadogProvider>
       </ErrorBoundary>
     </NativeBaseProvider>
+    </PaperProvider>
   );
 };
 

--- a/src/screens/auth/auth-layout.tsx
+++ b/src/screens/auth/auth-layout.tsx
@@ -1,6 +1,6 @@
-import { useTheme } from 'native-base';
 import React, { PropsWithChildren } from 'react';
-import { Keyboard, Platform, TouchableWithoutFeedback, View, Text, ScrollView, KeyboardAvoidingView, StyleSheet, StatusBar } from 'react-native';
+import { Keyboard, Platform, TouchableWithoutFeedback, View, ScrollView, KeyboardAvoidingView, StyleSheet, StatusBar } from 'react-native';
+import { useTheme,Text } from 'react-native-paper';
 
 import ChangeApiUrlButton from './change-api-url/change-api-url';
 
@@ -15,7 +15,7 @@ const useAuthLayoutStyles = () => {
   return StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: theme.colors.primary['500'],
+      backgroundColor: theme.colors.primary,
     },
     flex: {
       flex: 1,
@@ -24,9 +24,12 @@ const useAuthLayoutStyles = () => {
       flexGrow: 1,
     },
     header: {
-      backgroundColor: theme.colors.primary['500'],
-      paddingTop: Platform.OS === 'android' ? (StatusBar.currentHeight || 24) + Number(theme.space['4']) : Number(theme.space['10']) + Number(theme.space['4']),
-      paddingBottom: Number(theme.space['4']),
+      backgroundColor: theme.colors.primary,
+      paddingTop:
+        Platform.OS === 'android'
+          ? (StatusBar.currentHeight || 24) + 16
+          : 44,
+      paddingBottom: 16,
       paddingHorizontal: '5%',
     },
     titleRow: {
@@ -39,24 +42,25 @@ const useAuthLayoutStyles = () => {
       paddingHorizontal: '5%',
     },
     title: {
-      fontSize: Number(theme.fontSizes['4xl']),
-      fontWeight: 'bold',
-      color: theme.colors.secondary['50'],
+      fontSize: 32,
+      fontWeight: '700',
+      color: theme.colors.surfaceVariant,
     },
     cardContainer: {
       flex: 1,
-      backgroundColor: theme.colors.white,
-      borderTopLeftRadius: Number(theme.radii['2xl']),
-      borderTopRightRadius: Number(theme.radii['2xl']),
+      backgroundColor: theme.colors.surface,
+      borderTopLeftRadius: 24,
+      borderTopRightRadius: 24,
     },
     cardContent: {
       flex: 1,
-      paddingTop: Number(theme.space['6']),
-      paddingBottom: Number(theme.space['8']),
+      paddingTop: 24,
+      paddingBottom: 32,
       paddingHorizontal: '10%',
     },
   });
 };
+
 
 const AuthLayout: React.FC<PropsWithChildren<AuthLayoutProps>> = ({
   primaryTitle,
@@ -73,7 +77,7 @@ const AuthLayout: React.FC<PropsWithChildren<AuthLayoutProps>> = ({
             <View style={styles.header}>
               <View style={styles.titleRow}>
                 <View style={styles.titleContainer}>
-                  <Text style={styles.title}>{primaryTitle}</Text>
+                  <Text style={styles.title} >{primaryTitle}</Text>
                   <Text style={styles.title}>{secondaryTitle}</Text>
                 </View>
                 <ChangeApiUrlButton />

--- a/src/screens/auth/change-api-url/change-api-url-modal.tsx
+++ b/src/screens/auth/change-api-url/change-api-url-modal.tsx
@@ -68,7 +68,7 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
           />
 
         </Dialog.Content>
-        <Dialog.Actions style={styles.ButtonSection}>
+        <Dialog.Actions style={styles.buttonSection}>
           <Button
             mode="outlined"
             style={styles.button}
@@ -92,6 +92,7 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
       <Snackbar
         visible={snackbarVisible}
         onDismiss={() => setSnackbarVisible(false)}
+        duration={3000}
       >
         API Base URL cannot be empty
       </Snackbar>

--- a/src/screens/auth/change-api-url/change-api-url-modal.tsx
+++ b/src/screens/auth/change-api-url/change-api-url-modal.tsx
@@ -1,14 +1,19 @@
-import { Toast } from 'native-base';
 import React, { useEffect, useState } from 'react';
 import Config from 'react-native-config';
-import { FormControl, Input, Modal } from 'react-native-template/src/components';
+import { Dialog, Portal, Text, useTheme, IconButton, TextInput, Button, Snackbar } from 'react-native-paper';
+import Close from 'react-native-template/assets/icons/close.svg';
 import { ModalProps } from 'react-native-template/src/components/modal/modal';
 import { useLocalStorage } from 'react-native-template/src/utils';
 
+import { ChangeApiUrlStyles } from './change-api-url.style';
 const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose }) => {
   const localStorage = useLocalStorage();
+  const theme = useTheme();
+  const styles = ChangeApiUrlStyles();
 
   const [apiBaseUrl, setApiBaseUrl] = useState(Config.API_BASE_URL as string);
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+
 
   useEffect(() => {
     const loadApiBaseUrl = async () => {
@@ -22,9 +27,7 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
 
   const handleSaveChanges = async () => {
     if (!apiBaseUrl) {
-      Toast.show({
-        title: 'API Base URL can not be empty',
-      });
+      setSnackbarVisible(true);
       return;
     }
 
@@ -36,24 +39,64 @@ const ChangeApiUrlModal: React.FC<ModalProps> = ({ isModalOpen, handleModalClose
   };
 
   return (
-    <Modal isModalOpen={isModalOpen} handleModalClose={handleModalClose}>
-      <Modal.Header title="Change Base API URL" onClose={handleModalClose} />
-      <Modal.Body>
-        <FormControl label="New Base API URL">
-          <Input
+    <Portal>
+      <Dialog visible={isModalOpen} onDismiss={handleModalClose} style={styles.dialog}>
+        <Dialog.Title style={{ marginBottom: 38 }}>
+          <Text variant="titleMedium"
+            style={styles.heading}  >
+            Change Base API URL
+          </Text>
+        </Dialog.Title>
+        <IconButton
+          icon={() => (
+            <Close width={26} height={26} fill={theme.colors.primary} />
+          )}
+          onPress={handleModalClose}
+          style={styles.close}
+        />
+        <Dialog.Content>
+          <Text style={styles.text}>New Base API URL</Text>
+          <TextInput
             value={apiBaseUrl}
-            onChangeText={e => {
-              setApiBaseUrl(e);
+            onChangeText={text => {
+              setApiBaseUrl(text);
             }}
+            mode="outlined"
+            autoCapitalize="none"
+            autoCorrect={false}
+            style={{ backgroundColor: theme.colors.surface }}
           />
-        </FormControl>
-      </Modal.Body>
-      <Modal.Footer
-        onCancel={handleModalClose}
-        onConfirm={handleSaveChanges}
-        confirmText="Save Changes"
-      />
-    </Modal>
+
+        </Dialog.Content>
+        <Dialog.Actions style={styles.ButtonSection}>
+          <Button
+            mode="outlined"
+            style={styles.button}
+            onPress={handleModalClose}
+            theme={{
+              colors: {
+                outline: theme.colors.primary,
+              },
+            }}>
+            Cancel
+          </Button>
+          <Button
+            mode="contained"
+            style={styles.button}
+            onPress={handleSaveChanges}>
+            Save Changes
+          </Button>
+        </Dialog.Actions>
+
+      </Dialog>
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+      >
+        API Base URL cannot be empty
+      </Snackbar>
+
+    </Portal>
   );
 };
 

--- a/src/screens/auth/change-api-url/change-api-url.style.ts
+++ b/src/screens/auth/change-api-url/change-api-url.style.ts
@@ -29,7 +29,7 @@ export const ChangeApiUrlStyles = () => {
             textAlign:'center',
             marginBottom:43,
         },
-        ButtonSection:{
+        buttonSection:{
             justifyContent:'center',
             gap:24,
         },

--- a/src/screens/auth/change-api-url/change-api-url.style.ts
+++ b/src/screens/auth/change-api-url/change-api-url.style.ts
@@ -1,0 +1,37 @@
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+export const ChangeApiUrlStyles = () => {
+    const theme = useTheme();
+    return StyleSheet.create({
+        close: {
+            position: 'absolute',
+            top: 8,
+            right: 8,
+            zIndex: 10,
+        },
+
+        dialog: {
+            borderRadius: 8,
+            backgroundColor: theme.colors.surface,
+        },
+        button: {
+            borderRadius: 6,
+            paddingHorizontal:12,
+
+        },
+        text:{
+            color:theme.colors.primary,
+            marginBottom:10,
+            fontWeight:'600',
+        },
+        heading:{
+            color:theme.colors.primary,
+            textAlign:'center',
+            marginBottom:43,
+        },
+        ButtonSection:{
+            justifyContent:'center',
+            gap:24,
+        },
+    });
+};

--- a/src/screens/auth/change-api-url/change-api-url.tsx
+++ b/src/screens/auth/change-api-url/change-api-url.tsx
@@ -1,19 +1,16 @@
-import { useTheme } from 'native-base';
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Config from 'react-native-config';
+import { useTheme, IconButton } from 'react-native-paper';
 import GearIcon from 'react-native-template/assets/icons/gear.svg';
-import { Button } from 'react-native-template/src/components';
-import { ButtonKind } from 'react-native-template/src/types/button';
 
 import ChangeApiUrlModal from './change-api-url-modal';
 
 const useChangeApiUrlStyles = () => {
-  const theme = useTheme();
 
   return StyleSheet.create({
     buttonContainer: {
-      paddingTop: Number(theme.space['2']),
+      paddingTop: Number(2),
     },
   });
 };
@@ -34,9 +31,17 @@ const ChangeApiUrlButton = () => {
     isNonProdEnv && (
       <>
         <View style={styles.buttonContainer}>
-          <Button onClick={() => setIsChangeAPIUrlModalOpen(true)} kind={ButtonKind.LINK}>
-            <GearIcon width={24} height={24} fill={theme.colors.secondary[100]} />
-          </Button>
+          <IconButton
+            icon={() => (
+              <GearIcon
+                width={24}
+                height={24}
+                fill={theme.colors.secondaryContainer}
+              />
+            )}
+            size={24}
+            onPress={() => setIsChangeAPIUrlModalOpen(true)}
+          />
         </View>
         <ChangeApiUrlModal
           handleModalClose={() => setIsChangeAPIUrlModalOpen(false)}

--- a/src/screens/auth/otp-verify/index.tsx
+++ b/src/screens/auth/otp-verify/index.tsx
@@ -1,6 +1,7 @@
-import { Toast } from 'native-base';
 import React from 'react';
+import { useState } from 'react';
 import { Alert } from 'react-native';
+import { Snackbar } from 'react-native-paper';
 
 import { MainScreenProps } from '../../../../@types/navigation';
 import { AsyncError } from '../../../types';
@@ -16,6 +17,7 @@ const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
   const { startTimer, remainingSecondsStr, isResendEnabled } = useTimer({
     delayInMilliseconds: sendOTPDelayInMilliseconds,
   });
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
 
   const onError = (error: AsyncError) => {
     Alert.alert('Error', error.message);
@@ -26,9 +28,7 @@ const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
   };
 
   const onVerifyOTPSuccess = () => {
-    Toast.show({
-      title: 'OTP verified successfully',
-    });
+    setSnackbarVisible(true);
   };
 
   return (
@@ -42,6 +42,17 @@ const OTPVerify: React.FC<MainScreenProps<'OTPVerify'>> = ({ route }) => {
         phoneNumber={phoneNumber}
         remainingSecondsStr={remainingSecondsStr}
       />
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+        duration={3000}
+        action={{
+          label: 'OK',
+          onPress: () => setSnackbarVisible(false),
+        }}
+      >
+        OTP verified successfully
+      </Snackbar>
     </AuthLayout>
   );
 };

--- a/src/screens/auth/otp-verify/otp-form.styles.ts
+++ b/src/screens/auth/otp-verify/otp-form.styles.ts
@@ -1,0 +1,41 @@
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+export const useOtpFormStyles = () => {
+    const theme = useTheme();
+    return StyleSheet.create({
+        containerOtp: {
+            flexDirection: 'row',
+            gap:12,
+            marginBottom:22,
+        },
+        input: {
+            width: 68,
+            textAlign: 'center',
+            backgroundColor:theme.colors.surface,
+        },
+        container: {
+            flex: 1,
+            justifyContent: 'space-between',
+        },
+        label: {
+            color:theme.colors.primary,
+            marginTop:34,
+            marginBottom:12,
+        },
+        resendRow: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+
+        },
+        resend: {
+            color:theme.colors.primary,
+        },
+        resendDisabled: {
+            opacity: 0.5,
+        },
+         Button: {
+            borderRadius: 8,
+        },
+    });
+};

--- a/src/screens/auth/otp-verify/otp-form.styles.ts
+++ b/src/screens/auth/otp-verify/otp-form.styles.ts
@@ -34,7 +34,7 @@ export const useOtpFormStyles = () => {
         resendDisabled: {
             opacity: 0.5,
         },
-         Button: {
+        button: {
             borderRadius: 8,
         },
     });

--- a/src/screens/auth/otp-verify/otp-form.tsx
+++ b/src/screens/auth/otp-verify/otp-form.tsx
@@ -1,12 +1,13 @@
-import { Box, Center, Container, Heading, HStack, Link, Text, VStack } from 'native-base';
 import React from 'react';
+import { View } from 'react-native';
+import { Text, Button } from 'react-native-paper';
 
-import { Button, FormControl, OTPInput } from '../../../components';
 import { AuthOptions } from '../../../constants';
 import { AsyncError } from '../../../types';
 
 import useOTPForm from './otp-form-hook';
-
+import { useOtpFormStyles } from './otp-form.styles';
+import PaperOTPInput from './otp-input';
 interface OTPFormProps {
   countryCode: string;
   isResendEnabled: boolean;
@@ -33,51 +34,51 @@ const OTPForm: React.FC<OTPFormProps> = ({
     countryCode,
     phoneNumber,
   });
-
-  const handleSetOtp = (otp: string[]) => {
-    formik.setFieldValue('otp', otp);
-  };
+  const styles = useOtpFormStyles();
 
   return (
-    <Box flex={1} pb={4}>
-      <VStack space={6} flex={1} mb={8}>
-        <Container>
-          <Heading size="lg">Verify OTP</Heading>
-        </Container>
-        <Box mt={3}>
-          <FormControl label="Enter your otp sent to your mobile number">
-            <Center>
-              <OTPInput
-                length={AuthOptions.OTPLength}
-                otp={formik.values.otp}
-                setOtp={handleSetOtp}
-              />
-            </Center>
-          </FormControl>
+    <View style={styles.container}>
+      <View >
+        <Text variant="titleLarge">Verify OTP</Text>
 
-          <HStack flexWrap="wrap" alignItems="baseline" mt={2}>
-            <Text fontSize="xs">Didn't receive the OTP? </Text>
-            <Link
-              onPress={handleResendOTP}
-              _text={{
-                fontSize: 'xs',
-                color: isResendEnabled ? 'primary.500' : 'coolGray.600',
-              }}
-            >
-              {isResendEnabled ? 'Resend OTP' : `Resend OTP in 00:${remainingSecondsStr}`}
-            </Link>
-          </HStack>
-        </Box>
-      </VStack>
+        <Text variant="bodySmall" style={styles.label}>
+          Enter the OTP sent to your mobile number
+        </Text>
+
+        <PaperOTPInput
+          length={AuthOptions.OTPLength}
+          value={formik.values.otp}
+          onChange={(otp) => formik.setFieldValue('otp', otp)}
+        />
+
+        <View style={styles.resendRow}>
+          <Text variant="bodySmall">Didn't receive the OTP? </Text>
+          <Text
+            variant="bodySmall"
+            style={[
+              styles.resend,
+              !isResendEnabled && styles.resendDisabled,
+
+            ]}
+            onPress={isResendEnabled ? handleResendOTP : undefined}
+          >
+            {isResendEnabled
+              ? 'Resend OTP'
+              : `Resend OTP in 00:${remainingSecondsStr}`}
+          </Text>
+        </View>
+      </View>
 
       <Button
-        isLoading={isVerifyOTPLoading}
-        onClick={() => formik.handleSubmit()}
+        mode="contained"
+        loading={isVerifyOTPLoading}
+        onPress={() => formik.handleSubmit()}
         disabled={!(formik.isValid && formik.dirty)}
+        style={styles.Button}
       >
         Verify OTP
       </Button>
-    </Box>
+    </View>
   );
 };
 

--- a/src/screens/auth/otp-verify/otp-form.tsx
+++ b/src/screens/auth/otp-verify/otp-form.tsx
@@ -74,7 +74,7 @@ const OTPForm: React.FC<OTPFormProps> = ({
         loading={isVerifyOTPLoading}
         onPress={() => formik.handleSubmit()}
         disabled={!(formik.isValid && formik.dirty)}
-        style={styles.Button}
+        style={styles.button}
       >
         Verify OTP
       </Button>

--- a/src/screens/auth/otp-verify/otp-input.tsx
+++ b/src/screens/auth/otp-verify/otp-input.tsx
@@ -1,0 +1,62 @@
+import React, { useRef } from 'react';
+import { View, NativeSyntheticEvent, TextInputKeyPressEventData } from 'react-native';
+import { TextInput } from 'react-native-paper';
+
+import { useOtpFormStyles } from './otp-form.styles';
+interface PaperOTPInputProps {
+    length: number;
+    value: string[];
+    onChange: (otp: string[]) => void;
+}
+
+const PaperOTPInput: React.FC<PaperOTPInputProps> = ({
+    length,
+    value,
+    onChange,
+}) => {
+    const inputs = useRef<Array<React.ElementRef<typeof TextInput> | null>>([]);
+
+    const handleChange = (text: string, index: number) => {
+        const digit = text.replace(/[^0-9]/g, '').slice(-1);
+        const newOtp = [...value];
+        newOtp[index] = digit;
+        onChange(newOtp);
+
+        if (digit && index < length - 1) {
+            inputs.current[index + 1]?.focus();
+        }
+    };
+
+    const handleKeyPress = (
+        e: NativeSyntheticEvent<TextInputKeyPressEventData>,
+        index: number
+    ) => {
+        if (e.nativeEvent.key === 'Backspace' && !value[index] && index > 0) {
+            inputs.current[index - 1]?.focus();
+        }
+    };
+    const styles = useOtpFormStyles();
+
+    return (
+    <View style={styles.containerOtp}>
+      {Array.from({ length }).map((_, index) => (
+        <TextInput
+          key={index}
+          ref={(el: React.ElementRef<typeof TextInput> | null) => {
+            inputs.current[index] = el;
+          }}
+          mode="outlined"
+          keyboardType="number-pad"
+          maxLength={1}
+          value={value[index] || ''}
+          onChangeText={(text) => handleChange(text, index)}
+          onKeyPress={(e) => handleKeyPress(e, index)}
+          style={styles.input}
+          autoFocus={index === 0}
+        />
+      ))}
+    </View>
+    );
+};
+
+export default PaperOTPInput;

--- a/src/screens/auth/phone-auth/index.tsx
+++ b/src/screens/auth/phone-auth/index.tsx
@@ -29,6 +29,7 @@ const PhoneAuth: React.FC = () => {
       <Snackbar
         visible={snackbarVisible}
         onDismiss={() => setSnackbarVisible(false)}
+        duration={3000}
       >
         {snackbarMessage}
       </Snackbar>

--- a/src/screens/auth/phone-auth/index.tsx
+++ b/src/screens/auth/phone-auth/index.tsx
@@ -1,5 +1,5 @@
-import { Toast } from 'native-base';
-import React from 'react';
+import React, { useState } from 'react';
+import { Snackbar } from 'react-native-paper';
 
 import { AsyncError } from '../../../types';
 import AuthLayout from '../auth-layout';
@@ -7,22 +7,32 @@ import AuthLayout from '../auth-layout';
 import PhoneAuthForm from './phone-auth-form';
 
 const PhoneAuth: React.FC = () => {
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
   const onSuccess = () => {
-    Toast.show({
-      title: 'OTP sent successfully',
-    });
+    setSnackbarMessage('OTP sent successfully');
+    setSnackbarVisible(true);
   };
 
   const onError = (err: AsyncError) => {
-    Toast.show({
-      title: err.message,
-    });
+    setSnackbarMessage(err.message);
+    setSnackbarVisible(true);
   };
 
   return (
-    <AuthLayout primaryTitle="Better." secondaryTitle="">
-      <PhoneAuthForm onSuccess={onSuccess} onError={onError} />
-    </AuthLayout>
+    <>
+      <AuthLayout primaryTitle="Better." secondaryTitle="">
+        <PhoneAuthForm onSuccess={onSuccess} onError={onError} />
+      </AuthLayout>
+
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+      >
+        {snackbarMessage}
+      </Snackbar>
+    </>
   );
 };
 

--- a/src/screens/auth/phone-auth/phone-auth-form.styles.ts
+++ b/src/screens/auth/phone-auth/phone-auth-form.styles.ts
@@ -1,20 +1,75 @@
-import { useTheme } from 'native-base';
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
 
 export const usePhoneAuthFormStyles = () => {
-  const { colors, radii } = useTheme();
+  const theme = useTheme();
 
-  return {
-    inputBox: {
-      borderRadius: radii.md,
+  return StyleSheet.create({
+    phoneAuthScreen: {
+      flex: 1,
+      paddingBottom: 16,
     },
+
+    Login: {
+      flex: 1,
+      marginBottom: 24,
+      gap:6,
+    },
+
+    loginSpacing: {
+      marginBottom: 32,
+    },
+
+    Checkbox: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      marginTop: 16,
+    },
+
+    checkboxTextSpacing: {
+      marginLeft: 12,
+    },
+
+    inputBox: {
+      borderRadius: 8,
+      flex:3,
+      justifyContent:'center',
+    },
+
     errorStyle: {
-      borderColor: colors.danger[600],
+      borderColor: theme.colors.error,
       borderWidth: 1,
     },
+
     errorText: {
-      color: colors.danger[600],
+      color: theme.colors.error,
       fontSize: 14,
       marginTop: 4,
     },
-  };
+
+    Button: {
+      borderRadius: 8,
+    },
+
+    row: {
+      gap:9,
+      width:'100%',
+      flexDirection:'row',
+      marginTop:8,
+    },
+    text:{
+      color:theme.colors.primary,
+    },
+    checkBox:{
+      flexDirection:'row',
+    },
+    menu:{
+        borderWidth: 1,
+        borderColor: theme.colors.outline,
+        paddingHorizontal: 8,
+        justifyContent: 'center',
+        borderRadius: 4,
+        minHeight: 56,
+    },
+  });
 };

--- a/src/screens/auth/phone-auth/phone-auth-form.styles.ts
+++ b/src/screens/auth/phone-auth/phone-auth-form.styles.ts
@@ -10,7 +10,7 @@ export const usePhoneAuthFormStyles = () => {
       paddingBottom: 16,
     },
 
-    Login: {
+    login: {
       flex: 1,
       marginBottom: 24,
       gap:6,
@@ -20,7 +20,7 @@ export const usePhoneAuthFormStyles = () => {
       marginBottom: 32,
     },
 
-    Checkbox: {
+    checkBox: {
       flexDirection: 'row',
       alignItems: 'flex-start',
       marginTop: 16,
@@ -47,7 +47,7 @@ export const usePhoneAuthFormStyles = () => {
       marginTop: 4,
     },
 
-    Button: {
+    button: {
       borderRadius: 8,
     },
 
@@ -60,9 +60,7 @@ export const usePhoneAuthFormStyles = () => {
     text:{
       color:theme.colors.primary,
     },
-    checkBox:{
-      flexDirection:'row',
-    },
+
     menu:{
         borderWidth: 1,
         borderColor: theme.colors.outline,

--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -1,28 +1,15 @@
-import {
-  VStack,
-  Container,
-  Heading,
-  HStack,
-  useDisclose,
-  Text,
-  Pressable,
-  Menu,
-  ScrollView,
-  Link,
-  Box,
-  Checkbox,
-} from 'native-base';
+import { Checkbox } from 'native-base';
 import React, { useState } from 'react';
+import { Linking, View,Pressable, ScrollView } from 'react-native';
+import { Button, useTheme, TextInput, HelperText,Menu,Text } from 'react-native-paper';
 import CheckIcon from 'react-native-template/assets/icons/check.svg';
-import { FormControl, Input, Button } from 'react-native-template/src/components';
-import { ButtonKind } from 'react-native-template/src/types/button';
-import { useThemeColor } from 'react-native-template/src/utils';
 
 import { CountrySelectOptions } from '../../../constants';
 import { AsyncError, PhoneNumber } from '../../../types';
 
 import usePhoneAuthForm from './phone-auth-form-hook';
 import { usePhoneAuthFormStyles } from './phone-auth-form.styles';
+
 
 interface PhoneAuthFormProps {
   onSuccess: () => void;
@@ -35,51 +22,54 @@ const renderCountrySelectMenu = (
   onOpen: () => void,
   onClose: () => void,
   handleSelectChange: (value: string) => void,
-) => (
-  <Menu
-    isOpen={isOpen}
-    onOpen={onOpen}
-    onClose={onClose}
-    trigger={triggerProps => (
-      <Pressable
-        {...triggerProps}
-        borderWidth={1}
-        justifyContent="center"
-        borderColor={'warmGray.300'}
-        rounded="sm"
-        px={2}
-      >
-        <Text>{`${formik.values.country} (${formik.values.countryCode})`}</Text>
-      </Pressable>
-    )}
-  >
-    <ScrollView maxH={'200px'}>
-      {CountrySelectOptions.map(option => (
-        <Menu.Item
-          key={option.value}
-          onPress={() => {
-            handleSelectChange(option.value);
-            onClose();
-          }}
-        >
-          {option.label}
-        </Menu.Item>
-      ))}
-    </ScrollView>
-  </Menu>
-);
+  styles: ReturnType<typeof usePhoneAuthFormStyles>,
+) => {
+
+return (
+<Menu
+  visible={isOpen}
+  onDismiss={onClose}
+  contentStyle={{ width: 110 }}
+  anchor={
+    <Pressable
+      onPress={onOpen}
+      style={styles.menu}
+    >
+      <Text>{`${formik.values.country} (${formik.values.countryCode})`}</Text>
+    </Pressable>
+  }
+>
+  <ScrollView >
+    {CountrySelectOptions.map(option => (
+      <Menu.Item
+        key={option.value}
+        title={option.label}
+        titleStyle={{ fontSize: 18 }}
+        onPress={() => {
+          handleSelectChange(option.value);
+          onClose();
+        }}
+      />
+    ))}
+  </ScrollView>
+</Menu>
+);};
 
 const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => {
-  const themeColor = useThemeColor('primary.500');
-
+  const theme = useTheme();
   const styles = usePhoneAuthFormStyles();
   const { formik, isSendOTPLoading } = usePhoneAuthForm({
     onSendOTPSuccess: onSuccess,
     onError: onError,
   });
 
-  const { isOpen, onOpen, onClose } = useDisclose();
+
   const [isChecked, setIsChecked] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onOpen = () => setIsOpen(true);
+  const onClose = () => setIsOpen(false);
+
 
   const handleSelectChange = (value: string) => {
     const [countryCode, country] = value.split(', ');
@@ -98,67 +88,78 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
   }).getFormattedWithoutCountryCode();
 
   return (
-    <Box flex={1} pb={4}>
-      <VStack space={6} flex={1} mb={8}>
-        <Container>
-          <Heading size="lg">Login</Heading>
-        </Container>
-        <FormControl label={'Mobile Number'}>
-          <HStack space={2} width="100%">
-            {renderCountrySelectMenu(formik, isOpen, onOpen, onClose, handleSelectChange)}
-            <Box
-              flex={3}
-              justifyContent="center"
+    <View style={styles.phoneAuthScreen}>
+      <View style={styles.Login}>
+        <View style={{ paddingBottom: 24 }}>
+          <Text variant="headlineMedium">Login</Text>
+        </View>
+        <View>
+          <Text style={styles.text}>Mobile Number</Text>
+          <View style={styles.row}>
+            {renderCountrySelectMenu(formik, isOpen, onOpen, onClose, handleSelectChange,styles)}
+            <View
               style={[
                 styles.inputBox,
                 formik.touched.phoneNumber && formik.errors.phoneNumber ? styles.errorStyle : {},
               ]}
             >
-              <Input
+              <TextInput
                 value={phoneNumber.getFormattedWithoutCountryCode()}
                 onChangeText={formik.handleChange('phoneNumber')}
                 keyboardType="numeric"
                 placeholder={phoneNumberPlaceholder}
+                mode="outlined"
+                style={{ backgroundColor:theme.colors.surface }}
               />
-            </Box>
-          </HStack>
-          {formik.touched.phoneNumber && formik.errors.phoneNumber ? (
-            <Text style={styles.errorText}>{formik.errors.phoneNumber}</Text>
-          ) : null}
-        </FormControl>
+            </View>
+          </View>
+          <HelperText
+            type="error"
+            visible={!!(formik.touched.phoneNumber && formik.errors.phoneNumber)}
+          >
+            {formik.errors.phoneNumber}
+          </HelperText>
 
-        <HStack alignItems="flex-start" space={2} mt={2}>
+        </View>
+
+        <View style={styles.Checkbox}>
           <Checkbox
             isChecked={isChecked}
             onChange={setIsChecked}
             accessibilityLabel="Agree to privacy policy"
             value="agreePrivacyPolicy"
-            icon={<CheckIcon width={12} height={12} color={themeColor} />}
+            icon={<CheckIcon width={12} height={12} fill={theme.colors.primary} />}
             aria-label="Privacy Policy Checkbox"
             mt={0.5}
           />
-          <HStack flexWrap="wrap" alignItems="baseline" flex={1}>
-            <Text fontSize="sm">By continuing, you agree to our </Text>
-            <Link
-              _text={{ color: 'primary.500', underline: true, fontSize: 'sm' }}
-              href="https://jalantechnologies.github.io/react-native-template/"
-              isExternal
+
+          <View style={{ marginLeft:12 }}>
+            <Text >By continuing, you agree to our </Text>
+            <Text
+              style={{ color: theme.colors.primary, textDecorationLine: 'underline' }}
+              onPress={() =>
+                Linking.openURL(
+                  'https://jalantechnologies.github.io/react-native-template/'
+                )
+              }
             >
               Privacy Policy
-            </Link>
-          </HStack>
-        </HStack>
-      </VStack>
+            </Text>
+          </View>
+        </View>
+      </View>
+
 
       <Button
+        mode="contained"
         disabled={!isChecked}
-        isLoading={isSendOTPLoading}
-        onClick={() => formik.handleSubmit()}
-        kind={ButtonKind.CONTAINED}
+        loading={isSendOTPLoading}
+        onPress={() => formik.handleSubmit()}
+        style={styles.Button}
       >
         Send OTP
       </Button>
-    </Box>
+    </View>
   );
 };
 

--- a/src/screens/auth/phone-auth/phone-auth-form.tsx
+++ b/src/screens/auth/phone-auth/phone-auth-form.tsx
@@ -89,7 +89,7 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
 
   return (
     <View style={styles.phoneAuthScreen}>
-      <View style={styles.Login}>
+      <View style={styles.login}>
         <View style={{ paddingBottom: 24 }}>
           <Text variant="headlineMedium">Login</Text>
         </View>
@@ -122,7 +122,7 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
 
         </View>
 
-        <View style={styles.Checkbox}>
+        <View style={styles.checkBox}>
           <Checkbox
             isChecked={isChecked}
             onChange={setIsChecked}
@@ -155,7 +155,7 @@ const PhoneAuthForm: React.FC<PhoneAuthFormProps> = ({ onSuccess, onError }) => 
         disabled={!isChecked}
         loading={isSendOTPLoading}
         onPress={() => formik.handleSubmit()}
-        style={styles.Button}
+        style={styles.button}
       >
         Send OTP
       </Button>

--- a/src/screens/auth/registration/index.tsx
+++ b/src/screens/auth/registration/index.tsx
@@ -29,6 +29,7 @@ const RegistrationScreen: React.FC = () => {
       <Snackbar
         visible={snackbarVisible}
         onDismiss={() => setSnackbarVisible(false)}
+        duration={3000}
       >
         {snackbarMessage}
       </Snackbar>

--- a/src/screens/auth/registration/index.tsx
+++ b/src/screens/auth/registration/index.tsx
@@ -1,5 +1,5 @@
-import { Toast } from 'native-base';
-import React from 'react';
+import React, { useState } from 'react';
+import { Snackbar } from 'react-native-paper';
 
 import { AsyncError } from '../../../types';
 import AuthLayout from '../auth-layout';
@@ -7,21 +7,32 @@ import AuthLayout from '../auth-layout';
 import RegistrationForm from './registration-form';
 
 const RegistrationScreen: React.FC = () => {
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
   const onSuccess = () => {
-    Toast.show({
-      title: 'Account Created Successfully',
-    });
+    setSnackbarMessage('Account Created Successfully');
+    setSnackbarVisible(true);
   };
 
   const onError = (err: AsyncError) => {
-    Toast.show({
-      title: err.message,
-    });
+    setSnackbarMessage(err.message);
+    setSnackbarVisible(true);
   };
+
   return (
-    <AuthLayout primaryTitle="Create" secondaryTitle="Account">
-      <RegistrationForm onError={onError} onSuccess={onSuccess} />
-    </AuthLayout>
+    <>
+      <AuthLayout primaryTitle="Create" secondaryTitle="Account">
+        <RegistrationForm onError={onError} onSuccess={onSuccess} />
+      </AuthLayout>
+
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+      >
+        {snackbarMessage}
+      </Snackbar>
+    </>
   );
 };
 

--- a/src/screens/auth/registration/registration-form.tsx
+++ b/src/screens/auth/registration/registration-form.tsx
@@ -63,7 +63,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ onSuccess, onError 
         mode="contained"
         loading={isUpdateAccountLoading}
         onPress={() => formik.handleSubmit()}
-        style={styles.Button}
+        style={styles.button}
       >
         Create Account
       </Button>

--- a/src/screens/auth/registration/registration-form.tsx
+++ b/src/screens/auth/registration/registration-form.tsx
@@ -1,10 +1,11 @@
-import { Container, Heading, VStack } from 'native-base';
 import React from 'react';
-import { Button, FormControl, Input } from 'react-native-template/src/components';
+import { View } from 'react-native';
+import { Text, TextInput, Button, HelperText } from 'react-native-paper';
 
 import { AsyncError } from '../../../types';
 
 import useRegistrationForm from './registration-form-hook';
+import { useRegistrationStyles } from './registration.styles';
 
 interface RegistrationFormProps {
   onError: (error: AsyncError) => void;
@@ -17,33 +18,58 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ onSuccess, onError 
     onRegistrationSuccess: onSuccess,
   });
 
+  const styles = useRegistrationStyles();
+
   return (
-    <VStack space={4}>
-      <Container>
-        <Heading size="lg">New User Registration</Heading>
-        <Heading mt={2} size="xs">
-          Please fill the form to create an account
-        </Heading>
-      </Container>
-      <FormControl label={'First Name'} error={formik.errors.firstName}>
-        <Input
-          onChangeText={formik.handleChange('firstName')}
-          value={formik.values.firstName}
+    <View >
+      <View style={styles.header}>
+        <Text variant="titleLarge">New User Registration</Text>
+        <Text variant="bodyMedium" style={styles.subtitle}>
+          Please fill the form to create an {'\n'} account
+        </Text>
+      </View>
+
+      <View>
+        <Text style={styles.text}>First Name</Text>
+        <TextInput
           placeholder="First Name"
+          mode="outlined"
+          value={formik.values.firstName}
+          onChangeText={formik.handleChange('firstName')}
+          error={!!formik.errors.firstName}
+          style={styles.textBox}
         />
-      </FormControl>
-      <FormControl label={'Last Name'} error={formik.errors.lastName}>
-        <Input
-          onChangeText={formik.handleChange('lastName')}
-          value={formik.values.lastName}
+        <HelperText type="error" visible={!!formik.errors.firstName}>
+          {formik.errors.firstName}
+        </HelperText>
+      </View>
+
+      <View>
+        <Text style={styles.text}>Last Name</Text>
+        <TextInput
           placeholder="Last Name"
+          mode="outlined"
+          value={formik.values.lastName}
+          onChangeText={formik.handleChange('lastName')}
+          error={!!formik.errors.lastName}
+          style={styles.textBox}
         />
-      </FormControl>
-      <Button onClick={() => formik.handleSubmit()} isLoading={isUpdateAccountLoading}>
+        <HelperText type="error" visible={!!formik.errors.lastName}>
+          {formik.errors.lastName}
+        </HelperText>
+      </View>
+
+      <Button
+        mode="contained"
+        loading={isUpdateAccountLoading}
+        onPress={() => formik.handleSubmit()}
+        style={styles.Button}
+      >
         Create Account
       </Button>
-    </VStack>
+    </View>
   );
 };
 
 export default RegistrationForm;
+

--- a/src/screens/auth/registration/registration.styles.ts
+++ b/src/screens/auth/registration/registration.styles.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+export const useRegistrationStyles = () => {
+    const theme = useTheme();
+    return StyleSheet.create({
+        container: {
+            gap: 16,
+        },
+        header: {
+            marginVertical: 10,
+
+        },
+        subtitle: {
+            marginTop: 14,
+            opacity: 0.7,
+            marginBottom:20,
+        },
+        Button: {
+            borderRadius: 8,
+        },
+        text: {
+            color: theme.colors.primary,
+            paddingBottom: 8,
+            fontWeight:'600',
+        },
+        textBox:{
+            backgroundColor:theme.colors.surface,
+        },
+    });
+};

--- a/src/screens/auth/registration/registration.styles.ts
+++ b/src/screens/auth/registration/registration.styles.ts
@@ -15,7 +15,7 @@ export const useRegistrationStyles = () => {
             opacity: 0.7,
             marginBottom:20,
         },
-        Button: {
+        button: {
             borderRadius: 8,
         },
         text: {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,163 @@
+import { MD3LightTheme, configureFonts } from 'react-native-paper';
+
+
+const ICOLORHUES = {
+  primary: {
+    '50': '#E6F0FF',
+    '100': '#CCE0FF',
+    '200': '#99C2FF',
+    '300': '#66A3FF',
+    '400': '#3385FF',
+    '500': '#007AFF',
+    '600': '#0066CC',
+    '700': '#0052A3',
+    '800': '#00438C',
+    '900': '#003D7A',
+  },
+  secondary: {
+    '50': '#FAFAFA',
+    '100': '#F5F5F5',
+    '200': '#E5E5E5',
+    '300': '#D4D4D4',
+    '400': '#A3A3A3',
+    '500': '#737373',
+    '600': '#525252',
+    '700': '#404040',
+    '800': '#262626',
+    '900': '#171717',
+  },
+  danger: {
+    '50': '#FEECEC',
+    '100': '#FFD6D6',
+    '200': '#FFADAD',
+    '300': '#FF8484',
+    '400': '#FF5C5C',
+    '500': '#FF3B30',
+    '600': '#E2332B',
+    '700': '#BF2A23',
+    '800': '#991F1A',
+    '900': '#731512',
+  },
+  warning: {
+    '50': '#FFF8E6',
+    '100': '#FFF0CC',
+    '200': '#FFE199',
+    '300': '#FFD166',
+    '400': '#FFC233',
+    '500': '#FFA500',
+    '600': '#E59400',
+    '700': '#CC8400',
+    '800': '#B37300',
+    '900': '#805100',
+  },
+  success: {
+    '50': '#EAFBE9',
+    '100': '#D2F6D1',
+    '200': '#A7E9C4',
+    '300': '#7CE268',
+    '400': '#51D733',
+    '500': '#4BB543',
+    '600': '#38922F',
+    '700': '#2B6E21',
+    '800': '#1B4A14',
+    '900': '#0C2607',
+  },
+  info: {
+    '50': '#E0FCFF',
+    '100': '#BEF8FD',
+    '200': '#87EAF2',
+    '300': '#54D1DB',
+    '400': '#38BEC9',
+    '500': '#2CB1BC',
+    '600': '#14919B',
+    '700': '#0E7C86',
+    '800': '#0A6C74',
+    '900': '#044E54',
+  },
+};
+
+
+const fontConfig = {
+  headlineLarge: {
+    fontSize: 28,
+    fontWeight: '600' as const,
+    lineHeight: 32,
+  },
+  headlineMedium: {
+    fontSize: 26,
+    fontWeight: '600' as const,
+    lineHeight: 32,
+  },
+  titleLarge: {
+    fontSize: 20,
+    fontWeight: '600' as const,
+    lineHeight: 24,
+  },
+  titleMedium: {
+    fontSize: 18,
+    fontWeight: '500' as const,
+    lineHeight: 22,
+  },
+  bodyLarge: {
+    fontSize: 20,
+    fontWeight: '500' as const,
+    lineHeight: 24,
+  },
+  bodyMedium: {
+    fontSize: 16,
+    fontWeight: '500' as const,
+    lineHeight: 20,
+  },
+};
+
+export const theme = {
+  ...MD3LightTheme,
+
+  colors: {
+    ...MD3LightTheme.colors,
+
+    primary: ICOLORHUES.primary['500'],
+    primaryContainer: ICOLORHUES.primary['100'],
+    onPrimary: '#FFFFFF',
+    onPrimaryContainer: ICOLORHUES.primary['900'],
+
+
+    secondary: ICOLORHUES.secondary['500'],
+    secondaryContainer: ICOLORHUES.secondary['200'],
+    onSecondary: '#FFFFFF',
+    onSecondaryContainer: ICOLORHUES.secondary['900'],
+
+
+    error: ICOLORHUES.danger['500'],
+    errorContainer: ICOLORHUES.danger['100'],
+    onError: '#FFFFFF',
+    onErrorContainer: ICOLORHUES.danger['900'],
+
+    surface: '#FFFFFF',
+    surfaceVariant: ICOLORHUES.secondary['50'],
+    onSurface: ICOLORHUES.secondary['900'],
+    onSurfaceVariant: ICOLORHUES.secondary['700'],
+    outline: ICOLORHUES.secondary['200'],
+
+    success: ICOLORHUES.success['500'],
+    successContainer: ICOLORHUES.success['100'],
+    onSuccess: '#FFFFFF',
+    onSuccessContainer: ICOLORHUES.success['900'],
+
+    warning: ICOLORHUES.warning['500'],
+    warningContainer: ICOLORHUES.warning['100'],
+    onWarning: '#000000',
+    onWarningContainer: ICOLORHUES.warning['900'],
+
+    info: ICOLORHUES.info['500'],
+    infoContainer: ICOLORHUES.info['100'],
+    onInfo: '#FFFFFF',
+    onInfoContainer: ICOLORHUES.info['900'],
+  },
+  fonts: configureFonts({ config: fontConfig }),
+  customColors: ICOLORHUES,
+};
+
+
+export type AppTheme = typeof theme;
+

--- a/src/theme/useAppTheme.ts
+++ b/src/theme/useAppTheme.ts
@@ -1,0 +1,7 @@
+import { useTheme } from 'react-native-paper';
+
+import type { AppTheme } from './index';
+
+export const useAppTheme = () => {
+  return useTheme<AppTheme>();
+};

--- a/src/types/react-native-paper.d.ts
+++ b/src/types/react-native-paper.d.ts
@@ -1,0 +1,20 @@
+import 'react-native-paper';
+
+declare module 'react-native-paper' {
+  interface MD3Colors {
+    success: string;
+    successContainer: string;
+    onSuccess: string;
+    onSuccessContainer: string;
+
+    warning: string;
+    warningContainer: string;
+    onWarning: string;
+    onWarningContainer: string;
+
+    info: string;
+    infoContainer: string;
+    onInfo: string;
+    onInfoContainer: string;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@callstack/react-theme-provider@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "@callstack/react-theme-provider@npm:3.0.9"
+  dependencies:
+    deepmerge: ^3.2.0
+    hoist-non-react-statics: ^3.3.0
+  peerDependencies:
+    react: ">=16.3.0"
+  checksum: f888ef0b8f993d393a9d49864f75b04b5cf7259e72f290ec570fc5e314315f75c979b03b391243a72578ab55db4ffcdd4dc9dc1a2f8ec2b516cabb958971a85e
+  languageName: node
+  linkType: hard
+
 "@datadog/mobile-react-native-session-replay@npm:^2.8.0":
   version: 2.14.0
   resolution: "@datadog/mobile-react-native-session-replay@npm:2.14.0"
@@ -5444,7 +5456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -5476,13 +5488,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-string@npm:^1.9.0":
+"color-string@npm:^1.6.0, color-string@npm:^1.9.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
   dependencies:
     color-name: ^1.0.0
     simple-swizzle: ^0.2.2
   checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.2":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: ^1.9.3
+    color-string: ^1.6.0
+  checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
   languageName: node
   linkType: hard
 
@@ -5876,6 +5898,13 @@ __metadata:
   version: 2.2.1
   resolution: "deepmerge@npm:2.2.1"
   checksum: 284b71065079e66096229f735a9a0222463c9ca9ee9dda7d5e9a0545bf254906dbc7377e3499ca3b2212073672b1a430d80587993b43b87d8de17edc6af649a8
+  languageName: node
+  linkType: hard
+
+"deepmerge@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "deepmerge@npm:3.3.0"
+  checksum: 4322195389e0170a0443c07b36add19b90249802c4b47b96265fdc5f5d8beddf491d5e50cbc5bfd65f85ccf76598173083863c202f5463b3b667aca8be75d5ac
   languageName: node
   linkType: hard
 
@@ -10672,6 +10701,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-paper@npm:^5.14.5":
+  version: 5.14.5
+  resolution: "react-native-paper@npm:5.14.5"
+  dependencies:
+    "@callstack/react-theme-provider": ^3.0.9
+    color: ^3.1.2
+    use-latest-callback: ^0.2.3
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-safe-area-context: "*"
+  checksum: f986937ebeb2cdea338d384dfc7814d2c0dbe3e8cd3645ce720832b78f588eccf3fc490bf1afb942a9d6046cd842984c011316c4d9c2fabf59a38ae1a47fccb3
+  languageName: node
+  linkType: hard
+
 "react-native-reanimated@npm:3.16.7":
   version: 3.16.7
   resolution: "react-native-reanimated@npm:3.16.7"
@@ -10815,6 +10859,7 @@ __metadata:
     react-native-config: 1.5.3
     react-native-error-boundary: ^1.2.4
     react-native-gesture-handler: 2.19.0
+    react-native-paper: ^5.14.5
     react-native-reanimated: 3.16.7
     react-native-safe-area-context: 4.10.9
     react-native-screens: ^3.34.0
@@ -12359,7 +12404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-latest-callback@npm:^0.2.1":
+"use-latest-callback@npm:^0.2.1, use-latest-callback@npm:^0.2.3":
   version: 0.2.6
   resolution: "use-latest-callback@npm:0.2.6"
   peerDependencies:


### PR DESCRIPTION
## Overview
This PR introduces the initial phase of the React Native Paper migration. It sets up the Paper theme and migrates the Auth screens away from NativeBase and custom UI components, aligning them with the new design system foundation.

## Changes
**React Native Paper Setup**

- Added React Native Paper and configured the application theme
- Wrapped the app with PaperProvider
- Mapped existing design system colors and typography to Paper theme tokens

## Screen Migration
Migrated the following screens to React Native Paper components:

- Auth Screens
 change-api-url
 otp-verify
phone-auth
 registration
auth-layout


- Replaced custom UI components with React Native Paper equivalents
- Removed NativeBase usage from the above screens
- Preserved existing layouts, flows, and screen behavior

## UI Migration Preview

| Previous (NativeBase) | Current (React Native Paper) |
|----------------------|------------------------------|
| <img width="260" height="560" alt="Old Login" src="https://github.com/user-attachments/assets/daf400f2-ea46-480d-a878-7d08692e6ee6" /> | <img width="260" height="560" alt="New Login" src="https://github.com/user-attachments/assets/d016b88b-35a0-486c-bb7d-48d699c432a7" /> |
| <img width="260" height="560" alt="Old OTP" src="https://github.com/user-attachments/assets/938bfe2e-bde0-4497-a5e3-e37b7f5ebbd8" /> | <img width="260" height="560" alt="New OTP" src="https://github.com/user-attachments/assets/4f01f222-606d-4d66-b04d-f3339ad5997f" /> |
| <img width="260" height="560" alt="Old Registration" src="https://github.com/user-attachments/assets/7312e7ed-e9f9-4f8e-be93-5c3998b797e4" /> | <img width="260" height="560" alt="New Registration" src="https://github.com/user-attachments/assets/0f71c08e-d89b-453d-9aee-cad84740a441" /> |


Note: The phone-auth-form currently retains the NativeBase checkbox due to an icon rendering issue with React Native Paper’s checkbox component. This will be addressed in a follow-up PR.