### PR TITLE
ci: add automatic pr labelling and update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,15 @@
-## Description
-_A few sentences describing the overall goals of the pull request's commits. In case you are creating or updating new endpoints, please document request, response schema._
+# Pull Request
 
-## Screenshots
-_Add screenshots or videos demonstrating the working of the implementation_
+## Summary
 
-## Tests
-### Automated test cases added
-- _Description of automated test 1_
-- _Description of automated test 2_
-- _Description of automated test 3_
+What does this PR change and why?
 
-### Manual test cases run
-_For each manual test case, list the steps to test or reproduce the PR._
-- _Description of manual test 1_
-- _Description of manual test 2_
-- _Description of manual test 3_
+## Pre-Merge Checklist
+
+- [ ] Tests pass
+- [ ] Self-reviewed
+- [ ] AI code review completed (if applicable)
+
+## Additional Context
+
+Screenshots, test evidence, or notes for reviewers (optional).

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,88 @@
+name: pr-labeler
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR based on title prefix
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const prNumber = context.payload.pull_request.number;
+
+            // Define label mappings based on PR title prefix (with optional scope)
+            const labelMappings = [
+              { pattern: /^feat!(\(.+?\))?:/i, typeLabel: 'type: feat', semverLabel: 'semver: major' },
+              { pattern: /^fix!(\(.+?\))?:/i, typeLabel: 'type: fix', semverLabel: 'semver: major' },
+              { pattern: /^feat(\(.+?\))?:/i, typeLabel: 'type: feat', semverLabel: 'semver: minor' },
+              { pattern: /^fix(\(.+?\))?:/i, typeLabel: 'type: fix', semverLabel: 'semver: patch' },
+              { pattern: /^perf(\(.+?\))?:/i, typeLabel: 'type: perf', semverLabel: 'semver: patch' },
+              { pattern: /^docs(\(.+?\))?:/i, typeLabel: 'type: docs', semverLabel: null },
+              { pattern: /^style(\(.+?\))?:/i, typeLabel: 'type: style', semverLabel: null },
+              { pattern: /^refactor(\(.+?\))?:/i, typeLabel: 'type: refactor', semverLabel: null },
+              { pattern: /^test(\(.+?\))?:/i, typeLabel: 'type: test', semverLabel: null },
+              { pattern: /^chore(\(.+?\))?:/i, typeLabel: 'type: chore', semverLabel: null },
+              { pattern: /^ci(\(.+?\))?:/i, typeLabel: 'type: ci', semverLabel: null },
+            ];
+
+            // Find matching prefix
+            const match = labelMappings.find(mapping => mapping.pattern.test(title));
+
+            if (!match) {
+              core.setFailed(`❌ PR title does not follow conventional commit format. Expected format: type(scope): description\nValid types: feat, fix, perf, docs, style, refactor, test, chore, ci\nExample: feat(api): add new endpoint`);
+              return;
+            }
+
+            const labelsToAdd = [match.typeLabel];
+            if (match.semverLabel) {
+              labelsToAdd.push(match.semverLabel);
+            }
+
+            // Get existing labels on the PR
+            const { data: existingLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existingLabelNames = existingLabels.map(label => label.name);
+
+            // Remove old type and semver labels if they differ
+            const typeLabels = ['type: feat', 'type: fix', 'type: perf', 'type: docs', 'type: style', 'type: refactor', 'type: test', 'type: chore', 'type: ci'];
+            const semverLabels = ['semver: major', 'semver: minor', 'semver: patch'];
+
+            for (const label of existingLabelNames) {
+              if ((typeLabels.includes(label) && label !== match.typeLabel) ||
+                  (semverLabels.includes(label) && label !== match.semverLabel)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: label,
+                });
+                console.log(`Removed label: ${label}`);
+              }
+            }
+
+            // Add new labels
+            const labelsToApply = labelsToAdd.filter(label => !existingLabelNames.includes(label));
+            if (labelsToApply.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: labelsToApply,
+              });
+              console.log(`Added labels: ${labelsToApply.join(', ')}`);
+            }
+
+            console.log(`PR #${prNumber} labeled with: ${labelsToAdd.join(', ')}`);

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,8 +21,8 @@ jobs:
 
             // Define label mappings based on PR title prefix (with optional scope)
             const labelMappings = [
-              { pattern: /^feat!(\(.+?\))?:/i, typeLabel: 'type: feat', semverLabel: 'semver: major' },
-              { pattern: /^fix!(\(.+?\))?:/i, typeLabel: 'type: fix', semverLabel: 'semver: major' },
+              { pattern: /^feat(\(.+?\))?!:/i, typeLabel: 'type: feat', semverLabel: 'semver: major' },
+              { pattern: /^fix(\(.+?\))?!:/i, typeLabel: 'type: fix', semverLabel: 'semver: major' },
               { pattern: /^feat(\(.+?\))?:/i, typeLabel: 'type: feat', semverLabel: 'semver: minor' },
               { pattern: /^fix(\(.+?\))?:/i, typeLabel: 'type: fix', semverLabel: 'semver: patch' },
               { pattern: /^perf(\(.+?\))?:/i, typeLabel: 'type: perf', semverLabel: 'semver: patch' },

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -34,6 +34,68 @@ jobs:
               { pattern: /^ci(\(.+?\))?:/i, typeLabel: 'type: ci', semverLabel: null },
             ];
 
+            // Label metadata (color + description) for auto-created labels
+            const labelDetails = {
+              'type: feat': { color: '2E8B57', description: 'User-facing feature or enhancement' },
+              'type: fix': { color: 'D73A4A', description: 'User-visible bug fix' },
+              'type: perf': { color: 'BFDADC', description: 'Performance improvements' },
+              'type: docs': { color: '0366D6', description: 'Documentation-only change' },
+              'type: style': { color: 'F9D0C4', description: 'Formatting or stylistic tweaks (no logic change)' },
+              'type: refactor': { color: '8A63D2', description: 'Code restructuring without behavior change' },
+              'type: test': { color: '0E8A16', description: 'Add or update tests' },
+              'type: chore': { color: 'BFD4F2', description: 'Maintenance or tooling upkeep' },
+              'type: ci': { color: 'F9BC2F', description: 'CI/CD configuration or pipeline updates' },
+              'semver: major': { color: 'B60205', description: 'Breaking change; requires major bump' },
+              'semver: minor': { color: '5319E7', description: 'Backward-compatible feature' },
+              'semver: patch': { color: '1D76DB', description: 'Backward-compatible bug or perf fix' },
+            };
+
+            const ensureLabel = async (name) => {
+              const meta = labelDetails[name];
+              if (!meta) return;
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color: meta.color.replace('#', ''),
+                  description: meta.description,
+                });
+                console.log(`Created label: ${name}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    new_name: name,
+                    color: meta.color.replace('#', ''),
+                    description: meta.description,
+                  });
+                  console.log(`Updated label: ${name}`);
+                } else {
+                  throw error;
+                }
+              }
+            };
+
+            // Ensure type + semver labels exist with colors/descriptions
+            const labelsToEnsure = [
+              'type: feat',
+              'type: fix',
+              'type: perf',
+              'type: docs',
+              'type: style',
+              'type: refactor',
+              'type: test',
+              'type: chore',
+              'type: ci',
+              'semver: major',
+              'semver: minor',
+              'semver: patch',
+            ];
+            await Promise.all(labelsToEnsure.map(ensureLabel));
+
             // Find matching prefix
             const match = labelMappings.find(mapping => mapping.pattern.test(title));
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -7,6 +7,7 @@ This project uses GitHub Actions, Doppler, and Fastlane to build, test, and ship
 Read more detailed working of CI/CD in [CI](./ci.md) and [CD](./cd.md).
 
 - [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) — Pull-request checks (lint, type-check, SonarQube).
+- [`.github/workflows/pr-labeler.yml`](../.github/workflows/pr-labeler.yml) — Separate PR hook that validates semantic titles and auto-applies `type:`/`semver:` labels (see [CI guide](./ci.md#pr-titles--auto-labeling)).
 - [`.github/workflows/cd.yml`](../.github/workflows/cd.yml) — PR preview deployments (Android → Firebase App Distribution, iOS → TestFlight) with version and release-notes gates.
 - [`.github/workflows/production.yml`](../.github/workflows/production.yml) — Deploys `main` to Google Play (internal track) and App Store Connect.
 - [`.github/workflows/permanent_preview.yml`](../.github/workflows/permanent_preview.yml) — Builds signed preview APK/IPA on every `main` push and publishes them to a GitHub Release.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,6 +11,17 @@ GitHub Actions runs fast, parallel checks on every pull request to keep the code
 - **ci/lint** — ESLint validation on the source.
 - **ci/sonarqube** — SonarQube code-quality analysis for PRs.
 
+## PR Titles & Auto-Labeling
+
+- PR titles must use Conventional Commit format: `<type>(<scope>): <subject>` (scope optional, imperative, no period).
+- Breaking changes add `!` before the colon: `feat!: ...` or `feat(api)!: ...`.
+- `.github/workflows/pr-labeler.yml` applies labels based on the prefix:
+  - `feat:` → `type: feat` + `semver: minor`
+  - `fix:` → `type: fix` + `semver: patch`
+  - `perf:` → `type: perf` + `semver: patch`
+  - `docs|style|refactor|test|chore|ci:` → corresponding `type:` label (no semver)
+  - `feat!:` / `fix!:` (with or without scope) → `semver: major`
+
 ## Workflow Flow Diagram
 
 ```mermaid

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,14 +13,35 @@ GitHub Actions runs fast, parallel checks on every pull request to keep the code
 
 ## PR Titles & Auto-Labeling
 
-Use Conventional Commit titles so the `pr-labeler` workflow can tag PRs automatically and signal the expected semver impact.
+Use Conventional Commit titles so the [`pr-labeler.yml`](../.github/workflows/pr-labeler.yml) workflow can tag PRs automatically and signal the expected semver impact.
 
 - **Format:** `<type>(<scope>): <subject>` — scope optional, ≤50 chars, imperative, no period.
+  - **type:** one of `feat|fix|perf|docs|style|refactor|test|chore|ci`.
+  - **scope:** optional component/package in parentheses, e.g., `app`, `auth`, `api`.
+  - **subject:** short present-tense summary (no trailing period).
 - **Breaking changes:** add `!` before the colon: `feat!: ...` or `feat(api)!: ...`.
 - **Enforcement:** the workflow fails if the prefix is missing/invalid, so titles must be fixed before merge.
 - **Labels created + colored:** the workflow creates/updates the `type:` and `semver:` labels with preset colors and descriptions, then applies them to the PR.
 - **Mappings:** `feat:` → `type: feat` + `semver: minor`; `fix:` → `type: fix` + `semver: patch`; `perf:` → `type: perf` + `semver: patch`; `docs|style|refactor|test|chore|ci:` → matching `type:` label (no semver); `feat!:` / `fix!:` (with or without scope) → `semver: major`.
 - **Why:** reviewers see the change type at a glance, release automation can infer bump size, and changelog triage stays consistent with commit semantics.
+
+### Label mapping
+
+| PR Title Prefix                | Applied Label(s)                   | Notes                                  |
+| ------------------------------ | ---------------------------------- | -------------------------------------- |
+| `feat:`                        | `type: feat`, `semver: minor`      | New user-facing capability             |
+| `fix:`                         | `type: fix`, `semver: patch`       | Bug fix for users                      |
+| `perf:`                        | `type: perf`, `semver: patch`      | Performance improvement                |
+| `docs:`                        | `type: docs`                       | Documentation-only                     |
+| `style:`                       | `type: style`                      | Formatting, no logic change            |
+| `refactor:`                    | `type: refactor`                   | Behavior-preserving restructuring      |
+| `test:`                        | `type: test`                       | Add/update tests                       |
+| `chore:`                       | `type: chore`                      | Maintenance/tooling/infra              |
+| `ci:`                          | `type: ci`                         | CI/CD config changes                   |
+| `feat!:` / `feat(scope)!:`     | `type: feat`, `semver: major`      | Breaking change                        |
+| `fix!:` / `fix(scope)!:`       | `type: fix`, `semver: major`       | Breaking change                        |
+
+Scopes are optional and help route reviews: `feat(auth): ...` or `fix(app)!: ...` still apply the same labels.
 
 ## Workflow Flow Diagram
 
@@ -63,3 +84,9 @@ yarn test          # or yarn test:report for coverage
 ## CI-related issues
 
 Open a GitHub issue with the `Devops` label (and any relevant labels) and include the failing workflow run link.
+
+## PR Labeler workflow (separate from CI)
+
+- `.github/workflows/pr-labeler.yml` runs on PR open/edit/sync and is **not part of `ci.yml`**.
+- It validates semantic PR titles, creates/updates the `type:` / `semver:` labels with colors/descriptions, and applies them to the PR.
+- If the title prefix is invalid or missing, the workflow fails and must be fixed before merge.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,14 +13,14 @@ GitHub Actions runs fast, parallel checks on every pull request to keep the code
 
 ## PR Titles & Auto-Labeling
 
-- PR titles must use Conventional Commit format: `<type>(<scope>): <subject>` (scope optional, imperative, no period).
-- Breaking changes add `!` before the colon: `feat!: ...` or `feat(api)!: ...`.
-- `.github/workflows/pr-labeler.yml` applies labels based on the prefix:
-  - `feat:` → `type: feat` + `semver: minor`
-  - `fix:` → `type: fix` + `semver: patch`
-  - `perf:` → `type: perf` + `semver: patch`
-  - `docs|style|refactor|test|chore|ci:` → corresponding `type:` label (no semver)
-  - `feat!:` / `fix!:` (with or without scope) → `semver: major`
+Use Conventional Commit titles so the `pr-labeler` workflow can tag PRs automatically and signal the expected semver impact.
+
+- **Format:** `<type>(<scope>): <subject>` — scope optional, ≤50 chars, imperative, no period.
+- **Breaking changes:** add `!` before the colon: `feat!: ...` or `feat(api)!: ...`.
+- **Enforcement:** the workflow fails if the prefix is missing/invalid, so titles must be fixed before merge.
+- **Labels created + colored:** the workflow creates/updates the `type:` and `semver:` labels with preset colors and descriptions, then applies them to the PR.
+- **Mappings:** `feat:` → `type: feat` + `semver: minor`; `fix:` → `type: fix` + `semver: patch`; `perf:` → `type: perf` + `semver: patch`; `docs|style|refactor|test|chore|ci:` → matching `type:` label (no semver); `feat!:` / `fix!:` (with or without scope) → `semver: major`.
+- **Why:** reviewers see the change type at a glance, release automation can infer bump size, and changelog triage stays consistent with commit semantics.
 
 ## Workflow Flow Diagram
 

--- a/docs/release_notes/1.0.24.md
+++ b/docs/release_notes/1.0.24.md
@@ -1,0 +1,1 @@
+Added automatic PR labeling: semantic PR titles (`feat:`, `fix:`, `perf:`, etc.) now auto-apply `type:` labels and semver (`major`/`minor`/`patch`) with color-coded labels to keep changelog impacts consistent.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-template",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "private": true,
   "description": "Boilerplate project for React Native apps.",
   "engines": {


### PR DESCRIPTION
## Summary

Adds automatic PR labeling based on semantic title prefixes, streamlines the PR template, and updates documentation to reflect the new workflows and conventions.

**What changed:**
- Added `pr-labeler.yml` workflow — auto-labels PRs based on title prefix (feat:, fix:, etc.)
- Updated PR template to a streamlined format with a pre-merge checklist

Loom vide: https://www.loom.com/share/acfd6ee523f149afad4bbfb37a7b0432

**Label mappings:**

| PR Title Prefix | Type Label | Semver Label |
|-----------------|------------|--------------|
| `feat:` | `type: feat` | `semver: minor` |
| `fix:` | `type: fix` | `semver: patch` |
| `perf:` | `type: perf` | `semver: patch` |
| `docs:` | `type: docs` | - |
| `style:` | `type: style` | - |
| `refactor:` | `type: refactor` | - |
| `test:` | `type: test` | - |
| `chore:` | `type: chore` | - |
| `ci:` | `type: ci` | - |
| `feat!:` / `fix!:` (breaking) | `type: feat/fix` | `semver: major` |

Automatic version bumping based on semver labels is being added in a separate PR ([#333](https://github.com/jalantechnologies/react-native-template/pull/333)).

---
## Tests

- Manual testing done by changing the PR title.

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Screemshots

1) The labels are changing according to the PR title prefix
<img width="741" height="618" alt="image" src="https://github.com/user-attachments/assets/971e5323-be99-4df4-8517-5f32a5b4047f" />

2) PR labeler workflow is failing if no PR title prefix is provided or if the format is wrong
<img width="1762" height="769" alt="image" src="https://github.com/user-attachments/assets/e3bc34e6-494f-4a94-87b3-6b854d44ea1c" />
