### PR TITLE
fix(ios): skip pod install on cache hit and align with local dev workflow

### DIFF
--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -110,10 +110,8 @@ runs:
       shell: bash
       run: |
         if [[ "${{ steps.pods-cache.outputs.cache-hit }}" != "true" ]]; then
-          pod repo update
+          RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
         fi
-        bundle exec pod update boost --no-repo-update
-        bundle exec pod install
 
     - name: Set up SSH for Match
       uses: webfactory/ssh-agent@v0.7.0

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -82,9 +82,9 @@ runs:
           ios/Pods
           ~/Library/Caches/CocoaPods
           ~/.cocoapods
-        key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+        key: ${{ runner.os }}-pods-v2-${{ hashFiles('ios/Podfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-pods-
+          ${{ runner.os }}-pods-v2-
 
     - name: Cache SwiftPM
       id: spm-cache

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -86,9 +86,9 @@ runs:
           ios/Pods
           ~/Library/Caches/CocoaPods
           ~/.cocoapods
-        key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+        key: ${{ runner.os }}-pods-v2-${{ hashFiles('ios/Podfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-pods-
+          ${{ runner.os }}-pods-v2-
 
     - name: Cache SwiftPM
       id: spm-cache

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -106,10 +106,8 @@ runs:
       shell: bash
       run: |
         if [[ "${{ steps.pods-cache.outputs.cache-hit }}" != "true" ]]; then
-          pod repo update
+          RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
         fi
-        bundle exec pod update boost --no-repo-update
-        bundle exec pod install
 
     - name: Set up SSH for Match
       uses: webfactory/ssh-agent@v0.7.0

--- a/.github/actions/permanent_preview_ios/action.yml
+++ b/.github/actions/permanent_preview_ios/action.yml
@@ -71,9 +71,9 @@ runs:
           ios/Pods
           ~/Library/Caches/CocoaPods
           ~/.cocoapods
-        key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+        key: ${{ runner.os }}-pods-v2-${{ hashFiles('ios/Podfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-pods-
+          ${{ runner.os }}-pods-v2-
 
     - name: Cache SwiftPM
       id: spm-cache

--- a/.github/actions/permanent_preview_ios/action.yml
+++ b/.github/actions/permanent_preview_ios/action.yml
@@ -91,10 +91,8 @@ runs:
       shell: bash
       run: |
         if [[ "${{ steps.pods-cache.outputs.cache-hit }}" != "true" ]]; then
-          pod repo update
+          RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
         fi
-        bundle exec pod update boost --no-repo-update
-        bundle exec pod install
 
     - name: Set up SSH for Match
       uses: webfactory/ssh-agent@v0.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
               - 'src/**'
               - 'android/**'
               - 'ios/**'
+              - '.github/**'
               - 'package.json'
               - 'yarn.lock'
               - 'app.json'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
               - 'src/**'
               - 'android/**'
               - 'ios/**'
-              - '.github/**'
               - 'package.json'
               - 'yarn.lock'
               - 'app.json'

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,3 @@
-<enter release notes for the next version here (max 500 chars)>
+fix(ios): skip pod install on cache hit and align with local dev workflow
+
+iOS CI workflows now skip pod install entirely when the CocoaPods cache is restored, removing unconditional `pod repo update` and `pod update boost` calls that ran on every build. Pod install now uses `RCT_NEW_ARCH_ENABLED=1` to match the local `yarn pod-install` script, eliminating CI/local dependency drift.


### PR DESCRIPTION
## Summary

Fixes #260 — aligns CI pod install behavior with local dev workflow and makes the CocoaPods cache fully effective.

**Context:** PR #342 added CocoaPods caching infrastructure and conditionally skipped \`pod repo update\` on a cache hit, but \`pod update boost\` and \`bundle exec pod install\` still ran **unconditionally on every build** — even when the cache was restored. This made the pod cache nearly useless and caused CI/local environment drift via the rogue \`pod update boost\` call.

**Changes in all 3 iOS action files:**
- Bumped CocoaPods cache key to \`pods-v2-\` to invalidate old caches built without \`RCT_NEW_ARCH_ENABLED=1\`
- Guarded \`pod install\` behind a true cache-hit check — skips the step **entirely** on a cache hit
- Removed \`pod repo update\` (Podfile uses CDN source; no local repo index needed)
- Removed \`pod update boost --no-repo-update\` (was silently drifting CI dependencies away from local state)
- Added \`RCT_NEW_ARCH_ENABLED=1\` to match the local \`yarn pod-install\` script exactly

**Files changed:**
- \`.github/actions/deploy_ios_preview/action.yml\`
- \`.github/actions/deploy_ios_production/action.yml\`
- \`.github/actions/permanent_preview_ios/action.yml\`

## Pre-Merge Checklist

- [x] Self-reviewed
- [x] Tests pass
- [x] AI code review completed (if applicable)

## Additional Context

Video Walkthrough: https://www.loom.com/share/0dee972b8b4945d186464386beebc52f

On a cache hit: pod install is skipped entirely — Pods are restored from cache as-is.  
On a cache miss (new/changed Podfile.lock): \`RCT_NEW_ARCH_ENABLED=1 bundle exec pod install\` runs once, then gets cached for subsequent builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)