### PR TITLE
fix(android): resolve Hermes startup crash on React Native 0.76

### DIFF
--- a/android/app/src/main/java/com/boilerplate/MainApplication.kt
+++ b/android/app/src/main/java/com/boilerplate/MainApplication.kt
@@ -9,6 +9,7 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.soloader.OpenSourceMergedSoMapping 
 import com.facebook.soloader.SoLoader
 
 class MainApplication : Application(), ReactApplication {
@@ -34,7 +35,7 @@ class MainApplication : Application(), ReactApplication {
 
   override fun onCreate() {
     super.onCreate()
-    SoLoader.init(this, false)
+    SoLoader.init(this, OpenSourceMergedSoMapping)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       load()
     }

--- a/docs/release_notes/1.0.17.md
+++ b/docs/release_notes/1.0.17.md
@@ -1,0 +1,2 @@
+v1.0.17
+- Fixed Android app crash on startup caused by missing Hermes executor library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Summary
Fixes an Android startup crash on React Native 0.76 caused by Hermes native libraries not being resolved correctly.

## What was fixed
- Updated `SoLoader` initialization to use `OpenSourceMergedSoMapping`
- Ensures Hermes executor loads correctly with merged native libraries in RN 0.76+

## Root cause
React Native 0.76 merges multiple native libraries into consolidated `.so` files.  
The app was still attempting to load `libhermes_executor.so` directly, which no longer exists as a standalone library.

## Testing
- Built and ran app on physical Android device (Samsung A52)
- Verified app launches successfully without crashing

## Verification
Failed Build
<img width="1799" height="978" alt="Screenshot from 2026-01-02 13-36-16" src="https://github.com/user-attachments/assets/43918043-812e-4e05-ab2b-fcc023e1acde" />

successful Build
<img width="1799" height="978" alt="image-2" src="https://github.com/user-attachments/assets/32ba5abc-2e78-4978-97d2-13d57fde1239" />

Closes #302 

