### PR TITLE
feat: add variable package naming for android builds

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -51,6 +51,7 @@ These jobs run **independently and in parallel**, improving feedback time.
   - `versionNameOverride` is taken from `package.json` (e.g., `1.2.3`).
   - `versionCodeOverride` is computed from semantic version as  
     `major * 10000 + minor * 100 + patch` (e.g., `1.2.3 → 10203`).
+  - Uses the QA flavor by default (`ANDROID_PREVIEW_FLAVOR=qa`) so preview installs use the `.qa` package suffix.
   - Uploads the `.apk` (or `.aab` for preview if configured) to a preview group.
   - Attaches the same validated release notes as Firebase release notes.
 - Builds and deploys **iOS preview** to **TestFlight**:
@@ -93,6 +94,7 @@ Push to `main`
 * Builds and deploys Android apk to **Google Play Console**:
   * `versionNameOverride` comes from `package.json`.
   * `versionCodeOverride` is derived from the semantic version (`major*10000 + minor*100 + patch`).
+  * Uses the production flavor by default (`ANDROID_PRODUCTION_FLAVOR=production`) so Play Store uploads keep the base applicationId.
 * Builds and deploys iOS to the **Apple Store Connect**:
   * `version` number comes from `package.json`.
   * `build_number` is calculated by encoding the version / marketing version (e.g. "1.0.13" -> "1000013").
@@ -134,7 +136,10 @@ These environment variables are used by the GitHub Actions workflows and Fastlan
 | `ANDROID_FIREBASE_PROJECT_NUMBER` | GitHub Secret       | Firebase project number for Android app distribution.                                                                                       |
 | `ANDROID_FIREBASE_APP_ID`       | GitHub Secret         | Firebase App Distribution app ID for the Android app.                                                                                       |
 | `ANDROID_FIREBASE_PROJECT_ID`   | GitHub Secret         | Firebase project ID used for console links.                                                                                       |
-| `ANDROID_FIREBASE_APP_PACKAGE`  | GitHub Secret         | Android app package name used in Firebase.                                                                                       |
+| `ANDROID_FIREBASE_APP_PACKAGE`  | GitHub Secret         | Android app package name used in Firebase (for preview builds this should match the QA package, e.g. `<base>.qa`).                                                                                       |
+| `ANDROID_PREVIEW_FLAVOR`        | Workflow/ENV optional | Android flavor used for preview builds (defaults to `qa`).                                                                        |
+| `ANDROID_PRODUCTION_FLAVOR`     | Workflow/ENV optional | Android flavor used for production builds (defaults to `production`).                                                             |
+| `ANDROID_APP_IDENTIFIER`        | GitHub Secret         | Android applicationId/package name used by Fastlane for Play Store uploads (keeps Android config in secrets like iOS).            |
 | `ANDROID_FIREBASE_API_KEY`      | GitHub Secret         | Firebase API key for Android deployment.                                                                                       |
 | `KEYSTORE_FILE`         | GitHub Secret         | Base64-encoded Android keystore file. Decoded and used to sign Android builds during Play Store deployments.                                       |
 | `KEYSTORE_PASSWORD`     | GitHub Secret         | Password for the Android keystore file used in signing builds.                                                                               |

--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -31,6 +31,7 @@ These jobs run **independently and in parallel**, improving feedback time.
 * Builds and deploys Android (Firebase App Distribution) with explicit Gradle overrides so CD never uses manifest defaults:
   * `versionNameOverride` comes from `package.json`.
   * `versionCodeOverride` is derived from the semantic version (`major*10000 + minor*100 + patch`).
+* Uses the preview flavor by default (`ANDROID_PREVIEW_FLAVOR=preview`), which appends the `applicationIdSuffix` for side-by-side installs.
 * Builds and deploys iOS (TestFlight) with build number generated with combination of PR + Timestamp.
 * Comments on the PR with the Firebase and Testflight Link
 
@@ -51,7 +52,7 @@ These jobs run **independently and in parallel**, improving feedback time.
   - `versionNameOverride` is taken from `package.json` (e.g., `1.2.3`).
   - `versionCodeOverride` is computed from semantic version as  
     `major * 10000 + minor * 100 + patch` (e.g., `1.2.3 → 10203`).
-  - Uses the QA flavor by default (`ANDROID_PREVIEW_FLAVOR=qa`) so preview installs use the `.qa` package suffix.
+  - Uses the preview flavor by default (`ANDROID_PREVIEW_FLAVOR=preview`) so preview installs use the `.preview` package suffix.
   - Uploads the `.apk` (or `.aab` for preview if configured) to a preview group.
   - Attaches the same validated release notes as Firebase release notes.
 - Builds and deploys **iOS preview** to **TestFlight**:
@@ -136,8 +137,8 @@ These environment variables are used by the GitHub Actions workflows and Fastlan
 | `ANDROID_FIREBASE_PROJECT_NUMBER` | GitHub Secret       | Firebase project number for Android app distribution.                                                                                       |
 | `ANDROID_FIREBASE_APP_ID`       | GitHub Secret         | Firebase App Distribution app ID for the Android app.                                                                                       |
 | `ANDROID_FIREBASE_PROJECT_ID`   | GitHub Secret         | Firebase project ID used for console links.                                                                                       |
-| `ANDROID_FIREBASE_APP_PACKAGE`  | GitHub Secret         | Android app package name used in Firebase (for preview builds this should match the QA package, e.g. `<base>.qa`).                                                                                       |
-| `ANDROID_PREVIEW_FLAVOR`        | Workflow/ENV optional | Android flavor used for preview builds (defaults to `qa`).                                                                        |
+| `ANDROID_FIREBASE_APP_PACKAGE`  | GitHub Secret         | Android app package name used in Firebase (for preview builds this should match the preview package, e.g. `<base>.preview`).                                                                                       |
+| `ANDROID_PREVIEW_FLAVOR`        | Workflow/ENV optional | Android flavor used for preview builds (defaults to `preview`).                                                                        |
 | `ANDROID_PRODUCTION_FLAVOR`     | Workflow/ENV optional | Android flavor used for production builds (defaults to `production`).                                                             |
 | `ANDROID_APP_IDENTIFIER`        | GitHub Secret         | Android applicationId/package name used by Fastlane for Play Store uploads (keeps Android config in secrets like iOS).            |
 | `ANDROID_FIREBASE_API_KEY`      | GitHub Secret         | Firebase API key for Android deployment.                                                                                       |

--- a/.github/actions/deploy_android_production/action.yml
+++ b/.github/actions/deploy_android_production/action.yml
@@ -2,6 +2,9 @@ name: 'Deploy Android App to Production'
 description: 'Build and deploy the Android app to Production using Fastlane'
 
 inputs:
+  ANDROID_APP_IDENTIFIER:
+    required: false
+    description: 'Android applicationId/package name (overrides fastlane Appfile)'
   GPLAY_SERVICE_ACCOUNT_KEY_JSON:
     required: true
     description: 'Service Account Key JSON file for Google Play Store'
@@ -119,6 +122,7 @@ runs:
       working-directory: android
       run: bundle exec fastlane deploy_android_production
       env:
+        ANDROID_APP_IDENTIFIER: ${{ inputs.ANDROID_APP_IDENTIFIER }}
         ANDROID_KEYSTORE_FILE: ${{ steps.android_keystore.outputs.filePath }}
         ANDROID_KEYSTORE_PASSWORD: ${{ inputs.ANDROID_KEYSTORE_PASSWORD }}
         ANDROID_KEY_ALIAS: ${{ inputs.ANDROID_KEY_ALIAS }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     branches:
-      - vikram/feat/variable-package-naming
+      - main
 
 concurrency:
   group: cd-production
@@ -52,34 +52,34 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
 
-  # deploy_ios:
-  #   runs-on: macos-14
-  #   needs: [release_notes_check]
-  #   timeout-minutes: 30
-  #   steps:
-  #     - name: Checkout (app)
-  #       uses: actions/checkout@v4
+  deploy_ios:
+    runs-on: macos-14
+    needs: [release_notes_check]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (app)
+        uses: actions/checkout@v4
         
-  #     - name: Inject Doppler Production Secrets
-  #       uses: ./.github/actions/inject_doppler_secrets
-  #       with:
-  #         doppler_token: ${{ secrets.DOPPLER_PRODUCTION_TOKEN }}
-  #         doppler_project: react-native-template
-  #         doppler_environment: production
-  #         working_directory: . 
+      - name: Inject Doppler Production Secrets
+        uses: ./.github/actions/inject_doppler_secrets
+        with:
+          doppler_token: ${{ secrets.DOPPLER_PRODUCTION_TOKEN }}
+          doppler_project: react-native-template
+          doppler_environment: production
+          working_directory: . 
           
-  #     - name: Deploy iOS app to App Store
-  #       uses: ./.github/actions/deploy_ios_production
-  #       with:
-  #         RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
-  #         IOS_MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
-  #         IOS_MATCH_REPOSITORY_URL: ${{ secrets.IOS_MATCH_REPOSITORY_URL }}
-  #         IOS_APPLE_ID: ${{ secrets.IOS_APPLE_ID }}
-  #         IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
-  #         IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
-  #         IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-  #         IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
-  #         IOS_APP_IDENTIFIER: ${{ secrets.IOS_APP_IDENTIFIER }}
-  #         IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
-  #         IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
-  #         IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
+      - name: Deploy iOS app to App Store
+        uses: ./.github/actions/deploy_ios_production
+        with:
+          RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
+          IOS_MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
+          IOS_MATCH_REPOSITORY_URL: ${{ secrets.IOS_MATCH_REPOSITORY_URL }}
+          IOS_APPLE_ID: ${{ secrets.IOS_APPLE_ID }}
+          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+          IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
+          IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
+          IOS_APP_IDENTIFIER: ${{ secrets.IOS_APP_IDENTIFIER }}
+          IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
+          IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
+          IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -44,6 +44,7 @@ jobs:
         id: deploy_android_production
         uses: ./.github/actions/deploy_android_production
         with:
+          ANDROID_APP_IDENTIFIER: ${{ secrets.ANDROID_APP_IDENTIFIER }}
           GPLAY_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.GPLAY_SERVICE_ACCOUNT_KEY_JSON }}
           ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     branches:
-      - main  
+      - vikram/feat/variable-package-naming
 
 concurrency:
   group: cd-production
@@ -52,34 +52,34 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
 
-  deploy_ios:
-    runs-on: macos-14
-    needs: [release_notes_check]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout (app)
-        uses: actions/checkout@v4
+  # deploy_ios:
+  #   runs-on: macos-14
+  #   needs: [release_notes_check]
+  #   timeout-minutes: 30
+  #   steps:
+  #     - name: Checkout (app)
+  #       uses: actions/checkout@v4
         
-      - name: Inject Doppler Production Secrets
-        uses: ./.github/actions/inject_doppler_secrets
-        with:
-          doppler_token: ${{ secrets.DOPPLER_PRODUCTION_TOKEN }}
-          doppler_project: react-native-template
-          doppler_environment: production
-          working_directory: . 
+  #     - name: Inject Doppler Production Secrets
+  #       uses: ./.github/actions/inject_doppler_secrets
+  #       with:
+  #         doppler_token: ${{ secrets.DOPPLER_PRODUCTION_TOKEN }}
+  #         doppler_project: react-native-template
+  #         doppler_environment: production
+  #         working_directory: . 
           
-      - name: Deploy iOS app to App Store
-        uses: ./.github/actions/deploy_ios_production
-        with:
-          RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
-          IOS_MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
-          IOS_MATCH_REPOSITORY_URL: ${{ secrets.IOS_MATCH_REPOSITORY_URL }}
-          IOS_APPLE_ID: ${{ secrets.IOS_APPLE_ID }}
-          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
-          IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
-          IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
-          IOS_APP_IDENTIFIER: ${{ secrets.IOS_APP_IDENTIFIER }}
-          IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
-          IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
-          IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
+  #     - name: Deploy iOS app to App Store
+  #       uses: ./.github/actions/deploy_ios_production
+  #       with:
+  #         RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
+  #         IOS_MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
+  #         IOS_MATCH_REPOSITORY_URL: ${{ secrets.IOS_MATCH_REPOSITORY_URL }}
+  #         IOS_APPLE_ID: ${{ secrets.IOS_APPLE_ID }}
+  #         IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+  #         IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
+  #         IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+  #         IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
+  #         IOS_APP_IDENTIFIER: ${{ secrets.IOS_APP_IDENTIFIER }}
+  #         IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
+  #         IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
+  #         IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Set `LOGGER=datadog` or `LOGGER=console,datadog` to enable Datadog logging.
 2. **Android:**
    - `android/settings.gradle`: Update `rootProject.name`
    - `android/app/build.gradle`: Update `namespace` and `applicationId`
-   - Keep the default `production` flavor, as base package, and the `qa` flavor uses `"applicationIdSuffix".qa"` for side-by-side installs.
+   - Keep the default `production` flavor, as base package, and the `qa` flavor uses `applicationIdSuffix ".qa"` for side-by-side installs.
    - Rename package directories under `android/app/src/*/java/com/boilerplate/`
    - Update package declarations in Java/Kotlin files
    - `android/app/src/main/res/values/strings.xml`: Update `app_name`

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Set `LOGGER=datadog` or `LOGGER=console,datadog` to enable Datadog logging.
 2. **Android:**
    - `android/settings.gradle`: Update `rootProject.name`
    - `android/app/build.gradle`: Update `namespace` and `applicationId`
+   - Keep the default `production` flavor, as base package, and the `qa` flavor uses `"applicationIdSuffix".qa"` for side-by-side installs.
    - Rename package directories under `android/app/src/*/java/com/boilerplate/`
    - Update package declarations in Java/Kotlin files
    - `android/app/src/main/res/values/strings.xml`: Update `app_name`
@@ -118,6 +119,35 @@ Set `LOGGER=datadog` or `LOGGER=console,datadog` to enable Datadog logging.
 4. **CI/CD:**
    - `.github/workflows/*.yml`: Update project references
    - `sonar-project.properties`: Update `sonar.projectKey`
+
+## Android Flavoring & CI/CD Setup
+
+This template ships with two Android flavors so QA preview builds can coexist with production installs:
+- **production**: base `applicationId`
+- **qa**: uses `applicationIdSuffix".qa"` so it installs as `<base>.qa`
+
+### Required GitHub Secrets (Android)
+
+| Secret | Purpose |
+|--------|---------|
+| `ANDROID_APP_IDENTIFIER` | Production package name used by Fastlane/Play uploads (e.g., `com.company.app`). |
+| `ANDROID_FIREBASE_APP_ID` | Firebase App Distribution app ID for preview (QA) builds. |
+| `ANDROID_FIREBASE_APP_PACKAGE` | QA package name for Firebase (e.g., `com.company.app.qa`). |
+| `ANDROID_FIREBASE_PROJECT_NUMBER` | Firebase project number for preview builds. |
+| `ANDROID_FIREBASE_PROJECT_ID` | Firebase project ID for preview builds. |
+
+### Optional Environment Overrides
+
+| Variable | Default | When to change |
+|----------|---------|----------------|
+| `ANDROID_PREVIEW_FLAVOR` | `qa` | If you rename the preview flavor. |
+| `ANDROID_PRODUCTION_FLAVOR` | `production` | If you rename the production flavor. |
+
+### Firebase & Play Console Notes
+
+- **Firebase App Distribution** should point to the **QA package** (`<base>.qa`) so preview builds install separately.
+- **Google Play Console** should use the **production package** (`<base>`). No QA package is needed in Play Console.
+
 
 ## Key Libraries
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Set `LOGGER=datadog` or `LOGGER=console,datadog` to enable Datadog logging.
 2. **Android:**
    - `android/settings.gradle`: Update `rootProject.name`
    - `android/app/build.gradle`: Update `namespace` and `applicationId`
-   - Keep the default `production` flavor, as base package, and the `qa` flavor uses `applicationIdSuffix ".qa"` for side-by-side installs.
+   - Keep the default `production` flavor as the base package, and the `preview` flavor uses `applicationIdSuffix ".preview"` for side-by-side installs.
    - Rename package directories under `android/app/src/*/java/com/boilerplate/`
    - Update package declarations in Java/Kotlin files
    - `android/app/src/main/res/values/strings.xml`: Update `app_name`
@@ -122,17 +122,17 @@ Set `LOGGER=datadog` or `LOGGER=console,datadog` to enable Datadog logging.
 
 ## Android Flavoring & CI/CD Setup
 
-This template ships with two Android flavors so QA preview builds can coexist with production installs:
+This template ships with two Android flavors so preview builds can coexist with production installs:
 - **production**: base `applicationId`
-- **qa**: uses `applicationIdSuffix".qa"` so it installs as `<base>.qa`
+- **preview**: uses `applicationIdSuffix ".preview"` so it installs as `<base>.preview`
 
 ### Required GitHub Secrets (Android)
 
 | Secret | Purpose |
 |--------|---------|
 | `ANDROID_APP_IDENTIFIER` | Production package name used by Fastlane/Play uploads (e.g., `com.company.app`). |
-| `ANDROID_FIREBASE_APP_ID` | Firebase App Distribution app ID for preview (QA) builds. |
-| `ANDROID_FIREBASE_APP_PACKAGE` | QA package name for Firebase (e.g., `com.company.app.qa`). |
+| `ANDROID_FIREBASE_APP_ID` | Firebase App Distribution app ID for preview builds. |
+| `ANDROID_FIREBASE_APP_PACKAGE` | Preview package name for Firebase (e.g., `com.company.app.preview`). |
 | `ANDROID_FIREBASE_PROJECT_NUMBER` | Firebase project number for preview builds. |
 | `ANDROID_FIREBASE_PROJECT_ID` | Firebase project ID for preview builds. |
 
@@ -140,12 +140,12 @@ This template ships with two Android flavors so QA preview builds can coexist wi
 
 | Variable | Default | When to change |
 |----------|---------|----------------|
-| `ANDROID_PREVIEW_FLAVOR` | `qa` | If you rename the preview flavor. |
+| `ANDROID_PREVIEW_FLAVOR` | `preview` | If you rename the preview flavor. |
 | `ANDROID_PRODUCTION_FLAVOR` | `production` | If you rename the production flavor. |
 
 ### Firebase & Play Console Notes
 
-- **Firebase App Distribution** should point to the **QA package** (`<base>.qa`) so preview builds install separately.
+- **Firebase App Distribution** should point to the **preview package** (`<base>.preview`) so preview builds install separately.
 - **Google Play Console** should use the **production package** (`<base>`). No QA package is needed in Play Console.
 
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,7 +27,7 @@ react {
     //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
     //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
     // debuggableVariants = ["liteDebug", "prodDebug"]
-    debuggableVariants = shouldBundleInDebug ? [] : ["productionDebug", "qaDebug"]
+        debuggableVariants = shouldBundleInDebug ? [] : ["productionDebug", "previewDebug"]
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.
@@ -101,9 +101,9 @@ android {
         production {
             dimension "environment"
         }
-        qa {
+        preview {
             dimension "environment"
-            applicationIdSuffix ".qa"
+            applicationIdSuffix ".preview"
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,7 +27,7 @@ react {
     //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
     //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
     // debuggableVariants = ["liteDebug", "prodDebug"]
-    debuggableVariants = shouldBundleInDebug ? [] : ["debug"]
+    debuggableVariants = shouldBundleInDebug ? [] : ["productionDebug", "qaDebug"]
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.
@@ -94,6 +94,17 @@ android {
         versionCode appVersionCode
         versionName appVersionName
 
+    }
+    
+    flavorDimensions "environment"
+    productFlavors {
+        production {
+            dimension "environment"
+        }
+        qa {
+            dimension "environment"
+            applicationIdSuffix ".qa"
+        }
     }
 
     signingConfigs {

--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,1 +1,1 @@
-package_name("com.bettrsw.boilerplate.app") # e.g. com.krausefx.app
+package_name(ENV["ANDROID_APP_IDENTIFIER"] || "com.bettrsw.boilerplate.app") # e.g. com.krausefx.app

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -17,6 +17,9 @@
 default_platform(:android)
 
 platform :android do
+  def android_flavor_task_name(flavor)
+    flavor.split(/[^a-zA-Z0-9]/).map(&:capitalize).join
+  end
 
   desc "Fetches the latest version code from the Play Console and increments it by 1"
   lane :fetch_and_increment_build_number do
@@ -43,6 +46,14 @@ platform :android do
     version_name = package_json["version"]
     UI.user_error!("❌ Version not found in package.json") unless version_name
 
+    # Production builds should use the base applicationId (no suffix).
+    # Keep this overrideable for forks that rename flavors without touching Fastlane.
+    # ANDROID_PRODUCTION_FLAVOR is optional and can be passed from github secrets to workflows.
+    # If ANDROID_PRODUCTION_FLAVOR is available as ENV we will use it, otherwise default is production
+    # More about build variants and flavours : https://developer.android.com/build/build-variants
+    production_flavor = ENV.fetch("ANDROID_PRODUCTION_FLAVOR", "production")
+    gradle_task_flavor = android_flavor_task_name(production_flavor)
+
     app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier) ||
                      CredentialsManager::AppfileConfig.try_fetch_value(:package_name)
     UI.user_error!("❌ App identifier not configured") unless app_identifier
@@ -64,8 +75,7 @@ platform :android do
 
     # 3) Build with injected versionCode + versionName
     gradle(
-      task: "bundle",
-      build_type: "release",
+      task: "bundle#{gradle_task_flavor}Release",
       properties: {
         "android.injected.signing.store.file" => ENV["ANDROID_KEYSTORE_FILE"],
         "android.injected.signing.store.password" => ENV["ANDROID_KEYSTORE_PASSWORD"],

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -18,6 +18,7 @@ default_platform(:android)
 
 platform :android do
   def android_flavor_task_name(flavor)
+    # Convert a flavor string (e.g., "qa" or "production") into Gradle task casing.
     flavor.split(/[^a-zA-Z0-9]/).map(&:capitalize).join
   end
 

--- a/android/fastlane/scripts/firebase_distribution_service.rb
+++ b/android/fastlane/scripts/firebase_distribution_service.rb
@@ -58,12 +58,12 @@ class FirebaseDistributionService
 
     UI.message("🔨 Building APK with Gradle...")
 
-    # Preview builds should use the QA flavor so installs can coexist with production.
+    # Preview builds should use the preview flavor so installs can coexist with production.
     # Allow overrides for forks that rename flavors or use a different preview variant.
     # ANDROID_PREVIEW_FLAVOR is optional and can be passed from github secrets to workflows.
-    # If ANDROID_PREVIEW_FLAVOR is available as ENV we will use it, otherwise default is qa
+    # If ANDROID_PREVIEW_FLAVOR is available as ENV we will use it, otherwise default is preview
     # More about build variants and flavours : https://developer.android.com/build/build-variants
-    preview_flavor = ENV.fetch("ANDROID_PREVIEW_FLAVOR", "qa")
+    preview_flavor = ENV.fetch("ANDROID_PREVIEW_FLAVOR", "preview")
     flavor_task = android_flavor_task_name(preview_flavor)
 
     Actions::GradleAction.run(

--- a/android/fastlane/scripts/firebase_distribution_service.rb
+++ b/android/fastlane/scripts/firebase_distribution_service.rb
@@ -58,9 +58,18 @@ class FirebaseDistributionService
 
     UI.message("🔨 Building APK with Gradle...")
 
+    # Preview builds should use the QA flavor so installs can coexist with production.
+    # Allow overrides for forks that rename flavors or use a different preview variant.
+    # ANDROID_PREVIEW_FLAVOR is optional and can be passed from github secrets to workflows.
+    # If ANDROID_PREVIEW_FLAVOR is available as ENV we will use it, otherwise default is qa
+    # More about build variants and flavours : https://developer.android.com/build/build-variants
+    preview_flavor = ENV.fetch("ANDROID_PREVIEW_FLAVOR", "qa")
+    flavor_task = android_flavor_task_name(preview_flavor)
+
+
     Actions::GradleAction.run(
       gradle_path: "./gradlew",
-      task: "assembleDebug",
+      task: "assemble#{flavor_task}Debug",
       project_dir: File.expand_path("../../", __dir__),
       properties: {
         "BUNDLE_IN_DEBUG" => "true",
@@ -73,11 +82,11 @@ class FirebaseDistributionService
       print_command_output: true
     )
 
-    apk = apk_path
+    apk = apk_path(preview_flavor)
     UI.user_error!("❌ APK not found at #{apk}") unless File.exist?(apk)
     UI.success("✅ APK built successfully: #{File.size(apk)} bytes")
 
-    { version: version, version_code: version_code }
+    { version: version, version_code: version_code, apk_path: apk }
   end
 
 
@@ -207,7 +216,13 @@ class FirebaseDistributionService
   private
 
   # Returns the expected debug APK path.
-  def apk_path
-    File.expand_path("../../app/build/outputs/apk/debug/app-debug.apk", __dir__)
+  def apk_path(flavor)
+    # APK output path follows the flavor name for assemble<Flavor>Debug.
+    File.expand_path("../../app/build/outputs/apk/#{flavor}/debug/app-#{flavor}-debug.apk", __dir__)
+  end
+
+  def android_flavor_task_name(flavor)
+    # Ensure Gradle task naming matches the flavor (e.g., qa -> Qa, production -> Production).
+    flavor.split(/[^a-zA-Z0-9]/).map(&:capitalize).join
   end
 end

--- a/android/fastlane/scripts/firebase_distribution_service.rb
+++ b/android/fastlane/scripts/firebase_distribution_service.rb
@@ -66,7 +66,6 @@ class FirebaseDistributionService
     preview_flavor = ENV.fetch("ANDROID_PREVIEW_FLAVOR", "qa")
     flavor_task = android_flavor_task_name(preview_flavor)
 
-
     Actions::GradleAction.run(
       gradle_path: "./gradlew",
       task: "assemble#{flavor_task}Debug",

--- a/android/fastlane/scripts/firebase_pr_deploy.rb
+++ b/android/fastlane/scripts/firebase_pr_deploy.rb
@@ -31,7 +31,7 @@ def firebase_pr_deploy(pr_number:, pr_title:, project_number:, app_id:, service_
   # Build the new APK with unique version code (returns version code)
   version_info = firebase.build_apk(pr_number: pr_number)
   
-  apk_path = File.expand_path("../../app/build/outputs/apk/debug/app-debug.apk", __dir__)
+  apk_path = version_info[:apk_path]
   UI.user_error!("❌ APK file not found at #{apk_path}") unless File.exist?(apk_path)
   
   # Read release notes if provided

--- a/docs/release_notes/1.0.20.md
+++ b/docs/release_notes/1.0.20.md
@@ -1,0 +1,2 @@
+v1.0.20
+- Add Android QA/production flavor handling in Fastlane and CI.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Summary
- Adds Android production/preview flavors and updates Fastlane/CI to build the correct variants for preview and production.
- Documents Android flavor setup and required secrets for preview/production.

## Files Changed

- **android/app/build.gradle**
  - Added `production` and `preview` product flavors.
  - `preview` uses `applicationIdSuffix ".preview"` for side‑by‑side installs.
  - Updated `react.debuggableVariants` to include flavored debug builds.

- **android/fastlane/Appfile**
  - `package_name` now reads from `ANDROID_APP_IDENTIFIER` (with fallback).

- **android/fastlane/Fastfile**
  - Added helper to map flavor names to Gradle task casing.
  - Production build now runs `bundle{Flavor}Release` based on `ANDROID_PRODUCTION_FLAVOR` (default `production`).
  - Added comments explaining flavor behavior and overrides.

- **android/fastlane/scripts/firebase_distribution_service.rb**
  - Preview build uses `ANDROID_PREVIEW_FLAVOR` (default `preview`).
  - Builds `assemble{Flavor}Debug` and resolves flavored APK output path.
  - Added comments explaining preview flavor and APK path derivation.

- **android/fastlane/scripts/firebase_pr_deploy.rb**
  - Uses the APK path returned from the build step (flavor-aware).

- **.github/actions/deploy_android_production/action.yml**
  - Added `ANDROID_APP_IDENTIFIER` input and passed it to Fastlane.

- **.github/workflows/production.yml**
  - Wires `ANDROID_APP_IDENTIFIER` secret into Android production deploy action.

- **.github/CI_README.md**
  - Documented preview/production flavor defaults and optional overrides.
  - Added `ANDROID_APP_IDENTIFIER` and Firebase preview package guidance.

- **README.md**
  - Added "Android Flavoring & CI/CD Setup" section covering flavors, secrets, overrides, and Firebase vs Play responsibilities.

## Firebase
- Created new Firebase App Distribution app in same `React Native Boilerplate` Project by name: **React Native Preview App**
- Package name: `com.bettrsw.boilerplate.app.preview` i.e. `<base_package_name>.preview`


## Before and After Workflow
### Before Changes

```mermaid
flowchart TB
  Before[Before: Single App Flavor]
  
  subgraph BeforeFlow
    A1[Developer/CI Trigger] --> B1[Preview Build on PR update]
    H1 --> C1[APK: app-debug.apk]
    C1 --> D1[Firebase App Distribution]
    
    A1 --> E1[Production build on merge to main]
    H1 --> F1[AAB: app-release.aab]
    F1 --> G1[Google Play Console]
    B1 -.-> H1[Package: com.company.app]
    E1 -.-> H1[Package: com.company.app]
    
    style H1 stroke-dasharray: 5 5
  end
```

### After Changes

```mermaid
flowchart TB
  After[After: Production/Preview Flavors]
  
  subgraph AfterFlow
    direction TB
    
    A2[CD Trigger] --> B2{Gradle Task Selection}
    
    B2 --> C2[Preview build]
    C2 --> F2[Package: com.company.app.preview]
    F2 --> D2[APK: app-preview-debug.apk]
    D2 --> E2[Firebase App Distribution Preview app]
    
    B2 --> G2[Production build]
    G2 -.-> J2[Package: com.company.app]
    J2 --> H2[AAB: app-production-release.aab]
    H2 --> I2[Google Play Console]
    
    style F2 stroke-dasharray: 5 5
    style J2 stroke-dasharray: 5 5
    
  end
```


## Testing
- Manual: workflow ran for test

1) Confirmed new preview package name in Firebase App Distribution and Tested app on Browserstack
<img width="1790" height="897" alt="image" src="https://github.com/user-attachments/assets/bafb2d03-b919-4c42-bde3-b2456da92226" />
<img width="1790" height="897" alt="image" src="https://github.com/user-attachments/assets/a19acea5-002b-4025-bcb9-62613d8934ac" />

2) Confirmed production package name is as is as before in Google Play Console
<img width="1787" height="939" alt="image" src="https://github.com/user-attachments/assets/b212b4cf-6b4d-4fb6-8c26-c5690446e28f" />


In summary now android preview and production builds are using separate package names with separate build flavours.