### PR TITLE
fix(ios): guard production deploy against in-review App Store versions

### DIFF
--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,1 @@
-<enter release notes for the next version here (max 500 chars)>
+- Added App Store Connect review guard to prevent production deploys from overwriting in-review versions

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -6,6 +6,7 @@ def ios_deploy_production!(options = {})
   require 'fileutils'
   require 'json'
   require 'fastlane'
+  require 'spaceship'
   require_relative 'release_notes_helper'
 
   # ---------------------------------------------------------------------------
@@ -77,6 +78,63 @@ def ios_deploy_production!(options = {})
     key_content: api_key_b64,
     is_key_content_base64: true
   )
+
+  # Ensure Spaceship uses the same API key for Connect API calls below.
+  # Older fastlane versions return a Hash; newer versions return a Token-like object.
+  Spaceship::ConnectAPI.token =
+    if api_key.respond_to?(:token)
+      api_key
+    elsif api_key.is_a?(Hash)
+      key_content = api_key[:key] || api_key['key']
+      if (api_key[:is_key_content_base64] || api_key['is_key_content_base64']) && key_content
+        key_content = Base64.decode64(key_content)
+      end
+      UI.user_error!('❌ ASC API key content is missing') if key_content.to_s.strip.empty?
+
+      in_house = api_key.key?(:in_house) ? api_key[:in_house] : api_key['in_house']
+      in_house = false if in_house.nil?
+
+      Spaceship::ConnectAPI::Token.create(
+        key_id: api_key[:key_id] || api_key['key_id'],
+        issuer_id: api_key[:issuer_id] || api_key['issuer_id'],
+        key: key_content,
+        filepath: api_key[:filepath] || api_key['filepath'],
+        duration: api_key[:duration] || api_key['duration'],
+        in_house: in_house
+      )
+    else
+      UI.user_error!("❌ Unexpected api_key type: #{api_key.class}")
+    end
+
+  # ---------------------------------------------------------------------------
+  # Guard: block deploy if any version is currently in review
+  # ---------------------------------------------------------------------------
+  app = Spaceship::ConnectAPI::App.find(app_identifier)
+  versions = app.get_app_store_versions(filter: { platform: 'IOS' })
+
+  state_of = lambda do |v|
+    v.respond_to?(:app_store_state) ? v.app_store_state : v.app_version_state
+  end
+
+  review_states   = %w[WAITING_FOR_REVIEW READY_FOR_REVIEW IN_REVIEW PENDING_APPLE_REVIEW]
+  editable_states = %w[PREPARE_FOR_SUBMISSION DEVELOPER_REJECTED REJECTED METADATA_REJECTED READY_FOR_REVIEW]
+
+  pending_reviews = versions.select { |v| review_states.include?(state_of.call(v)) }
+  unless pending_reviews.empty?
+    states = pending_reviews.map { |v| "#{v.version_string} (#{state_of.call(v)})" }.join(', ')
+    UI.user_error!("❌ App Store has version(s) in review: #{states}. Remove from review or wait until they finish before deploying.")
+  end
+
+  target_version = versions.find { |v| v.version_string == marketing_version }
+  if target_version
+    state = state_of.call(target_version)
+    unless editable_states.include?(state)
+      UI.user_error!("❌ App Store version #{marketing_version} exists but is in state #{state}, which is not editable. Bump the version in package.json or move it to Prepare for Submission.")
+    end
+    UI.message("📌 Using existing App Store version #{marketing_version} (state: #{state}).")
+  else
+    UI.message("🆕 No App Store version #{marketing_version} found; letting upload_to_app_store create it in 'Prepare for Submission'.")
+  end
 
   # ---------------------------------------------------------------------------
   # Set marketing version + compute production build number from it
@@ -252,6 +310,7 @@ def ios_deploy_production!(options = {})
   upload_to_app_store(
     api_key: api_key,
     app_identifier: app_identifier,
+    app_version: marketing_version,
     ipa: ipa_path,
     metadata_path: File.join(__dir__, '..', 'metadata'),
     skip_screenshots: true,

--- a/ios/fastlane/scripts/ios_deploy_production.rb
+++ b/ios/fastlane/scripts/ios_deploy_production.rb
@@ -116,7 +116,7 @@ def ios_deploy_production!(options = {})
     v.respond_to?(:app_store_state) ? v.app_store_state : v.app_version_state
   end
 
-  review_states   = %w[WAITING_FOR_REVIEW READY_FOR_REVIEW IN_REVIEW PENDING_APPLE_REVIEW]
+  review_states   = %w[WAITING_FOR_REVIEW IN_REVIEW PENDING_APPLE_REVIEW]
   editable_states = %w[PREPARE_FOR_SUBMISSION DEVELOPER_REJECTED REJECTED METADATA_REJECTED READY_FOR_REVIEW]
 
   pending_reviews = versions.select { |v| review_states.include?(state_of.call(v)) }


### PR DESCRIPTION
# Pull Request

## Summary

Fixes a metadata/binary mismatch bug (#328) where merging to `main` would trigger the iOS production lane and overwrite an in-review version's metadata while keeping the old binary attached (e.g. version 1.3.81 showing build 1.3.79).

**Changes to `ios/fastlane/scripts/ios_deploy_production.rb`:**

- Added `require 'spaceship'` to enable App Store Connect API queries before building.
- Wires the existing ASC API key into `Spaceship::ConnectAPI.token` (handles both Hash and object forms across fastlane versions).
- Added a pre-flight guard that fetches all iOS versions from ASC and **fails immediately** if any version is in `WAITING_FOR_REVIEW`, `IN_REVIEW`, or `PENDING_APPLE_REVIEW` — with a clear error message telling the developer to remove it from review or wait.
- Added a check that the target marketing version (from `package.json`) is in an editable state (`PREPARE_FOR_SUBMISSION`, `REJECTED`, etc.) before proceeding.
- Passes `app_version: marketing_version` to `upload_to_app_store` so the upload is explicitly pinned to the correct version instead of floating to whatever ASC selects.

All checks run **before** the expensive build step, so CI fails fast with no wasted macOS minutes.

## Test Cases

### TC-1: Deploy blocked when a version is in review
**Precondition:** An app version (e.g. `1.3.80`) is in `WAITING_FOR_REVIEW` or `IN_REVIEW` state on App Store Connect.

**Steps:**
1. Merge a change to `main` that would normally trigger the production workflow.
2. Observe the `Deploy iOS App to App Store (Production)` job in GitHub Actions.
3. The job runs the Fastlane `production_deploy` lane.

**Expected:** Job fails at the Spaceship guard step with the error:
```
❌ App Store has version(s) in review: 1.3.80 (WAITING_FOR_REVIEW). Remove from review or wait until they finish before deploying.
```
No IPA is built. No metadata is uploaded to ASC.

---

### TC-2: Deploy blocked when target version is in a non-editable state
**Precondition:** `package.json` version is `1.3.81`. That version exists on ASC in state `APPROVED` or `READY_FOR_SALE`.

**Steps:**
1. Trigger the production workflow without bumping the version.
2. Observe the Fastlane lane output.

**Expected:** Job fails with:
```
❌ App Store version 1.3.81 exists but is in state APPROVED, which is not editable. Bump the version in package.json or move it to Prepare for Submission.
```

---

### TC-3: Deploy succeeds when no version is in review
**Precondition:** No version is in review. `package.json` version is a new version not yet on ASC (or is in `PREPARE_FOR_SUBMISSION`).

**Steps:**
1. Merge to `main` with a valid version bump.
2. Observe the production workflow run end-to-end.

**Expected:**
- Guard step passes and logs either:
  - `📌 Using existing App Store version X.X.X (state: PREPARE_FOR_SUBMISSION).`
  - `🆕 No App Store version X.X.X found; letting upload_to_app_store create it in 'Prepare for Submission'.`
- IPA builds and uploads successfully.
- ASC shows the correct version with the correct binary attached.

---

### TC-4: Re-run after version is removed from review
**Precondition:** A previous run was blocked (TC-1). The developer has removed the version from review in ASC.

**Steps:**
1. Re-trigger the production workflow (or merge another commit).
2. Observe the job.

**Expected:** Guard passes, deploy proceeds normally.

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

## Additional Context
Video Walkthrough: https://www.loom.com/share/21947dde3c304c579d56ae977d8ed3b3
Reference implementation from the Picket mobile app: https://github.com/caliyan/picket-mobile-app/pull/360

The guard runs before `build_app`, so a blocked deploy costs zero macOS build minutes — CI fails in seconds at the Spaceship API call.