### PR TITLE
chore: rename project image references from boilerplate-react-native to react-native-template

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    image: 'boilerplate-react-native'
+    image: 'react-native-template'
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   app:
     platform: 'linux/amd64'
-    image: 'boilerplate-react-native'
+    image: 'react-native-template'
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,1 @@
-<enter release notes for the next version here (max 500 chars)>
+- Renamed project image references from boilerplate-react-native to react-native-template


### PR DESCRIPTION
# Pull Request

## Summary

Renames all occurrences of the old project image name `boilerplate-react-native` to `react-native-template` in the Docker Compose configuration files, aligning with the current project name.

The only affected files were:
- `docker-compose.yml` — image name updated on line 6
- `docker-compose.test.yml` — image name updated on line 5

These files are still in use (referenced by `.github/actions/check/action.yml`) so they were updated rather than removed.

Closes #236

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

## Additional Context

Identified via `rg "boilerplate-react-native" .` — only 2 occurrences existed, both in Docker Compose image name fields.