### PR TITLE
[WIP] feat: Add CI scan - Mobile Security Scan Gate for Deployments

### DIFF
--- a/.github/actions/deploy_android_preview/action.yml
+++ b/.github/actions/deploy_android_preview/action.yml
@@ -17,6 +17,9 @@ inputs:
   ANDROID_FIREBASE_API_KEY:
     description: 'Firebase API key'
     required: true
+  OSTORLAB_API_KEY:
+    description: 'API key for Ostorlab vulnerability scans'
+    required: true
   ANDROID_GCP_JSON_BASE64:
     description: 'GCP JSON key (base64 encoded)'
     required: true
@@ -84,13 +87,39 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - name: Build & Deploy to Firebase App Distribution
+    - name: Build preview APK (no upload)
+      id: build_apk
       working-directory: android
       env:
         FIREBASE_API_KEY: "${{ inputs.ANDROID_FIREBASE_API_KEY }}"
         ANDROID_FIREBASE_PROJECT_NUMBER: "${{ inputs.ANDROID_FIREBASE_PROJECT_NUMBER }}"
         ANDROID_FIREBASE_APP_ID: "${{ inputs.ANDROID_FIREBASE_APP_ID }}"
         ANDROID_JSON_KEY_FILE: "/tmp/gcp_key.json"
+        FIREBASE_SKIP_UPLOAD: "1"
+        APK_PATH_FILE: "/tmp/firebase_apk_path.txt"
+      shell: bash
+      run: |
+        bundle exec fastlane android pr_deploy \
+          pr_number:"${{ inputs.PR_NUMBER }}" \
+          pr_title:"${{ inputs.PR_TITLE }}" \
+          project_number:"${{ inputs.ANDROID_FIREBASE_PROJECT_NUMBER }}" \
+          app_id:"${{ inputs.ANDROID_FIREBASE_APP_ID }}"
+        echo "apk_path=$(cat /tmp/firebase_apk_path.txt)" >> "$GITHUB_OUTPUT"
+
+    - name: Mobile security scan (Trivy + Ostorlab)
+      uses: ./.github/actions/mobile-scan
+      with:
+        android-apk-path: ${{ steps.build_apk.outputs.apk_path }}
+        ostorlab-api-key: ${{ inputs.OSTORLAB_API_KEY }}
+
+    - name: Upload preview APK to Firebase App Distribution
+      working-directory: android
+      env:
+        FIREBASE_API_KEY: "${{ inputs.ANDROID_FIREBASE_API_KEY }}"
+        ANDROID_FIREBASE_PROJECT_NUMBER: "${{ inputs.ANDROID_FIREBASE_PROJECT_NUMBER }}"
+        ANDROID_FIREBASE_APP_ID: "${{ inputs.ANDROID_FIREBASE_APP_ID }}"
+        ANDROID_JSON_KEY_FILE: "/tmp/gcp_key.json"
+        APK_PATH: "${{ steps.build_apk.outputs.apk_path }}"
       shell: bash
       run: |
         bundle exec fastlane android pr_deploy \

--- a/.github/actions/deploy_android_production/action.yml
+++ b/.github/actions/deploy_android_production/action.yml
@@ -20,6 +20,9 @@ inputs:
   ANDROID_KEY_PASSWORD:
     required: true
     description: 'Password for the key alias'
+  OSTORLAB_API_KEY:
+    required: true
+    description: 'API key for Ostorlab vulnerability scans'
   RELEASE_NOTES:
     required: true
     description: 'Release notes for the build'
@@ -117,10 +120,10 @@ runs:
         printf "%s" "${{ inputs.RELEASE_NOTES }}" > "$CHANGELOG_PATH"
         echo "📝 Updated default changelog at $CHANGELOG_PATH"
 
-    - name: Build and deploy android App via fastlane
+    - name: Build Play artifacts (no upload)
+      id: build_android
       shell: bash
       working-directory: android
-      run: bundle exec fastlane deploy_android_production
       env:
         ANDROID_APP_IDENTIFIER: ${{ inputs.ANDROID_APP_IDENTIFIER }}
         ANDROID_KEYSTORE_FILE: ${{ steps.android_keystore.outputs.filePath }}
@@ -128,3 +131,30 @@ runs:
         ANDROID_KEY_ALIAS: ${{ inputs.ANDROID_KEY_ALIAS }}
         ANDROID_KEY_PASSWORD: ${{ inputs.ANDROID_KEY_PASSWORD }}
         ANDROID_JSON_KEY_FILE: ${{ steps.service_account_json_file.outputs.filePath }}
+        SKIP_PLAY_UPLOAD: "1"
+        AAB_PATH_FILE: "/tmp/play_aab_path.txt"
+        APK_PATH_FILE: "/tmp/play_apk_path.txt"
+      run: |
+        bundle exec fastlane deploy_android_production
+        echo "aab_path=$(cat /tmp/play_aab_path.txt)" >> "$GITHUB_OUTPUT"
+        echo "apk_path=$(cat /tmp/play_apk_path.txt)" >> "$GITHUB_OUTPUT"
+
+    - name: Mobile security scan (Trivy + Ostorlab)
+      uses: ./.github/actions/mobile-scan
+      with:
+        android-apk-path: ${{ steps.build_android.outputs.apk_path }}
+        ostorlab-api-key: ${{ inputs.OSTORLAB_API_KEY }}
+
+    - name: Upload to Play Store (using scanned artifact)
+      shell: bash
+      working-directory: android
+      env:
+        ANDROID_APP_IDENTIFIER: ${{ inputs.ANDROID_APP_IDENTIFIER }}
+        ANDROID_KEYSTORE_FILE: ${{ steps.android_keystore.outputs.filePath }}
+        ANDROID_KEYSTORE_PASSWORD: ${{ inputs.ANDROID_KEYSTORE_PASSWORD }}
+        ANDROID_KEY_ALIAS: ${{ inputs.ANDROID_KEY_ALIAS }}
+        ANDROID_KEY_PASSWORD: ${{ inputs.ANDROID_KEY_PASSWORD }}
+        ANDROID_JSON_KEY_FILE: ${{ steps.service_account_json_file.outputs.filePath }}
+        AAB_PATH: ${{ steps.build_android.outputs.aab_path }}
+        APK_PATH: ${{ steps.build_android.outputs.apk_path }}
+      run: bundle exec fastlane deploy_android_production

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -34,6 +34,9 @@ inputs:
   IOS_MATCH_DEPLOY_KEY:
     required: true
     description: 'SSH private key for Match repo'
+  OSTORLAB_API_KEY:
+    required: true
+    description: 'API key for Ostorlab vulnerability scans'
   PR_NUMBER:
     required: false
     description: 'Pull request number for PR-specific builds'
@@ -133,7 +136,37 @@ runs:
       run: rm -rf ~/Library/Developer/Xcode/DerivedData
       shell: bash
 
-    - name: iOS PR Deploy to TestFlight
+    - name: Build iOS preview (no upload)
+      id: build_ios
+      working-directory: ios
+      run: |
+        bundle exec fastlane ios pr_deploy
+        echo "ipa_path=$(cat /tmp/ios_preview_ipa.txt)" >> "$GITHUB_OUTPUT"
+      shell: bash
+      env:
+        MATCH_PASSWORD: ${{ inputs.IOS_MATCH_PASSWORD }}
+        IOS_MATCH_REPOSITORY_URL: ${{ inputs.IOS_MATCH_REPOSITORY_URL }}
+        IOS_APPLE_ID: ${{ inputs.IOS_APPLE_ID }}
+        IOS_KEYCHAIN_PASSWORD: ${{ inputs.IOS_KEYCHAIN_PASSWORD }}
+        IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_ID }}
+        IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
+        IOS_APP_IDENTIFIER: ${{ inputs.IOS_APP_IDENTIFIER }}
+        IOS_APP_STORE_TEAM_ID: ${{ inputs.IOS_APP_STORE_TEAM_ID }}
+        IOS_DEV_EMAIL: ${{ inputs.IOS_DEV_EMAIL }}
+        FASTLANE_USER: ${{ inputs.IOS_DEV_EMAIL }}
+        PR_NUMBER: ${{ inputs.PR_NUMBER }}
+        RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
+        IOS_SKIP_UPLOAD: "1"
+        IPA_PATH_FILE: "/tmp/ios_preview_ipa.txt"
+
+    - name: Mobile security scan (Trivy + Ostorlab)
+      uses: ./.github/actions/mobile-scan
+      with:
+        ios-ipa-path: ${{ steps.build_ios.outputs.ipa_path }}
+        ostorlab-api-key: ${{ inputs.OSTORLAB_API_KEY }}
+
+    - name: Upload iOS preview (using scanned IPA)
       working-directory: ios
       run: bundle exec fastlane ios pr_deploy
       shell: bash
@@ -151,12 +184,14 @@ runs:
         FASTLANE_USER: ${{ inputs.IOS_DEV_EMAIL }}
         PR_NUMBER: ${{ inputs.PR_NUMBER }}
         RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
+        IOS_SKIP_BUILD: "1"
+        IOS_IPA_PATH: ${{ steps.build_ios.outputs.ipa_path }}
     
     - name: Upload .ipa artifact
       uses: actions/upload-artifact@v4
       with:
         name: ios-preview-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
-        path: ios/Boilerplate.ipa
+        path: ${{ steps.build_ios.outputs.ipa_path }}
         retention-days: 1
         if-no-files-found: error
         compression-level: 6

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -34,6 +34,9 @@ inputs:
   IOS_MATCH_DEPLOY_KEY:
     required: true
     description: 'SSH private key for Match repo'
+  OSTORLAB_API_KEY:
+    required: true
+    description: 'API key for Ostorlab vulnerability scans'
   RELEASE_NOTES:
     required: true
     description: 'Release notes text to upload to App Store Connect'
@@ -135,7 +138,35 @@ runs:
       run: rm -rf ~/Library/Developer/Xcode/DerivedData
       shell: bash
 
-    - name: Deploy the iOS app to Production
+    - name: Build iOS production (no upload)
+      id: build_ios_prod
+      working-directory: ios
+      run: |
+        bundle exec fastlane ios production_deploy
+        echo "ipa_path=$(cat /tmp/ios_production_ipa.txt)" >> "$GITHUB_OUTPUT"
+      shell: bash
+      env:
+          MATCH_PASSWORD: ${{ inputs.IOS_MATCH_PASSWORD }}
+          IOS_MATCH_REPOSITORY_URL: ${{ inputs.IOS_MATCH_REPOSITORY_URL }}
+          IOS_APPLE_ID: ${{ inputs.IOS_APPLE_ID }}
+          IOS_KEYCHAIN_PASSWORD: ${{ inputs.IOS_KEYCHAIN_PASSWORD }}
+          IOS_APP_STORE_CONNECT_API_KEY_ID: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_ID }}
+          IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          IOS_APP_STORE_CONNECT_API_KEY_B64: ${{ inputs.IOS_APP_STORE_CONNECT_API_KEY_B64 }}
+          IOS_APP_IDENTIFIER: ${{ inputs.IOS_APP_IDENTIFIER }}
+          IOS_APP_STORE_TEAM_ID: ${{ inputs.IOS_APP_STORE_TEAM_ID }}
+          IOS_DEV_EMAIL: ${{ inputs.IOS_DEV_EMAIL }}
+          RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
+          IOS_SKIP_UPLOAD: "1"
+          IPA_PATH_FILE: "/tmp/ios_production_ipa.txt"
+
+    - name: Mobile security scan (Trivy + Ostorlab)
+      uses: ./.github/actions/mobile-scan
+      with:
+        ios-ipa-path: ${{ steps.build_ios_prod.outputs.ipa_path }}
+        ostorlab-api-key: ${{ inputs.OSTORLAB_API_KEY }}
+
+    - name: Upload iOS production (using scanned IPA)
       working-directory: ios
       run: bundle exec fastlane ios production_deploy
       shell: bash
@@ -151,6 +182,8 @@ runs:
           IOS_APP_STORE_TEAM_ID: ${{ inputs.IOS_APP_STORE_TEAM_ID }}
           IOS_DEV_EMAIL: ${{ inputs.IOS_DEV_EMAIL }}
           RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
+          IOS_SKIP_BUILD: "1"
+          IOS_IPA_PATH: ${{ steps.build_ios_prod.outputs.ipa_path }}
 
     - name: Upload Xcode build logs
       if: failure()

--- a/.github/actions/mobile-scan/action.yml
+++ b/.github/actions/mobile-scan/action.yml
@@ -1,0 +1,86 @@
+name: 'Mobile Security Scan'
+description: 'Run Trivy (code/deps) and Ostorlab (APK/IPA) before mobile deploys'
+
+inputs:
+  android-apk-path:
+    description: 'Glob or path to Android APK to scan (optional)'
+    required: false
+    default: ''
+  ios-ipa-path:
+    description: 'Path to iOS IPA to scan (optional)'
+    required: false
+    default: ''
+  ostorlab-api-key:
+    description: 'API key for Ostorlab scans'
+    required: false
+    default: ''
+
+outputs:
+  has-issues:
+    description: 'true when any scan reports HIGH/CRITICAL findings'
+    value: ${{ steps.set-output.outputs.has-issues }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Trivy filesystem scan (HIGH/CRITICAL)
+      id: trivy
+      uses: aquasecurity/trivy-action@v0.33.1
+      continue-on-error: true
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        scanners: 'vuln,secret'
+        severity: 'HIGH,CRITICAL'
+        format: 'table'
+        ignore-unfixed: true
+        timeout: '10m'
+        exit-code: '1'
+
+    - name: Ostorlab scan - Android APK
+      id: ostorlab-android
+      if: inputs.android-apk-path != ''
+      uses: ostorlab/github-action@v1.1.1
+      continue-on-error: true
+      with:
+        asset_type: 'android-apk'
+        target: ${{ inputs.android-apk-path }}
+        api-key: ${{ inputs.ostorlab-api-key }}
+
+    - name: Ostorlab scan - iOS IPA
+      id: ostorlab-ios
+      if: inputs.ios-ipa-path != ''
+      uses: ostorlab/github-action@v1.1.1
+      continue-on-error: true
+      with:
+        asset_type: 'ios-ipa'
+        target: ${{ inputs.ios-ipa-path }}
+        api-key: ${{ inputs.ostorlab-api-key }}
+
+    - name: Set scan output / fail on issues
+      id: set-output
+      shell: bash
+      run: |
+        issues=false
+
+        if [ "${{ steps.trivy.outcome }}" = "failure" ]; then
+          echo "Trivy reported HIGH/CRITICAL findings."
+          issues=true
+        fi
+
+        if [ "${{ steps.ostorlab-android.outcome }}" = "failure" ]; then
+          echo "Ostorlab (Android) reported findings."
+          issues=true
+        fi
+
+        if [ "${{ steps.ostorlab-ios.outcome }}" = "failure" ]; then
+          echo "Ostorlab (iOS) reported findings."
+          issues=true
+        fi
+
+        echo "has-issues=$issues" >> "$GITHUB_OUTPUT"
+
+        if [ "$issues" = "true" ]; then
+          echo "Blocking deployment because HIGH/CRITICAL issues were detected."
+          exit 1
+        fi

--- a/.github/actions/mobile-scan/action.yml
+++ b/.github/actions/mobile-scan/action.yml
@@ -84,3 +84,17 @@ runs:
           echo "Blocking deployment because HIGH/CRITICAL issues were detected."
           exit 1
         fi
+
+    - name: Comment PR on scan failure
+      if: ${{ github.event_name == 'pull_request' && steps.set-output.outputs.has-issues == 'true' }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        GITHUB_TOKEN: ${{ github.token }}
+        header: "Mobile Security Scan"
+        message: |
+          ❌ Mobile security scan failed.
+          - Trivy: ${{ steps.trivy.outcome }}
+          - Ostorlab (Android): ${{ steps.ostorlab-android.outcome || 'skipped' }}
+          - Ostorlab (iOS): ${{ steps.ostorlab-ios.outcome || 'skipped' }}
+
+          See the workflow run logs for details.

--- a/.github/actions/mobile-scan/action.yml
+++ b/.github/actions/mobile-scan/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: Trivy filesystem scan (HIGH/CRITICAL)
       id: trivy
-      uses: aquasecurity/trivy-action@v0.33.1
+      uses: aquasecurity/trivy-action@0.33.1
       continue-on-error: true
       with:
         scan-type: 'fs'
@@ -40,22 +40,22 @@ runs:
     - name: Ostorlab scan - Android APK
       id: ostorlab-android
       if: inputs.android-apk-path != ''
-      uses: ostorlab/github-action@v1.1.1
+      uses: Ostorlab/ostorlab_actions@v1.1.1
       continue-on-error: true
       with:
         asset_type: 'android-apk'
         target: ${{ inputs.android-apk-path }}
-        api-key: ${{ inputs.ostorlab-api-key }}
+        ostorlab_api_key: ${{ inputs.ostorlab-api-key }}
 
     - name: Ostorlab scan - iOS IPA
       id: ostorlab-ios
       if: inputs.ios-ipa-path != ''
-      uses: ostorlab/github-action@v1.1.1
+      uses: Ostorlab/ostorlab_actions@v1.1.1
       continue-on-error: true
       with:
         asset_type: 'ios-ipa'
         target: ${{ inputs.ios-ipa-path }}
-        api-key: ${{ inputs.ostorlab-api-key }}
+        ostorlab_api_key: ${{ inputs.ostorlab-api-key }}
 
     - name: Set scan output / fail on issues
       id: set-output

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,7 @@ jobs:
           ANDROID_FIREBASE_PROJECT_ID: ${{ secrets.ANDROID_FIREBASE_PROJECT_ID }}
           ANDROID_FIREBASE_APP_PACKAGE: ${{ secrets.ANDROID_FIREBASE_APP_PACKAGE }}
           ANDROID_FIREBASE_API_KEY: ${{ secrets.ANDROID_FIREBASE_API_KEY }}
+          OSTORLAB_API_KEY: ${{ secrets.OSTORLAB_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
@@ -128,6 +129,7 @@ jobs:
           IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
           IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          OSTORLAB_API_KEY: ${{ secrets.OSTORLAB_API_KEY }}
       
       - name: Post or update PR comment (IOS)
         uses: ./.github/actions/update_preview_comment

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -50,6 +50,7 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          OSTORLAB_API_KEY: ${{ secrets.OSTORLAB_API_KEY }}
           RELEASE_NOTES: ${{ needs.release_notes_check.outputs.release_notes }}
 
   deploy_ios:
@@ -83,3 +84,4 @@ jobs:
           IOS_APP_STORE_TEAM_ID: ${{ secrets.IOS_APP_STORE_TEAM_ID }}
           IOS_DEV_EMAIL: ${{ secrets.IOS_DEV_EMAIL }}
           IOS_MATCH_DEPLOY_KEY: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
+          OSTORLAB_API_KEY: ${{ secrets.OSTORLAB_API_KEY }}

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -59,6 +59,12 @@ platform :android do
                      CredentialsManager::AppfileConfig.try_fetch_value(:package_name)
     UI.user_error!("❌ App identifier not configured") unless app_identifier
 
+    skip_upload = ENV["SKIP_PLAY_UPLOAD"] == "1" || ENV["PLAY_SKIP_UPLOAD"] == "1"
+    export_aab_path = ENV["AAB_PATH_FILE"]
+    export_apk_path = ENV["APK_PATH_FILE"]
+    provided_aab = ENV["AAB_PATH"]
+    provided_apk = ENV["APK_PATH"]
+
     version_codes = google_play_track_version_codes(
       package_name: app_identifier,
       track: "internal",
@@ -75,20 +81,71 @@ platform :android do
     end
 
     # 3) Build with injected versionCode + versionName
-    gradle(
-      task: "bundle#{gradle_task_flavor}Release",
-      properties: {
-        "android.injected.signing.store.file" => ENV["ANDROID_KEYSTORE_FILE"],
-        "android.injected.signing.store.password" => ENV["ANDROID_KEYSTORE_PASSWORD"],
-        "android.injected.signing.key.alias" => ENV["ANDROID_KEY_ALIAS"],
-        "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASSWORD"],
-        "versionCode" => version_code.to_s,
-        "versionName" => version_name
-      }
-    )
+    aab_path = nil
+    apk_path = nil
+
+    if provided_aab && !provided_aab.empty?
+      aab_path = File.expand_path(provided_aab)
+      UI.user_error!("❌ Provided AAB not found at #{aab_path}") unless File.exist?(aab_path)
+      UI.message("ℹ️ Re-using prebuilt AAB at #{aab_path}")
+    else
+      gradle(
+        task: "bundle#{gradle_task_flavor}Release",
+        properties: {
+          "android.injected.signing.store.file" => ENV["ANDROID_KEYSTORE_FILE"],
+          "android.injected.signing.store.password" => ENV["ANDROID_KEYSTORE_PASSWORD"],
+          "android.injected.signing.key.alias" => ENV["ANDROID_KEY_ALIAS"],
+          "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASSWORD"],
+          "versionCode" => version_code.to_s,
+          "versionName" => version_name
+        }
+      )
+      aab_path = File.expand_path("../../app/build/outputs/bundle/#{production_flavor}/release/app-#{production_flavor}-release.aab", __dir__)
+      UI.user_error!("❌ AAB not found at #{aab_path}") unless File.exist?(aab_path)
+    end
+
+    if provided_apk && !provided_apk.empty?
+      apk_path = File.expand_path(provided_apk)
+      UI.user_error!("❌ Provided APK not found at #{apk_path}") unless File.exist?(apk_path)
+      UI.message("ℹ️ Re-using prebuilt APK at #{apk_path}")
+    else
+      Actions::GradleAction.run(
+        gradle_path: "./gradlew",
+        task: "assemble#{gradle_task_flavor}Release",
+        project_dir: File.expand_path("../../", __dir__),
+        properties: {
+          "android.injected.signing.store.file" => ENV["ANDROID_KEYSTORE_FILE"],
+          "android.injected.signing.store.password" => ENV["ANDROID_KEYSTORE_PASSWORD"],
+          "android.injected.signing.key.alias" => ENV["ANDROID_KEY_ALIAS"],
+          "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASSWORD"],
+          "versionCode" => version_code.to_s,
+          "versionName" => version_name
+        },
+        print_command: true,
+        print_command_output: true
+      )
+      apk_path = File.expand_path("../../app/build/outputs/apk/#{production_flavor}/release/app-#{production_flavor}-release.apk", __dir__)
+      UI.user_error!("❌ APK not found at #{apk_path}") unless File.exist?(apk_path)
+    end
+
+    if export_aab_path && !export_aab_path.empty?
+      File.write(export_aab_path, aab_path)
+      UI.message("📝 Wrote AAB path to #{export_aab_path}")
+    end
+
+    if export_apk_path && !export_apk_path.empty?
+      File.write(export_apk_path, apk_path)
+      UI.message("📝 Wrote APK path to #{export_apk_path}")
+    end
+
+    if skip_upload
+      UI.message("⏭️ SKIP_PLAY_UPLOAD set; skipping upload. AAB at #{aab_path}")
+      return
+    end
 
     # 4) Upload (supply automatically picks changelog)
     upload_to_play_store(
+      aab: aab_path,
       track: "internal",
       release_status: "draft",
       json_key: ENV["ANDROID_JSON_KEY_FILE"],

--- a/docs/release_notes/1.0.22.md
+++ b/docs/release_notes/1.0.22.md
@@ -1,0 +1,2 @@
+v1.0.22
+- Add ci scan for vulnerability and security checks

--- a/ios/fastlane/scripts/ios_deploy_preview.rb
+++ b/ios/fastlane/scripts/ios_deploy_preview.rb
@@ -26,6 +26,11 @@ def ios_deploy_preview!(options = {})
   team_id           = options.fetch(:team_id)
   release_notes     = options.fetch(:release_notes)
 
+  skip_build  = ENV['IOS_SKIP_BUILD'] == '1'
+  skip_upload = ENV['IOS_SKIP_UPLOAD'] == '1'
+  export_ipa  = ENV['IPA_PATH_FILE']
+  provided_ipa = ENV['IOS_IPA_PATH']
+
   # ---------------------------------------------------------------------------
   # Version (from package.json)
   # ---------------------------------------------------------------------------
@@ -38,15 +43,19 @@ def ios_deploy_preview!(options = {})
   # ---------------------------------------------------------------------------
   # Cleanup old preview builds for this PR
   # ---------------------------------------------------------------------------
-  UI.message("🧹 Cleaning old builds for PR ##{pr_number}...")
-  require_relative 'ios_cleanup_preview'
-  ios_cleanup_preview!(
-    pr_number: pr_number,
-    app_identifier: app_identifier,
-    api_key_id: api_key_id,
-    issuer_id: issuer_id,
-    api_key_b64: api_key_b64
-  )
+  if provided_ipa.to_s.strip.empty?
+    UI.message("🧹 Cleaning old builds for PR ##{pr_number}...")
+    require_relative 'ios_cleanup_preview'
+    ios_cleanup_preview!(
+      pr_number: pr_number,
+      app_identifier: app_identifier,
+      api_key_id: api_key_id,
+      issuer_id: issuer_id,
+      api_key_b64: api_key_b64
+    )
+  else
+    UI.message("ℹ️ Skipping cleanup because a prebuilt IPA was provided.")
+  end
 
   # ---------------------------------------------------------------------------
   # Keychain + match (signing)
@@ -87,14 +96,7 @@ def ios_deploy_preview!(options = {})
   # ---------------------------------------------------------------------------
   # Marketing version + PR‑based build number
   # ---------------------------------------------------------------------------
-  UI.message("📱 Setting marketing version: #{marketing_version}")
-  increment_version_number(
-    xcodeproj: xcodeproj,
-    version_number: marketing_version
-  )
-
   # Build number pattern: <PR_NUMBER><YYMMDDHHMM>
-  # Example: PR 42 on 2025-12-17 10:58 UTC → 422512171058
   pr_digits = pr_number.to_s.gsub(/[^0-9]/, '')
   UI.user_error!("❌ Invalid PR number '#{pr_number}'") if pr_digits.empty?
 
@@ -107,11 +109,19 @@ def ios_deploy_preview!(options = {})
     UI.important("⚠️ Preview build number truncated to 18 chars: #{next_build}")
   end
 
-  UI.message("🔢 Using preview build number: #{next_build} (PR ##{pr_number}, ts=#{timestamp})")
-  increment_build_number(
-    xcodeproj: xcodeproj,
-    build_number: next_build
-  )
+  unless skip_build
+    UI.message("📱 Setting marketing version: #{marketing_version}")
+    increment_version_number(
+      xcodeproj: xcodeproj,
+      version_number: marketing_version
+    )
+
+    UI.message("🔢 Using preview build number: #{next_build} (PR ##{pr_number}, ts=#{timestamp})")
+    increment_build_number(
+      xcodeproj: xcodeproj,
+      build_number: next_build
+    )
+  end
 
   # ---------------------------------------------------------------------------
   # Bundle and Verify React Native for iOS (preview env)
@@ -121,101 +131,121 @@ def ios_deploy_preview!(options = {})
   ENV['NODE_ENV'] = 'production'
   repo_root = File.expand_path('../../..', __dir__)
 
-  UI.message('📦 Bundling React Native for iOS (preview)...')
-  sh <<~BASH
-    cd "#{repo_root}"
-    ENVFILE=.env NODE_ENV=production npx react-native bundle \\
-      --entry-file index.js \\
-      --platform ios \\
-      --dev false \\
-      --bundle-output ios/main.jsbundle \\
-      --assets-dest .
-  BASH
+  ipa_path = nil
 
-  js_bundle_path = File.expand_path('../../main.jsbundle', __dir__)
-  UI.message("🔍 Checking for main.jsbundle at: #{js_bundle_path}")
-  UI.user_error!('❌ main.jsbundle not found') unless File.exist?(js_bundle_path)
+  unless skip_build && provided_ipa
+    UI.message('📦 Bundling React Native for iOS (preview)...')
+    sh <<~BASH
+      cd "#{repo_root}"
+      ENVFILE=.env NODE_ENV=production npx react-native bundle \\
+        --entry-file index.js \\
+        --platform ios \\
+        --dev false \\
+        --bundle-output ios/main.jsbundle \\
+        --assets-dest .
+    BASH
 
-  # ---------------------------------------------------------------------------
-  # Build IPA (Boilerplate workspace)
-  # ---------------------------------------------------------------------------
-  UI.message('🏗️ Building IPA...')
-  build_app(
-    clean: true,
-    scheme: scheme,
-    workspace: workspace,
-    export_method: 'app-store',
-    verbose: true,
-    xcargs: "CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=\"Apple Distribution\" DEVELOPMENT_TEAM=#{team_id} PROVISIONING_PROFILE_SPECIFIER=\"#{profile_name}\" PRODUCT_BUNDLE_IDENTIFIER=#{app_identifier}",
-    export_options: {
-      compileBitcode: false,
-      signingStyle: 'manual',
-      provisioningProfiles: {
-        app_identifier => profile_name
+    js_bundle_path = File.expand_path('../../main.jsbundle', __dir__)
+    UI.message("🔍 Checking for main.jsbundle at: #{js_bundle_path}")
+    UI.user_error!('❌ main.jsbundle not found') unless File.exist?(js_bundle_path)
+
+    # ---------------------------------------------------------------------------
+    # Build IPA (Boilerplate workspace)
+    # ---------------------------------------------------------------------------
+    UI.message('🏗️ Building IPA...')
+    build_app(
+      clean: true,
+      scheme: scheme,
+      workspace: workspace,
+      export_method: 'app-store',
+      verbose: true,
+      xcargs: "CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=\"Apple Distribution\" DEVELOPMENT_TEAM=#{team_id} PROVISIONING_PROFILE_SPECIFIER=\"#{profile_name}\" PRODUCT_BUNDLE_IDENTIFIER=#{app_identifier}",
+      export_options: {
+        compileBitcode: false,
+        signingStyle: 'manual',
+        provisioningProfiles: {
+          app_identifier => profile_name
+        }
       }
-    }
-  )
+    )
 
-  # ---------------------------------------------------------------------------
-  # Hermes bitcode stripping + re-sign
-  # ---------------------------------------------------------------------------
-  ipa_path = lane_context[:IPA_OUTPUT_PATH]
-  UI.message("📦 Processing IPA: #{ipa_path}")
-  UI.user_error!('❌ IPA path missing in lane_context') unless ipa_path && File.exist?(ipa_path)
+    ipa_path = lane_context[:IPA_OUTPUT_PATH]
+    UI.message("📦 Processing IPA: #{ipa_path}")
+    UI.user_error!('❌ IPA path missing in lane_context') unless ipa_path && File.exist?(ipa_path)
+  else
+    ipa_path = File.expand_path(provided_ipa)
+    UI.user_error!("❌ Provided IPA not found at #{ipa_path}") unless File.exist?(ipa_path)
+    UI.message("ℹ️ Re-using prebuilt IPA at #{ipa_path}")
+  end
 
-  sh("unzip -q #{ipa_path} -d temp_payload")
-  app_path = Dir['temp_payload/Payload/*.app'].first
-  UI.user_error!('❌ .app bundle not found') unless app_path
+  unless skip_build && provided_ipa
+    # ---------------------------------------------------------------------------
+    # Hermes bitcode stripping + re-sign
+    # ---------------------------------------------------------------------------
+    sh("unzip -q #{ipa_path} -d temp_payload")
+    app_path = Dir['temp_payload/Payload/*.app'].first
+    UI.user_error!('❌ .app bundle not found') unless app_path
 
-  hermes_bin = File.join(app_path, 'Frameworks/hermes.framework/hermes')
-  sh <<~BASH
-    echo "🔍 Stripping Hermes bitcode..."
-    if [ -f "#{hermes_bin}" ]; then
-      echo "📦 Found Hermes: #{hermes_bin}"
-      xcrun bitcode_strip -r "#{hermes_bin}" -o "#{hermes_bin}"
+    hermes_bin = File.join(app_path, 'Frameworks/hermes.framework/hermes')
+    sh <<~BASH
+      echo "🔍 Stripping Hermes bitcode..."
+      if [ -f "#{hermes_bin}" ]; then
+        echo "📦 Found Hermes: #{hermes_bin}"
+        xcrun bitcode_strip -r "#{hermes_bin}" -o "#{hermes_bin}"
 
-      echo "🔬 Verifying..."
-      if otool -l "#{hermes_bin}" | grep -i bitcode; then
-        echo "❌ Bitcode still present!"
-        exit 1
-      fi
-      echo "✅ Bitcode stripped"
-
-      echo "🔐 Re-signing..."
-      CERT_ID=$(security find-identity -v -p codesigning "#{keychain_name}" | grep "Apple Distribution" | head -n1 | awk '{print $2}')
-
-      if [ -z "$CERT_ID" ]; then
-        echo "❌ No Apple Distribution cert found!"
-        exit 1
-      fi
-
-      echo "Using cert: $CERT_ID"
-
-      for FRAMEWORK in "#{app_path}/Frameworks/"*; do
-        if [ -d "$FRAMEWORK" ]; then
-          /usr/bin/codesign --force --sign "$CERT_ID" --timestamp=none --generate-entitlement-der "$FRAMEWORK"
+        echo "🔬 Verifying..."
+        if otool -l "#{hermes_bin}" | grep -i bitcode; then
+          echo "❌ Bitcode still present!"
+          exit 1
         fi
-      done
+        echo "✅ Bitcode stripped"
 
-      /usr/bin/codesign --force --sign "$CERT_ID" \
-        --timestamp=none \
-        --preserve-metadata=entitlements \
-        --generate-entitlement-der \
-        "#{app_path}"
+        echo "🔐 Re-signing..."
+        CERT_ID=$(security find-identity -v -p codesigning "#{keychain_name}" | grep "Apple Distribution" | head -n1 | awk '{print $2}')
 
-      echo "🔬 Verifying signature..."
-      /usr/bin/codesign --verify --deep --strict --verbose=2 "#{app_path}"
-      echo "✅ Signing complete"
-    else
-      echo "⚠️ Hermes not found: #{hermes_bin}"
-    fi
+        if [ -z "$CERT_ID" ]; then
+          echo "❌ No Apple Distribution cert found!"
+          exit 1
+        fi
 
-    echo "📦 Repacking IPA..."
-    cd temp_payload && zip -r -q ../fixed.ipa Payload >/dev/null && cd ..
-    mv fixed.ipa "#{ipa_path}"
-    rm -rf temp_payload
-    echo "✅ IPA ready"
-  BASH
+        echo "Using cert: $CERT_ID"
+
+        for FRAMEWORK in "#{app_path}/Frameworks/"*; do
+          if [ -d "$FRAMEWORK" ]; then
+            /usr/bin/codesign --force --sign "$CERT_ID" --timestamp=none --generate-entitlement-der "$FRAMEWORK"
+          fi
+        done
+
+        /usr/bin/codesign --force --sign "$CERT_ID" \
+          --timestamp=none \
+          --preserve-metadata=entitlements \
+          --generate-entitlement-der \
+          "#{app_path}"
+
+        echo "🔬 Verifying signature..."
+        /usr/bin/codesign --verify --deep --strict --verbose=2 "#{app_path}"
+        echo "✅ Signing complete"
+      else
+        echo "⚠️ Hermes not found: #{hermes_bin}"
+      fi
+
+      echo "📦 Repacking IPA..."
+      cd temp_payload && zip -r -q ../fixed.ipa Payload >/dev/null && cd ..
+      mv fixed.ipa "#{ipa_path}"
+      rm -rf temp_payload
+      echo "✅ IPA ready"
+    BASH
+  end
+
+  if export_ipa && !export_ipa.strip.empty?
+    File.write(export_ipa, ipa_path)
+    UI.message("📝 Wrote IPA path to #{export_ipa}")
+  end
+
+  if skip_upload
+    UI.message("⏭️ IOS_SKIP_UPLOAD set; skipping upload. IPA ready at #{ipa_path}")
+    return
+  end
 
   # ---------------------------------------------------------------------------
   # TestFlight changelog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Summary
- Introduced a pre-deploy security gate that scans code/dependencies with Trivy and built APK/IPA artifacts with Ostorlab before any store upload.
- Ensures the exact artifacts that get uploaded are the ones that were scanned, blocking on HIGH/CRITICAL findings.
- Keeps developer friction low by reusing existing Fastlane builds and injecting secrets via Doppler; only a new `OSTORLAB_API_KEY` secret was required.

## Rationale
- Mobile binaries must be scanned before distribution to catch critical vulns or secrets leakage.
- Previous pipelines uploaded directly after build; adding a scan step reduces release risk without slowing the happy path (build → scan → upload).
- Separating build and upload lets us reuse the same artifact for scanning and deployment, preventing “scanned something else” drift.

## File Changes
- `.github/actions/mobile-scan/action.yml` — new composite action running Trivy + Ostorlab and enforcing failure on HIGH/CRITICAL issues.
- `.github/actions/deploy_android_preview/action.yml` — split build/upload; added scan gate and OSTORLAB secret plumbed through.
- `.github/actions/deploy_android_production/action.yml` — same build→scan→upload pattern for Play Store.
- `.github/actions/deploy_ios_preview/action.yml` — build IPA, scan, then upload to TestFlight using scanned artifact.
- `.github/actions/deploy_ios_production/action.yml` — build IPA, scan, then upload to App Store Connect.
- `.github/workflows/cd.yml` — passes `OSTORLAB_API_KEY` into preview deploy jobs.
- `.github/workflows/production.yml` — passes `OSTORLAB_API_KEY` into production deploy jobs.
- `.github/CI_README.md` — documents the “Mobile Security Scan Gate” behavior and required secret.
- `android/fastlane/Fastfile`, `android/fastlane/scripts/firebase_pr_deploy.rb`, `ios/fastlane/scripts/ios_deploy_preview.rb`, `ios/fastlane/scripts/ios_deploy_production.rb` — support build-only mode, write artifact paths, and reuse them for upload after scanning.

## Tests
- [ ] `yarn lint`
- [ ] `yarn test`
- [ ] Android preview deploy workflow (CI)
- [ ] iOS preview deploy workflow (CI)
- [ ] Production workflows (dry-run or on release)

