### PR TITLE
docs: add AI-assisted post-fork rename guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Production-ready React Native boilerplate with TypeScript, navigation, state man
 
 ## Post-Fork Setup
 
-After forking, rename the project from `Boilerplate` to your app — see [Customization](docs/customization.md) for the AI-assisted one-session approach.
+After forking, rename the project from `Boilerplate` to your app — see [Customization](docs/customization.md) for an AI-assisted one-session approach (Claude Code, Cursor, Copilot Workspace, or any AI coding assistant).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Production-ready React Native boilerplate with TypeScript, navigation, state management, monitoring, and CI/CD pipelines.
 
+## Post-Fork Setup
+
+After forking, rename the project from `Boilerplate` to your app — see [Customization](docs/customization.md) for the AI-assisted one-session approach.
+
 ## Quickstart
 
 ```sh

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -1,0 +1,129 @@
+# Post-Fork Setup — Claude Prompt
+
+After forking this template, open a **Claude Code** session at the project root and paste the contents of the prompt below. Fill in your values for `APP_NAME` and `BUNDLE_ID` before pasting.
+
+> **APP_NAME** — PascalCase, single word, no spaces (e.g. `TrackIt`)
+> **BUNDLE_ID** — reverse-domain bundle identifier (e.g. `com.mycompany.trackit`)
+
+---
+
+## Prompt (paste into Claude Code)
+
+```
+I've just forked react-native-template. Rename the project from "Boilerplate" to my app.
+
+APP_NAME  = <YOUR_APP_NAME>       e.g. TrackIt
+BUNDLE_ID = <YOUR_BUNDLE_ID>      e.g. com.mycompany.trackit
+APP_NAME_LOWER = lowercase of APP_NAME  e.g. trackit
+
+Make every change below. Use the Edit tool for file edits and Bash mv for directory renames.
+Work through the list in order — edit file contents before renaming directories.
+
+─── ANDROID ────────────────────────────────────────────────────────────────────
+
+1. android/settings.gradle
+   Change:  rootProject.name = 'Boilerplate'
+   To:      rootProject.name = '<APP_NAME>'
+
+2. android/app/build.gradle
+   Change all occurrences of:  com.bettrsw.boilerplate.app
+   To:                         <BUNDLE_ID>
+
+3. android/app/src/main/res/values/strings.xml
+   Change:  <string name="app_name">Boilerplate</string>
+   To:      <string name="app_name"><APP_NAME></string>
+
+4. android/app/src/main/java/com/boilerplate/MainActivity.kt
+   Change package:  package com.bettrsw.boilerplate.app
+   To:              package <BUNDLE_ID>
+   Change:  override fun getMainComponentName(): String = "Boilerplate"
+   To:      override fun getMainComponentName(): String = "<APP_NAME>"
+
+5. android/app/src/main/java/com/boilerplate/MainApplication.kt
+   Change package:  package com.bettrsw.boilerplate.app
+   To:              package <BUNDLE_ID>
+
+6. android/app/src/main/java/com/boilerplate/SplashActivity.kt
+   Change package:  package com.bettrsw.boilerplate.app
+   To:              package <BUNDLE_ID>
+
+7. android/app/src/debug/java/com/boilerplate/ReactNativeFlipper.java
+   Change package:  package com.bettrsw.boilerplate.app;
+   To:              package <BUNDLE_ID>;
+
+8. Rename directory:
+   android/app/src/main/java/com/boilerplate/
+   → android/app/src/main/java/com/<APP_NAME_LOWER>/
+
+9. Rename directory:
+   android/app/src/debug/java/com/boilerplate/
+   → android/app/src/debug/java/com/<APP_NAME_LOWER>/
+
+10. android/fastlane/Appfile
+    Change:  "com.bettrsw.boilerplate.app"
+    To:      "<BUNDLE_ID>"
+
+─── iOS ─────────────────────────────────────────────────────────────────────────
+
+Note: edit all file contents before renaming any directories.
+
+11. ios/Boilerplate/AppDelegate.mm
+    Change:  self.moduleName = @"Boilerplate";
+    To:      self.moduleName = @"<APP_NAME>";
+
+12. ios/Boilerplate/Info.plist
+    The key CFBundleDisplayName has value "Boilerplate".
+    Change that value to "<APP_NAME>".
+
+13. ios/Boilerplate/LaunchScreen.storyboard
+    Change:  text="Boilerplate"
+    To:      text="<APP_NAME>"
+
+14. ios/BoilerplateTests/BoilerplateTests.m
+    Change all occurrences of "BoilerplateTests" to "<APP_NAME>Tests"
+    (covers @interface, @implementation, and @end)
+
+15. ios/Podfile
+    Change:  target 'Boilerplate' do
+    To:      target '<APP_NAME>' do
+    Change:  target 'BoilerplateTests' do
+    To:      target '<APP_NAME>Tests' do
+
+16. ios/Boilerplate.xcworkspace/contents.xcworkspacedata
+    Change:  group:Boilerplate.xcodeproj
+    To:      group:<APP_NAME>.xcodeproj
+
+17. ios/Boilerplate.xcodeproj/project.pbxproj
+    Replace every occurrence of "Boilerplate" with "<APP_NAME>".
+    (This automatically renames BoilerplateTests → <APP_NAME>Tests throughout.)
+
+18. ios/Boilerplate.xcodeproj/xcshareddata/xcschemes/Boilerplate.xcscheme
+    Replace every occurrence of "Boilerplate" with "<APP_NAME>" in the file content.
+    Then rename the file itself from Boilerplate.xcscheme to <APP_NAME>.xcscheme.
+
+19. Rename directory:  ios/Boilerplate/         → ios/<APP_NAME>/
+20. Rename directory:  ios/BoilerplateTests/     → ios/<APP_NAME>Tests/
+21. Rename directory:  ios/Boilerplate.xcodeproj/ → ios/<APP_NAME>.xcodeproj/
+22. Rename directory:  ios/Boilerplate.xcworkspace/ → ios/<APP_NAME>.xcworkspace/
+
+23. Delete ios/Podfile.lock  (pods must be reinstalled)
+
+─── ROOT FILES ──────────────────────────────────────────────────────────────────
+
+24. app.json
+    Change:  "name": "Boilerplate"        → "name": "<APP_NAME>"
+    Change:  "displayName": "Boilerplate" → "displayName": "<APP_NAME>"
+
+25. package.json
+    Change:  "name": "react-native-template"  → "name": "<APP_NAME_LOWER>"
+
+26. sonar-project.properties
+    Change:  sonar.projectKey=jalantechnologies_react-native-template
+    To:      sonar.projectKey=<APP_NAME_LOWER>
+
+─── AFTER ALL CHANGES ───────────────────────────────────────────────────────────
+
+Once every edit is confirmed, tell me so I can run:
+  yarn pod-install
+to reinstall iOS pods with the new target name.
+```

--- a/docs/ai-setup-prompt.md
+++ b/docs/ai-setup-prompt.md
@@ -1,13 +1,13 @@
-# Post-Fork Setup — Claude Prompt
+# Post-Fork Setup — AI Rename Prompt
 
-After forking this template, open a **Claude Code** session at the project root and paste the contents of the prompt below. Fill in your values for `APP_NAME` and `BUNDLE_ID` before pasting.
+After forking this template, open an AI coding session (Claude Code, Cursor, Copilot Workspace, or similar) at the project root and paste the contents of the prompt below. Fill in your values for `APP_NAME` and `BUNDLE_ID` before pasting.
 
 > **APP_NAME** — PascalCase, single word, no spaces (e.g. `TrackIt`)
 > **BUNDLE_ID** — reverse-domain bundle identifier (e.g. `com.mycompany.trackit`)
 
 ---
 
-## Prompt (paste into Claude Code)
+## Prompt (paste into your AI assistant)
 
 ```
 I've just forked react-native-template. Rename the project from "Boilerplate" to my app.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,29 +1,67 @@
 # Customizing the Template
 
-Use these steps to rebrand the template for your product.
+After forking, the project must be renamed from `Boilerplate` to your app name and its package identifier updated throughout.
 
-## App Name
+## Recommended: AI-Assisted Rename
 
-1. Update [`app.json`](../app.json) `name` and `displayName`.
-2. Update [`package.json`](../package.json) `name`.
+The fastest and most reliable path is to use Claude Code. A ready-made prompt is provided that instructs Claude to make every change in one session.
 
-## Android
+1. Fork the repository and open a Claude Code session at the project root.
+2. Open [`docs/ai-setup-prompt.md`](./ai-setup-prompt.md).
+3. Fill in your `APP_NAME` and `BUNDLE_ID` values in the prompt block.
+4. Paste the entire prompt into Claude Code and let it make all changes.
+5. When Claude confirms, run `yarn pod-install` to reinstall iOS pods.
 
-- [`android/settings.gradle`](../android/settings.gradle): set `rootProject.name`.
-- [`android/app/build.gradle`](../android/app/build.gradle): update `namespace` and `applicationId`.
-- Keep `production` as the base package; `preview` flavor uses `applicationIdSuffix ".preview"` so installs remain side by side.
-- Rename package directories under [`android/app/src/*/java/com/boilerplate/`](../android/app/src).
-- Update package declarations in Java/Kotlin files.
-- [`android/app/src/main/res/values/strings.xml`](../android/app/src/main/res/values/strings.xml): adjust `app_name`.
+## What Gets Changed
 
-## iOS
+The prompt covers every location where `Boilerplate` / `com.bettrsw.boilerplate.app` appears:
 
-- Rename [`ios/Boilerplate`](../ios/Boilerplate) folder to your app name.
-- Update targets in [`ios/Podfile`](../ios/Podfile).
-- Update `CFBundleDisplayName` in [`ios/Boilerplate/Info.plist`](../ios/Boilerplate/Info.plist).
-- Run `yarn pod-install` after changes.
+| Area | Files |
+|---|---|
+| Android build | `android/settings.gradle`, `android/app/build.gradle` |
+| Android sources | `MainActivity.kt`, `MainApplication.kt`, `SplashActivity.kt`, `ReactNativeFlipper.java` — package declarations + directory rename |
+| Android resources | `android/app/src/main/res/values/strings.xml` |
+| Android CI | `android/fastlane/Appfile` |
+| iOS sources | `AppDelegate.mm`, `Info.plist`, `LaunchScreen.storyboard`, `BoilerplateTests.m` |
+| iOS project | `project.pbxproj`, `Podfile`, `*.xcscheme`, `contents.xcworkspacedata` |
+| iOS directories | `Boilerplate/`, `BoilerplateTests/`, `Boilerplate.xcodeproj/`, `Boilerplate.xcworkspace/` |
+| Root | `app.json`, `package.json`, `sonar-project.properties` |
+
+## Manual Reference
+
+If you need to update only specific parts, these are the exact locations:
+
+### Android
+
+- `android/settings.gradle` — `rootProject.name`
+- `android/app/build.gradle` — `namespace` and `applicationId`
+- `android/app/src/main/res/values/strings.xml` — `app_name`
+- All `.kt` / `.java` files under `android/app/src/*/java/com/boilerplate/` — package declaration
+- `MainActivity.kt` — `getMainComponentName()` return value
+- Rename `android/app/src/*/java/com/boilerplate/` directories to your app name (lowercase)
+- `android/fastlane/Appfile` — fallback `package_name`
+
+### iOS
+
+- `ios/Boilerplate/AppDelegate.mm` — `self.moduleName`
+- `ios/Boilerplate/Info.plist` — `CFBundleDisplayName`
+- `ios/Boilerplate/LaunchScreen.storyboard` — title label `text`
+- `ios/BoilerplateTests/BoilerplateTests.m` — `@interface` and `@implementation` class name
+- `ios/Podfile` — `target` names
+- `ios/Boilerplate.xcodeproj/project.pbxproj` — global replace `Boilerplate` → new name
+- `ios/Boilerplate.xcodeproj/xcshareddata/xcschemes/Boilerplate.xcscheme` — content + filename
+- `ios/Boilerplate.xcworkspace/contents.xcworkspacedata` — `FileRef` location
+- Rename `ios/Boilerplate*/` directories and `ios/Boilerplate*.xcodeproj/` / `ios/Boilerplate*.xcworkspace/`
+- Delete `ios/Podfile.lock` and run `yarn pod-install`
+
+### Root
+
+- `app.json` — `name` and `displayName`
+- `package.json` — `name`
+- `sonar-project.properties` — `sonar.projectKey`
 
 ## CI/CD Metadata
 
-- [`.github/workflows/*.yml`](../.github/workflows): update any hardcoded project identifiers.
-- [`sonar-project.properties`](../sonar-project.properties): set the correct `sonar.projectKey`.
+Update any hardcoded project identifiers in:
+- [`.github/workflows/*.yml`](../.github/workflows) — app identifiers, project keys
+- Environment secrets in Doppler — `IOS_APP_IDENTIFIER`, `ANDROID_APP_IDENTIFIER`, bundle signing details

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -4,13 +4,13 @@ After forking, the project must be renamed from `Boilerplate` to your app name a
 
 ## Recommended: AI-Assisted Rename
 
-The fastest and most reliable path is to use Claude Code. A ready-made prompt is provided that instructs Claude to make every change in one session.
+The fastest and most reliable path is to use an AI coding assistant (Claude Code, Cursor, Copilot Workspace, or similar). A ready-made prompt is provided that instructs the AI to make every change in one session.
 
-1. Fork the repository and open a Claude Code session at the project root.
+1. Fork the repository and open an AI coding session at the project root.
 2. Open [`docs/ai-setup-prompt.md`](./ai-setup-prompt.md).
 3. Fill in your `APP_NAME` and `BUNDLE_ID` values in the prompt block.
-4. Paste the entire prompt into Claude Code and let it make all changes.
-5. When Claude confirms, run `yarn pod-install` to reinstall iOS pods.
+4. Paste the entire prompt into your AI assistant and let it make all changes.
+5. When the AI confirms, run `yarn pod-install` to reinstall iOS pods.
 
 ## What Gets Changed
 

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,4 @@
-<enter release notes for the next version here (max 500 chars)>
+### Post-Fork Setup Guide
+- Added `docs/ai-setup-prompt.md`: a copy-paste prompt for any AI coding assistant (Claude Code, Cursor, Copilot Workspace) that renames all Boilerplate references across Android, iOS, and root files in one session.
+- Rewrote `docs/customization.md` with a full file-by-file rename reference.
+- Added Post-Fork Setup callout to README.


### PR DESCRIPTION
## Summary

- Adds `docs/ai-setup-prompt.md` — a copy-paste Claude Code prompt that covers every `Boilerplate` reference across Android, iOS, and root files in a single session
- Rewrites `docs/customization.md` to lead with the AI-assisted path and retain a full manual reference table for partial updates
- Adds a **Post-Fork Setup** callout in `README.md` pointing to the customization guide

Closes #55

## What the prompt covers

| Area | Changes |
|---|---|
| Android build | `settings.gradle`, `app/build.gradle` |
| Android sources | Package declarations in all `.kt`/`.java` files + directory renames |
| Android resources | `strings.xml` app name |
| iOS sources | `AppDelegate.mm`, `Info.plist`, `LaunchScreen.storyboard`, `BoilerplateTests.m` |
| iOS project | `project.pbxproj`, `Podfile`, `.xcscheme`, `.xcworkspacedata` + directory renames |
| Root | `app.json`, `package.json`, `sonar-project.properties` |

## Test plan

- [ ] Fork the template, open Claude Code, paste the prompt from `docs/ai-setup-prompt.md` with a test app name and bundle ID
- [ ] Verify `grep -r "Boilerplate" android/ ios/ app.json` returns no matches after Claude completes the changes
- [ ] Verify iOS directories are correctly renamed
- [ ] Run `yarn pod-install` and confirm pods install cleanly under the new target name

🤖 Generated with [Claude Code](https://claude.com/claude-code)