### PR TITLE
refactor: merge two separate PR  build comments into one.

### DIFF
--- a/.github/actions/deploy_android_preview/action.yml
+++ b/.github/actions/deploy_android_preview/action.yml
@@ -103,20 +103,3 @@ runs:
       if: always()
       shell: bash
       run: rm -f /tmp/gcp_key.json
-
-    # - name: Comment on PR with Firebase link
-    #   uses: actions/github-script@v7
-    #   with:
-    #     script: |
-    #       const prNumber = context.issue.number;
-    #       const projectId = "${{ inputs.ANDROID_FIREBASE_PROJECT_ID }}";
-    #       const appPackage = "${{ inputs.ANDROID_FIREBASE_APP_PACKAGE }}";
-    #       const encodedAppPackage = encodeURIComponent(appPackage);
-    #       const releaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
-
-    #       github.rest.issues.createComment({
-    #         issue_number: prNumber,
-    #         owner: context.repo.owner,
-    #         repo: context.repo.repo,
-    #         body: `🚀 Deployed PR #${prNumber} to Firebase App Distribution.\n\n🔗 [View Release in Firebase Console](${releaseUrl})`
-    #       });

--- a/.github/actions/deploy_android_preview/action.yml
+++ b/.github/actions/deploy_android_preview/action.yml
@@ -104,19 +104,19 @@ runs:
       shell: bash
       run: rm -f /tmp/gcp_key.json
 
-    - name: Comment on PR with Firebase link
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const prNumber = context.issue.number;
-          const projectId = "${{ inputs.ANDROID_FIREBASE_PROJECT_ID }}";
-          const appPackage = "${{ inputs.ANDROID_FIREBASE_APP_PACKAGE }}";
-          const encodedAppPackage = encodeURIComponent(appPackage);
-          const releaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
+    # - name: Comment on PR with Firebase link
+    #   uses: actions/github-script@v7
+    #   with:
+    #     script: |
+    #       const prNumber = context.issue.number;
+    #       const projectId = "${{ inputs.ANDROID_FIREBASE_PROJECT_ID }}";
+    #       const appPackage = "${{ inputs.ANDROID_FIREBASE_APP_PACKAGE }}";
+    #       const encodedAppPackage = encodeURIComponent(appPackage);
+    #       const releaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
 
-          github.rest.issues.createComment({
-            issue_number: prNumber,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `🚀 Deployed PR #${prNumber} to Firebase App Distribution.\n\n🔗 [View Release in Firebase Console](${releaseUrl})`
-          });
+    #       github.rest.issues.createComment({
+    #         issue_number: prNumber,
+    #         owner: context.repo.owner,
+    #         repo: context.repo.repo,
+    #         body: `🚀 Deployed PR #${prNumber} to Firebase App Distribution.\n\n🔗 [View Release in Firebase Console](${releaseUrl})`
+    #       });

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -168,24 +168,24 @@ runs:
         name: xcode-build-logs
         path: /Users/runner/Library/Logs/gym/*.log
 
-    - name: Post PR comment with TestFlight link
-      if: ${{ inputs.PR_NUMBER != '' }}
-      env:
-        GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ inputs.PR_NUMBER }}
-        BUILD_HASH: ${{ github.sha }}
-        IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-        IOS_APPLE_ID: ${{ inputs.IOS_APPLE_ID }}
-        IOS_APP_IDENTIFIER: ${{ inputs.IOS_APP_IDENTIFIER }}
-      run: |
-        brew install gh
-        gh auth setup-git
-        TESTFLIGHT_LINK="https://appstoreconnect.apple.com/teams/$IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID/apps/$IOS_APPLE_ID/testflight/ios"
-        gh pr comment "$PR_NUMBER" --body "✅ TestFlight build uploaded for PR #$PR_NUMBER
+    # - name: Post PR comment with TestFlight link
+    #   if: ${{ inputs.PR_NUMBER != '' }}
+    #   env:
+    #     GH_TOKEN: ${{ github.token }}
+    #     PR_NUMBER: ${{ inputs.PR_NUMBER }}
+    #     BUILD_HASH: ${{ github.sha }}
+    #     IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+    #     IOS_APPLE_ID: ${{ inputs.IOS_APPLE_ID }}
+    #     IOS_APP_IDENTIFIER: ${{ inputs.IOS_APP_IDENTIFIER }}
+    #   run: |
+    #     brew install gh
+    #     gh auth setup-git
+    #     TESTFLIGHT_LINK="https://appstoreconnect.apple.com/teams/$IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID/apps/$IOS_APPLE_ID/testflight/ios"
+    #     gh pr comment "$PR_NUMBER" --body "✅ TestFlight build uploaded for PR #$PR_NUMBER
 
-        - 🔗 [View in App Store Connect]($TESTFLIGHT_LINK)
-        - 🆔 App ID: \`$IOS_APP_IDENTIFIER\`
-        - 🧱 Build Hash: \`$BUILD_HASH\`
+    #     - 🔗 [View in App Store Connect]($TESTFLIGHT_LINK)
+    #     - 🆔 App ID: \`$IOS_APP_IDENTIFIER\`
+    #     - 🧱 Build Hash: \`$BUILD_HASH\`
 
-        _This build was deployed by CI using Fastlane._"
-      shell: bash
+    #     _This build was deployed by CI using Fastlane._"
+    #   shell: bash

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -167,25 +167,3 @@ runs:
       with:
         name: xcode-build-logs
         path: /Users/runner/Library/Logs/gym/*.log
-
-    # - name: Post PR comment with TestFlight link
-    #   if: ${{ inputs.PR_NUMBER != '' }}
-    #   env:
-    #     GH_TOKEN: ${{ github.token }}
-    #     PR_NUMBER: ${{ inputs.PR_NUMBER }}
-    #     BUILD_HASH: ${{ github.sha }}
-    #     IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-    #     IOS_APPLE_ID: ${{ inputs.IOS_APPLE_ID }}
-    #     IOS_APP_IDENTIFIER: ${{ inputs.IOS_APP_IDENTIFIER }}
-    #   run: |
-    #     brew install gh
-    #     gh auth setup-git
-    #     TESTFLIGHT_LINK="https://appstoreconnect.apple.com/teams/$IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID/apps/$IOS_APPLE_ID/testflight/ios"
-    #     gh pr comment "$PR_NUMBER" --body "✅ TestFlight build uploaded for PR #$PR_NUMBER
-
-    #     - 🔗 [View in App Store Connect]($TESTFLIGHT_LINK)
-    #     - 🆔 App ID: \`$IOS_APP_IDENTIFIER\`
-    #     - 🧱 Build Hash: \`$BUILD_HASH\`
-
-    #     _This build was deployed by CI using Fastlane._"
-    #   shell: bash

--- a/.github/actions/update_preview_comment/action.yml
+++ b/.github/actions/update_preview_comment/action.yml
@@ -1,0 +1,105 @@
+name: Update Preview PR Comment
+description: Update the shared preview comment with platform-specific build links.
+inputs:
+  platform:
+    description: 'Platform that completed (android|ios)'
+    required: true
+  android_firebase_project_id:
+    description: 'Firebase project ID'
+    required: true
+  android_firebase_app_package:
+    description: 'Firebase app package'
+    required: true
+  ios_app_store_connect_api_key_issuer_id:
+    description: 'App Store Connect issuer ID'
+    required: true
+  ios_apple_id:
+    description: 'Apple app ID'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Upsert preview PR comment
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const marker = '<!-- preview-build-links -->';
+          const platform = '${{ inputs.platform }}';
+          const prNumber = context.issue.number;
+          const buildSha = context.sha;
+
+          const projectId = '${{ inputs.android_firebase_project_id }}';
+          const appPackage = '${{ inputs.android_firebase_app_package }}';
+          const encodedAppPackage = encodeURIComponent(appPackage);
+          const firebaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
+
+          const issuerId = '${{ inputs.ios_app_store_connect_api_key_issuer_id }}';
+          const appId = '${{ inputs.ios_apple_id }}';
+          const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
+
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+          const attempts = 3;
+
+          for (let attempt = 0; attempt < attempts; attempt += 1) {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            const existingLines = existing?.body?.split('\n') ?? [];
+            const existingAndroidLine = existingLines.find((line) => line.includes('Android (Firebase)'));
+            const existingIosLine = existingLines.find((line) => line.includes('iOS (TestFlight)'));
+
+            let androidLine = '';
+            let iosLine = '';
+
+            if (platform === 'android') {
+              const iosHasCurrentSha = existingIosLine?.includes(`ios-sha:${buildSha}`);
+              androidLine = `- ✅ Android (Firebase): ${firebaseUrl} <!-- android-sha:${buildSha} -->`;
+              iosLine = iosHasCurrentSha
+                ? existingIosLine
+                : `- ⏳ iOS (TestFlight): pending upload <!-- ios-sha:${buildSha} -->`;
+            } else if (platform === 'ios') {
+              const androidHasCurrentSha = existingAndroidLine?.includes(`android-sha:${buildSha}`);
+              androidLine = androidHasCurrentSha
+                ? existingAndroidLine
+                : `- ⏳ Android (Firebase): pending upload <!-- android-sha:${buildSha} -->`;
+              iosLine = `- ✅ iOS (TestFlight): ${testflightUrl} <!-- ios-sha:${buildSha} -->`;
+            } else {
+              throw new Error(`Unsupported platform: ${platform}`);
+            }
+
+            const body = `${marker}
+          ✅ Preview build links for PR #${prNumber}
+
+          ${androidLine}
+          ${iosLine}
+          `;
+
+            try {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+              }
+              break;
+            } catch (error) {
+              if (attempt === attempts - 1) {
+                throw error;
+              }
+              await sleep(1000 * (attempt + 1));
+            }
+          }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,6 +50,9 @@ jobs:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     needs: [check_version_number, release_notes_check]
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: Checkout (root for actions)
         uses: actions/checkout@v4
@@ -80,11 +83,68 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
 
+
+      - name: Post or update preview comment (Android)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- preview-build-links -->';
+            const prNumber = context.issue.number;
+
+            const projectId = '${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}';
+            const appPackage = '${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}';
+            const encodedAppPackage = encodeURIComponent(appPackage);
+            const firebaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
+
+            const issuerId = '${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}';
+            const appId = '${{ secrets.IOS_APPLE_ID }}';
+            const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            const existingLines = existing?.body?.split('\n') ?? [];
+            const existingIosLine = existingLines.find((line) => line.includes('iOS (TestFlight)'));
+
+            const androidLine = `- ✅ Android (Firebase): ${firebaseUrl}`;
+            const iosLine = existingIosLine ?? `- ⏳ iOS (TestFlight): ${testflightUrl}`;
+
+            const body = `${marker}
+            ✅ Preview build links for PR #${prNumber}
+
+            ${androidLine}
+            ${iosLine}
+            `;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
   deploy_ios:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     needs: [check_version_number, release_notes_check]
     runs-on: macos-14
     timeout-minutes: 60
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -114,16 +174,7 @@ jobs:
           IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
-          
-  post_preview_comment:
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
-    needs: [deploy_android, deploy_ios]
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: read
-    steps:
-      - name: Post or update consolidated preview comment
+      - name: Post or update preview comment (iOS)
         uses: actions/github-script@v7
         with:
           script: |
@@ -138,14 +189,6 @@ jobs:
             const issuerId = '${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}';
             const appId = '${{ secrets.IOS_APPLE_ID }}';
             const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
-
-            const body = `${marker}
-            ✅ Preview builds are ready for PR #${prNumber}
-
-            - 🤖 Android (Firebase): ${firebaseUrl}
-            - 🍏 iOS (TestFlight): ${testflightUrl}
-            `;
-
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -154,6 +197,18 @@ jobs:
             });
 
             const existing = comments.find((c) => c.body && c.body.includes(marker));
+            const existingLines = existing?.body?.split('\n') ?? [];
+            const existingAndroidLine = existingLines.find((line) => line.includes('Android (Firebase)'));
+
+            const androidLine = existingAndroidLine ?? `- ⏳ Android (Firebase): ${firebaseUrl}`;
+            const iosLine = `- ✅ iOS (TestFlight): ${testflightUrl}`;
+
+            const body = `${marker}
+            ✅ Preview build links for PR #${prNumber}
+
+            ${androidLine}
+            ${iosLine}
+            `;
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -170,3 +225,4 @@ jobs:
                 body,
               });
             }
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,76 +83,14 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
 
-
-      - name: Post or update preview comment (Android)
-        uses: actions/github-script@v7
+      - name: Post or update PR comment (Android)
+        uses: ./.github/actions/update_preview_comment
         with:
-          script: |
-            const marker = '<!-- preview-build-links -->';
-            const prNumber = context.issue.number;
-            const buildSha = context.sha;
-
-            const projectId = '${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}';
-            const appPackage = '${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}';
-            const encodedAppPackage = encodeURIComponent(appPackage);
-            const firebaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
-
-            const issuerId = '${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}';
-            const appId = '${{ secrets.IOS_APPLE_ID }}';
-            const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
-
-            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-            const attempts = 3;
-
-            for (let attempt = 0; attempt < attempts; attempt += 1) {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100,
-              });
-
-              const existing = comments.find((c) => c.body && c.body.includes(marker));
-              const existingLines = existing?.body?.split('\n') ?? [];
-              const existingIosLine = existingLines.find((line) => line.includes('iOS (TestFlight)'));
-              const iosHasCurrentSha = existingIosLine?.includes(`ios-sha:${buildSha}`);
-
-              const androidLine = `- ✅ Android (Firebase): ${firebaseUrl} <!-- android-sha:${buildSha} -->`;
-              const iosLine = iosHasCurrentSha
-                ? existingIosLine
-                : `- ⏳ iOS (TestFlight): pending upload <!-- ios-sha:${buildSha} -->`;
-
-              const body = `${marker}
-              ✅ Preview build links for PR #${prNumber}
-
-              ${androidLine}
-              ${iosLine}
-              `;
-
-              try {
-                if (existing) {
-                  await github.rest.issues.updateComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: existing.id,
-                    body,
-                  });
-                } else {
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: prNumber,
-                    body,
-                  });
-                }
-                break;
-              } catch (error) {
-                if (attempt === attempts - 1) {
-                  throw error;
-                }
-                await sleep(1000 * (attempt + 1));
-              }
-            }
+          platform: android
+          android_firebase_project_id: ${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}
+          android_firebase_app_package: ${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}
+          ios_app_store_connect_api_key_issuer_id: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          ios_apple_id: ${{ secrets.IOS_APPLE_ID }}
 
   deploy_ios:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
@@ -190,74 +128,12 @@ jobs:
           IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
           IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Post or update preview comment (iOS)
-        uses: actions/github-script@v7
+      
+      - name: Post or update PR comment (IOS)
+        uses: ./.github/actions/update_preview_comment
         with:
-          script: |
-            const marker = '<!-- preview-build-links -->';
-            const prNumber = context.issue.number;
-            const buildSha = context.sha;
-
-            const projectId = '${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}';
-            const appPackage = '${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}';
-            const encodedAppPackage = encodeURIComponent(appPackage);
-            const firebaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
-
-            const issuerId = '${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}';
-            const appId = '${{ secrets.IOS_APPLE_ID }}';
-            const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
-            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-            const attempts = 3;
-
-            for (let attempt = 0; attempt < attempts; attempt += 1) {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100,
-              });
-
-              const existing = comments.find((c) => c.body && c.body.includes(marker));
-              const existingLines = existing?.body?.split('\n') ?? [];
-              const existingAndroidLine = existingLines.find((line) => line.includes('Android (Firebase)'));
-              const androidHasCurrentSha = existingAndroidLine?.includes(`android-sha:${buildSha}`);
-
-              const androidLine = androidHasCurrentSha
-                ? existingAndroidLine
-                : `- ⏳ Android (Firebase): pending upload <!-- android-sha:${buildSha} -->`;
-              const iosLine = `- ✅ iOS (TestFlight): ${testflightUrl} <!-- ios-sha:${buildSha} -->`;
-
-              const body = `${marker}
-              ✅ Preview build links for PR #${prNumber}
-
-              ${androidLine}
-              ${iosLine}
-              `;
-
-              try {
-                if (existing) {
-                  await github.rest.issues.updateComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: existing.id,
-                    body,
-                  });
-                } else {
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: prNumber,
-                    body,
-                  });
-                }
-                break;
-              } catch (error) {
-                if (attempt === attempts - 1) {
-                  throw error;
-                }
-                await sleep(1000 * (attempt + 1));
-              }
-            }
-
-
+          platform: ios
+          android_firebase_project_id: ${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}
+          android_firebase_app_package: ${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}
+          ios_app_store_connect_api_key_issuer_id: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          ios_apple_id: ${{ secrets.IOS_APPLE_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,6 +90,7 @@ jobs:
           script: |
             const marker = '<!-- preview-build-links -->';
             const prNumber = context.issue.number;
+            const buildSha = context.sha;
 
             const projectId = '${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}';
             const appPackage = '${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}';
@@ -110,9 +111,12 @@ jobs:
             const existing = comments.find((c) => c.body && c.body.includes(marker));
             const existingLines = existing?.body?.split('\n') ?? [];
             const existingIosLine = existingLines.find((line) => line.includes('iOS (TestFlight)'));
+            const iosHasCurrentSha = existingIosLine?.includes(`ios-sha:${buildSha}`);
 
-            const androidLine = `- ✅ Android (Firebase): ${firebaseUrl}`;
-            const iosLine = existingIosLine ?? `- ⏳ iOS (TestFlight): ${testflightUrl}`;
+            const androidLine = `- ✅ Android (Firebase): ${firebaseUrl} <!-- android-sha:${buildSha} -->`;
+            const iosLine = iosHasCurrentSha
+              ? existingIosLine
+              : `- ⏳ iOS (TestFlight): pending upload <!-- ios-sha:${buildSha} -->`;
 
             const body = `${marker}
             ✅ Preview build links for PR #${prNumber}
@@ -180,6 +184,7 @@ jobs:
           script: |
             const marker = '<!-- preview-build-links -->';
             const prNumber = context.issue.number;
+            const buildSha = context.sha;
 
             const projectId = '${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}';
             const appPackage = '${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}';
@@ -199,9 +204,12 @@ jobs:
             const existing = comments.find((c) => c.body && c.body.includes(marker));
             const existingLines = existing?.body?.split('\n') ?? [];
             const existingAndroidLine = existingLines.find((line) => line.includes('Android (Firebase)'));
+            const androidHasCurrentSha = existingAndroidLine?.includes(`android-sha:${buildSha}`);
 
-            const androidLine = existingAndroidLine ?? `- ⏳ Android (Firebase): ${firebaseUrl}`;
-            const iosLine = `- ✅ iOS (TestFlight): ${testflightUrl}`;
+            const androidLine = androidHasCurrentSha
+              ? existingAndroidLine
+              : `- ⏳ Android (Firebase): pending upload <!-- android-sha:${buildSha} -->`;
+            const iosLine = `- ✅ iOS (TestFlight): ${testflightUrl} <!-- ios-sha:${buildSha} -->`;
 
             const body = `${marker}
             ✅ Preview build links for PR #${prNumber}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,3 +113,60 @@ jobs:
           IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
           IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+
+          
+  post_preview_comment:
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
+    needs: [deploy_android, deploy_ios]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Post or update consolidated preview comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- preview-build-links -->';
+            const prNumber = context.issue.number;
+
+            const projectId = '${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}';
+            const appPackage = '${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}';
+            const encodedAppPackage = encodeURIComponent(appPackage);
+            const firebaseUrl = `https://console.firebase.google.com/u/0/project/${projectId}/appdistribution/app/android:${encodedAppPackage}/releases`;
+
+            const issuerId = '${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}';
+            const appId = '${{ secrets.IOS_APPLE_ID }}';
+            const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
+
+            const body = `${marker}
+            ✅ Preview builds are ready for PR #${prNumber}
+
+            - 🤖 Android (Firebase): ${firebaseUrl}
+            - 🍏 iOS (TestFlight): ${testflightUrl}
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,44 +101,57 @@ jobs:
             const appId = '${{ secrets.IOS_APPLE_ID }}';
             const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const attempts = 3;
 
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            const existingLines = existing?.body?.split('\n') ?? [];
-            const existingIosLine = existingLines.find((line) => line.includes('iOS (TestFlight)'));
-            const iosHasCurrentSha = existingIosLine?.includes(`ios-sha:${buildSha}`);
-
-            const androidLine = `- ✅ Android (Firebase): ${firebaseUrl} <!-- android-sha:${buildSha} -->`;
-            const iosLine = iosHasCurrentSha
-              ? existingIosLine
-              : `- ⏳ iOS (TestFlight): pending upload <!-- ios-sha:${buildSha} -->`;
-
-            const body = `${marker}
-            ✅ Preview build links for PR #${prNumber}
-
-            ${androidLine}
-            ${iosLine}
-            `;
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            for (let attempt = 0; attempt < attempts; attempt += 1) {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body,
+                per_page: 100,
               });
+
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
+              const existingLines = existing?.body?.split('\n') ?? [];
+              const existingIosLine = existingLines.find((line) => line.includes('iOS (TestFlight)'));
+              const iosHasCurrentSha = existingIosLine?.includes(`ios-sha:${buildSha}`);
+
+              const androidLine = `- ✅ Android (Firebase): ${firebaseUrl} <!-- android-sha:${buildSha} -->`;
+              const iosLine = iosHasCurrentSha
+                ? existingIosLine
+                : `- ⏳ iOS (TestFlight): pending upload <!-- ios-sha:${buildSha} -->`;
+
+              const body = `${marker}
+              ✅ Preview build links for PR #${prNumber}
+
+              ${androidLine}
+              ${iosLine}
+              `;
+
+              try {
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body,
+                  });
+                }
+                break;
+              } catch (error) {
+                if (attempt === attempts - 1) {
+                  throw error;
+                }
+                await sleep(1000 * (attempt + 1));
+              }
             }
 
   deploy_ios:
@@ -194,43 +207,57 @@ jobs:
             const issuerId = '${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}';
             const appId = '${{ secrets.IOS_APPLE_ID }}';
             const testflightUrl = `https://appstoreconnect.apple.com/teams/${issuerId}/apps/${appId}/testflight/ios`;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const attempts = 3;
 
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            const existingLines = existing?.body?.split('\n') ?? [];
-            const existingAndroidLine = existingLines.find((line) => line.includes('Android (Firebase)'));
-            const androidHasCurrentSha = existingAndroidLine?.includes(`android-sha:${buildSha}`);
-
-            const androidLine = androidHasCurrentSha
-              ? existingAndroidLine
-              : `- ⏳ Android (Firebase): pending upload <!-- android-sha:${buildSha} -->`;
-            const iosLine = `- ✅ iOS (TestFlight): ${testflightUrl} <!-- ios-sha:${buildSha} -->`;
-
-            const body = `${marker}
-            ✅ Preview build links for PR #${prNumber}
-
-            ${androidLine}
-            ${iosLine}
-            `;
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            for (let attempt = 0; attempt < attempts; attempt += 1) {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body,
+                per_page: 100,
               });
+
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
+              const existingLines = existing?.body?.split('\n') ?? [];
+              const existingAndroidLine = existingLines.find((line) => line.includes('Android (Firebase)'));
+              const androidHasCurrentSha = existingAndroidLine?.includes(`android-sha:${buildSha}`);
+
+              const androidLine = androidHasCurrentSha
+                ? existingAndroidLine
+                : `- ⏳ Android (Firebase): pending upload <!-- android-sha:${buildSha} -->`;
+              const iosLine = `- ✅ iOS (TestFlight): ${testflightUrl} <!-- ios-sha:${buildSha} -->`;
+
+              const body = `${marker}
+              ✅ Preview build links for PR #${prNumber}
+
+              ${androidLine}
+              ${iosLine}
+              `;
+
+              try {
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body,
+                  });
+                }
+                break;
+              } catch (error) {
+                if (attempt === attempts - 1) {
+                  throw error;
+                }
+                await sleep(1000 * (attempt + 1));
+              }
             }
+
 

--- a/docs/release_notes/1.0.19.md
+++ b/docs/release_notes/1.0.19.md
@@ -1,0 +1,4 @@
+v1.0.19
+
+# CI/CD improvements
+- Refactor and consolidate iOS + Android Build Comments into a Single PR Comment.

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -267,9 +267,6 @@ def ios_deploy_preview!(options = {})
 
       # Distribution
       skip_waiting_for_build_processing: false,  # wait so changelog can be attached
-      distribute_external: true,                 # send to external testers, project specific
-      groups: ["External Testers"],    # <-- project-specific, see comment
-      notify_external_testers: true,             # send email/notification, project specific
     )
     UI.success("✅ TestFlight upload complete! Build: #{next_build}")
   rescue => e

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -253,7 +253,6 @@ def ios_deploy_preview!(options = {})
 
   # IMPORTANT:
   # - Assumes Beta App Info + Test Info already configured in App Store Connect.
-  # - Assumes external group "QA" exists and has testers.
   begin
     UI.message('☁️ Uploading to TestFlight...')
     upload_to_testflight(

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -253,6 +253,7 @@ def ios_deploy_preview!(options = {})
 
   # IMPORTANT:
   # - Assumes Beta App Info + Test Info already configured in App Store Connect.
+  # - Assumes external group "QA" exists and has testers.
   begin
     UI.message('☁️ Uploading to TestFlight...')
     upload_to_testflight(
@@ -266,6 +267,9 @@ def ios_deploy_preview!(options = {})
 
       # Distribution
       skip_waiting_for_build_processing: false,  # wait so changelog can be attached
+      distribute_external: true,                 # send to external testers, project specific
+      groups: ["External Testers"],    # <-- project-specific, see comment
+      notify_external_testers: true,             # send email/notification, project specific
     )
     UI.success("✅ TestFlight upload complete! Build: #{next_build}")
   rescue => e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Description
Our CD workflows currently posts two separate PR comments for each preview build (Android and iOS) on every run. This creates unnecessary noise and makes PR discussions harder to scan. This PR replaces the two comments with a single consolidated comment that includes links to both Android (Firebase/App Distribution) and iOS (TestFlight/App Store Connect).

**Key Improvements:**
- One comment updated in-place (no noise).
- Status tracking (✅ complete / ⏳ pending) via SHA markers.
- **Reusable composite action** for forks/templates.
- Race-safe with retry logic.

## File Changes
- `.github/actions/update_preview_comment/action.yml` → **New** reusable action.
- `.github/workflows/cd.yml` → Short action calls in android/ios jobs.
- `.github/actions/deploy_android_preview/action.yml` → Removed PR comment.
- `.github/actions/deploy_ios_preview/action.yml` → Removed PR comment.
- `.github/CI_README.md` → Updated docs.

## Tests

### Manual Workflow Ran and Tested

## Screenshots

**1) Android upload complete + comment showing Android link with iOS pending (works vice versa)**


<img width="1169" height="336" alt="Screenshot from 2026-01-07 16-10-54" src="https://github.com/user-attachments/assets/6875fc92-8118-4275-9a68-256bf0193054" />
<img width="1169" height="336" alt="Screenshot from 2026-01-07 16-10-41" src="https://github.com/user-attachments/assets/4c229c91-273e-468d-bb7f-8840be2be54d" />

**2) Both Android and iOS uploads complete + comment showing both links**


<img width="1169" height="336" alt="Screenshot from 2026-01-07 16-20-51" src="https://github.com/user-attachments/assets/089ca54a-e5ea-40ad-ae42-0bccee183f95" />
<img width="1169" height="336" alt="Screenshot from 2026-01-07 16-21-10" src="https://github.com/user-attachments/assets/3623d8ca-ed2e-4276-9f7a-d5aa1c6b1dea" />
