### PR TITLE
fix: add privacy policy page for GitHub Pages and Play Store links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Production-ready React Native boilerplate with TypeScript, navigation, state management, monitoring, and CI/CD pipelines.
 
+Live demo on Google Play: [Boilerplate](https://play.google.com/store/apps/details?id=com.bettrsw.boilerplate.app)
+
 ## Quickstart
 
 ```sh
@@ -30,6 +32,7 @@ yarn android              # or: yarn ios
 - [CI](docs/ci.md) — GitHub Actions checks and SonarQube gate expectations
 - [CD](docs/cd.md) — preview/production/permanent-preview deployment pipelines
 - [Troubleshooting](docs/troubleshooting.md) — common local build fixes
+- [Privacy Policy](https://jalantechnologies.github.io/react-native-template/privacy-policy.html) — Play Store privacy policy, served via GitHub Pages (enable in repo Settings → Pages → Deploy from branch `main` → `/` root)
 
 ## License
 

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,4 @@
-<enter release notes for the next version here (max 500 chars)>
+### Privacy Policy & Play Store Links
+- Added `privacy-policy.html` at repo root served via GitHub Pages for Play Store compliance.
+- Added `.nojekyll` to enable clean GitHub Pages serving.
+- Updated README with Google Play Store link and privacy policy link.

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -47,17 +47,25 @@
 
   <h2>3. Automatically Collected Data</h2>
   <p>
-    Third-party SDKs integrated for monitoring and crash reporting may automatically collect
-    device-level information such as device model, OS version, app version, and crash diagnostics.
-    This data is used solely to improve application stability and is not linked to any individual
-    identity.
+    The App integrates Datadog for observability. Datadog may automatically collect the following:
+  </p>
+  <ul>
+    <li><strong>Device and app diagnostics</strong> — device model, OS version, app version, and native crash reports</li>
+    <li><strong>User interactions</strong> — tap events and UI element interactions (element type or accessibility label)</li>
+    <li><strong>Network requests</strong> — XHR/HTTP resource timing and error information</li>
+    <li><strong>Session replay</strong> — screen recordings at a 20% sample rate; sensitive text inputs are masked, and touch events are visible</li>
+    <li><strong>JavaScript errors</strong> — unhandled errors and stack traces</li>
+  </ul>
+  <p>
+    This data is used solely to monitor application stability and performance. It is processed by
+    Datadog under their privacy policy and is not sold or used for advertising purposes.
   </p>
 
   <h2>4. Third-Party Services</h2>
-  <p>The App may use the following third-party services, each governed by their own privacy policy:</p>
+  <p>The App uses the following third-party services, each governed by their own privacy policy:</p>
   <ul>
     <li>Google Play Services — device authentication and app distribution</li>
-    <li>Sentry — error and crash monitoring</li>
+    <li><a href="https://www.datadoghq.com/legal/privacy/">Datadog</a> — performance monitoring, error tracking, and session replay</li>
   </ul>
 
   <h2>5. Data Retention</h2>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy — Boilerplate</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      line-height: 1.7;
+      color: #333;
+      max-width: 720px;
+      margin: 40px auto;
+      padding: 0 24px 60px;
+    }
+    h1 { font-size: 1.8rem; margin-bottom: 4px; }
+    h2 { font-size: 1.1rem; margin-top: 32px; }
+    p, li { margin: 8px 0; }
+    a { color: #0070f3; }
+    .meta { color: #666; font-size: 0.9rem; margin-bottom: 32px; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p class="meta">
+    <strong>App:</strong> Boilerplate &nbsp;|&nbsp;
+    <strong>Developer:</strong> Jalan Technologies &nbsp;|&nbsp;
+    <strong>Package:</strong> com.bettrsw.boilerplate.app<br />
+    <strong>Effective date:</strong> April 10, 2026
+  </p>
+
+  <h2>1. Introduction</h2>
+  <p>
+    This Privacy Policy describes how the Boilerplate application ("App") handles information.
+    Boilerplate is a demonstration and template application published on the Google Play Store by
+    Jalan Technologies. It exists to showcase the
+    <a href="https://github.com/jalantechnologies/react-native-template">react-native-template</a>
+    boilerplate and is not intended for general consumer use.
+  </p>
+
+  <h2>2. Information We Collect</h2>
+  <p>
+    The App itself does not collect, store, or transmit any personally identifiable information (PII).
+    No user accounts, profiles, or personal data are created or retained through this App.
+  </p>
+
+  <h2>3. Automatically Collected Data</h2>
+  <p>
+    Third-party SDKs integrated for monitoring and crash reporting may automatically collect
+    device-level information such as device model, OS version, app version, and crash diagnostics.
+    This data is used solely to improve application stability and is not linked to any individual
+    identity.
+  </p>
+
+  <h2>4. Third-Party Services</h2>
+  <p>The App may use the following third-party services, each governed by their own privacy policy:</p>
+  <ul>
+    <li>Google Play Services — device authentication and app distribution</li>
+    <li>Sentry — error and crash monitoring</li>
+  </ul>
+
+  <h2>5. Data Retention</h2>
+  <p>
+    Since the App directly collects no personal data, there is no retention period to specify.
+    Crash and diagnostic data held by third-party services is subject to those services' own
+    retention policies.
+  </p>
+
+  <h2>6. Children's Privacy</h2>
+  <p>
+    This App is not directed at children under the age of 13. We do not knowingly collect data
+    from children.
+  </p>
+
+  <h2>7. Changes to This Policy</h2>
+  <p>
+    We may update this Privacy Policy from time to time. Any changes will be reflected by an
+    updated effective date at the top of this page.
+  </p>
+
+  <h2>8. Contact</h2>
+  <p>
+    For questions or concerns about this Privacy Policy, please open an issue at
+    <a href="https://github.com/jalantechnologies/react-native-template/issues">
+      github.com/jalantechnologies/react-native-template/issues
+    </a>.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Resolves the remaining task from issue #38 (Publish Android App to PlayStore). The app is already live on the Play Store, but two items were outstanding:

- Privacy Policy page accessible via GitHub Pages (required for Play Store compliance)
- README update with Play Store link and privacy policy link

Changes:
- **`privacy-policy.html`** — standalone, self-contained HTML privacy policy page at the repo root; will be served at `https://jalantechnologies.github.io/react-native-template/privacy-policy.html` once GitHub Pages is enabled
- **`.nojekyll`** — empty file at repo root to suppress Jekyll processing so the HTML page is served as-is
- **`README.md`** — added Play Store live demo link after the description, and a Privacy Policy entry in the Documentation Directory
- **`docs/release_notes/release_notes.md`** — updated with release notes for this change

Closes #38

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

## Additional Context 

Video Walkthrough: https://www.loom.com/share/2f98e9e0f3cf4ed5ab98d169b29fdd18

**One manual step required after merge:** Enable GitHub Pages in the repository settings:
> Settings → Pages → Build and deployment → Source: "Deploy from a branch" → Branch: `main` → Folder: `/ (root)` → Save

The privacy policy URL (`https://jalantechnologies.github.io/react-native-template/privacy-policy.html`) should go live within 1–5 minutes after Pages is enabled. This URL should be entered in the Google Play Console under App Content → Privacy Policy.