### PR TITLE
ci: add mobile security scan before deployments

### DIFF
--- a/.github/actions/mobile-scan/action.yml
+++ b/.github/actions/mobile-scan/action.yml
@@ -1,0 +1,63 @@
+name: 'Mobile Security Scan'
+description: 'Scan source/dependencies with Trivy and optionally scan APK/IPA binaries with Ostorlab'
+
+inputs:
+  android-apk-path:
+    description: 'Glob path to the Android APK for Ostorlab binary scan (leave empty to skip)'
+    required: false
+    default: ''
+  ios-ipa-path:
+    description: 'Glob path to the iOS IPA for Ostorlab binary scan (leave empty to skip)'
+    required: false
+    default: ''
+
+outputs:
+  has-issues:
+    description: 'Set to "true" if any scan found HIGH or CRITICAL vulnerabilities'
+    value: ${{ steps.scan.outputs.has-issues }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Trivy source and dependency scan
+      id: trivy
+      uses: aquasecurity/trivy-action@0.33.0
+      continue-on-error: true
+      with:
+        scan-type: 'fs'
+        format: 'github'
+        severity: 'HIGH,CRITICAL'
+        ignore-unfixed: true
+
+    - name: Ostorlab Android APK scan
+      id: ostorlab_android
+      if: inputs.android-apk-path != ''
+      uses: ostorlab/github-action@main
+      continue-on-error: true
+      with:
+        asset_type: 'android-apk'
+        target: ${{ inputs.android-apk-path }}
+        api-key: ${{ secrets.OSTORLAB_API_KEY }}
+
+    - name: Ostorlab iOS IPA scan
+      id: ostorlab_ios
+      if: inputs.ios-ipa-path != ''
+      uses: ostorlab/github-action@main
+      continue-on-error: true
+      with:
+        asset_type: 'ios-ipa'
+        target: ${{ inputs.ios-ipa-path }}
+        api-key: ${{ secrets.OSTORLAB_API_KEY }}
+
+    - name: Set has-issues output
+      id: scan
+      if: steps.trivy.outcome == 'failure' || steps.ostorlab_android.outcome == 'failure' || steps.ostorlab_ios.outcome == 'failure'
+      shell: bash
+      run: echo "has-issues=true" >> $GITHUB_OUTPUT
+
+    - name: Fail if vulnerabilities found
+      if: steps.trivy.outcome == 'failure' || steps.ostorlab_android.outcome == 'failure' || steps.ostorlab_ios.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "❌ Security scan found HIGH or CRITICAL vulnerabilities. Blocking deployment."
+        exit 1

--- a/.github/actions/mobile-scan/action.yml
+++ b/.github/actions/mobile-scan/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: Trivy source and dependency scan
       id: trivy
-      uses: aquasecurity/trivy-action@0.33.0
+      uses: aquasecurity/trivy-action@v0.35.0
       continue-on-error: true
       with:
         scan-type: 'fs'
@@ -36,22 +36,22 @@ runs:
     - name: Ostorlab Android APK scan
       id: ostorlab_android
       if: inputs.android-apk-path != ''
-      uses: ostorlab/github-action@main
+      uses: Ostorlab/ostorlab_actions@v2.1.0
       continue-on-error: true
       with:
         asset_type: 'android-apk'
         target: ${{ inputs.android-apk-path }}
-        api-key: ${{ inputs.ostorlab-api-key }}
+        ostorlab_api_key: ${{ inputs.ostorlab-api-key }}
 
     - name: Ostorlab iOS IPA scan
       id: ostorlab_ios
       if: inputs.ios-ipa-path != ''
-      uses: ostorlab/github-action@main
+      uses: Ostorlab/ostorlab_actions@v2.1.0
       continue-on-error: true
       with:
         asset_type: 'ios-ipa'
         target: ${{ inputs.ios-ipa-path }}
-        api-key: ${{ inputs.ostorlab-api-key }}
+        ostorlab_api_key: ${{ inputs.ostorlab-api-key }}
 
     - name: Set has-issues output
       id: scan

--- a/.github/actions/mobile-scan/action.yml
+++ b/.github/actions/mobile-scan/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Glob path to the iOS IPA for Ostorlab binary scan (leave empty to skip)'
     required: false
     default: ''
+  ostorlab-api-key:
+    description: 'Ostorlab API key (required when android-apk-path or ios-ipa-path is provided)'
+    required: false
+    default: ''
 
 outputs:
   has-issues:
@@ -37,7 +41,7 @@ runs:
       with:
         asset_type: 'android-apk'
         target: ${{ inputs.android-apk-path }}
-        api-key: ${{ secrets.OSTORLAB_API_KEY }}
+        api-key: ${{ inputs.ostorlab-api-key }}
 
     - name: Ostorlab iOS IPA scan
       id: ostorlab_ios
@@ -47,7 +51,7 @@ runs:
       with:
         asset_type: 'ios-ipa'
         target: ${{ inputs.ios-ipa-path }}
-        api-key: ${{ secrets.OSTORLAB_API_KEY }}
+        api-key: ${{ inputs.ostorlab-api-key }}
 
     - name: Set has-issues output
       id: scan

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,9 +76,49 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
-  deploy_android:
+  scan_android:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && needs.changes.outputs.android == 'true'
     needs: [changes, release_notes_check]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run mobile security scan
+        uses: ./.github/actions/mobile-scan
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "## ❌ Android Security Scan Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy found HIGH or CRITICAL vulnerabilities in source/dependencies. Resolve them before deploying." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+
+  scan_ios:
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && needs.changes.outputs.ios == 'true'
+    needs: [changes, release_notes_check]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run mobile security scan
+        uses: ./.github/actions/mobile-scan
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "## ❌ iOS Security Scan Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy found HIGH or CRITICAL vulnerabilities in source/dependencies. Resolve them before deploying." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+
+  deploy_android:
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && needs.changes.outputs.android == 'true'
+    needs: [changes, release_notes_check, scan_android]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -133,7 +173,7 @@ jobs:
 
   deploy_ios:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && needs.changes.outputs.ios == 'true'
-    needs: [changes, release_notes_check]
+    needs: [changes, release_notes_check, scan_ios]
     runs-on: macos-15-xlarge
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Run mobile security scan
         uses: ./.github/actions/mobile-scan
+        with:
+          ostorlab-api-key: ${{ secrets.OSTORLAB_API_KEY }}
 
       - name: Failure summary
         if: failure()
@@ -106,6 +108,8 @@ jobs:
 
       - name: Run mobile security scan
         uses: ./.github/actions/mobile-scan
+        with:
+          ostorlab-api-key: ${{ secrets.OSTORLAB_API_KEY }}
 
       - name: Failure summary
         if: failure()

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,12 +28,14 @@ jobs:
             android:
               - 'android/**'
               - '.github/actions/deploy_android_*/**'
+              - '.github/actions/mobile-scan/**'
               - '**/*.gradle*'
               - 'package.json'
               - 'yarn.lock'
             ios:
               - 'ios/**'
               - '.github/actions/deploy_ios_*/**'
+              - '.github/actions/mobile-scan/**'
               - '.ruby-version'
               - 'Gemfile*'
               - 'package.json'

--- a/.github/workflows/permanent_preview.yml
+++ b/.github/workflows/permanent_preview.yml
@@ -50,9 +50,47 @@ jobs:
           notes_dir: 'docs/release_notes'
           notes_ext: '.md'
 
-  build_android_permanent_preview:
+  scan_android:
     runs-on: ubuntu-latest
     needs: [release_notes_check]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run mobile security scan
+        uses: ./.github/actions/mobile-scan
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "## ❌ Android Security Scan Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy found HIGH or CRITICAL vulnerabilities in source/dependencies. Resolve them before deploying." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+
+  scan_ios:
+    runs-on: ubuntu-latest
+    needs: [release_notes_check]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run mobile security scan
+        uses: ./.github/actions/mobile-scan
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "## ❌ iOS Security Scan Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy found HIGH or CRITICAL vulnerabilities in source/dependencies. Resolve them before deploying." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+
+  build_android_permanent_preview:
+    runs-on: ubuntu-latest
+    needs: [release_notes_check, scan_android]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -99,7 +137,7 @@ jobs:
   build_ios_permanent_preview:
     runs-on: macos-15-xlarge
     timeout-minutes: 60
-    needs: [release_notes_check]
+    needs: [release_notes_check, scan_ios]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/permanent_preview.yml
+++ b/.github/workflows/permanent_preview.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Run mobile security scan
         uses: ./.github/actions/mobile-scan
+        with:
+          ostorlab-api-key: ${{ secrets.OSTORLAB_API_KEY }}
 
       - name: Failure summary
         if: failure()
@@ -78,6 +80,8 @@ jobs:
 
       - name: Run mobile security scan
         uses: ./.github/actions/mobile-scan
+        with:
+          ostorlab-api-key: ${{ secrets.OSTORLAB_API_KEY }}
 
       - name: Failure summary
         if: failure()

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Run mobile security scan
         uses: ./.github/actions/mobile-scan
+        with:
+          ostorlab-api-key: ${{ secrets.OSTORLAB_API_KEY }}
 
       - name: Failure summary
         if: failure()
@@ -96,6 +98,8 @@ jobs:
 
       - name: Run mobile security scan
         uses: ./.github/actions/mobile-scan
+        with:
+          ostorlab-api-key: ${{ secrets.OSTORLAB_API_KEY }}
 
       - name: Failure summary
         if: failure()

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -68,9 +68,47 @@ jobs:
           notes_dir: 'docs/release_notes'
           notes_ext: '.md'
           
-  deploy_android:
+  scan_android:
     runs-on: ubuntu-latest
     needs: [release_notes_check]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run mobile security scan
+        uses: ./.github/actions/mobile-scan
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "## ❌ Android Security Scan Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy found HIGH or CRITICAL vulnerabilities in source/dependencies. Resolve them before deploying." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+
+  scan_ios:
+    runs-on: ubuntu-latest
+    needs: [release_notes_check]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run mobile security scan
+        uses: ./.github/actions/mobile-scan
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "## ❌ iOS Security Scan Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy found HIGH or CRITICAL vulnerabilities in source/dependencies. Resolve them before deploying." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+
+  deploy_android:
+    runs-on: ubuntu-latest
+    needs: [release_notes_check, scan_android]
     steps:
       - name: Checkout (app)
         uses: actions/checkout@v4
@@ -130,7 +168,7 @@ jobs:
 
   deploy_ios:
     runs-on: macos-15-xlarge
-    needs: [release_notes_check]
+    needs: [release_notes_check, scan_ios]
     timeout-minutes: 30
     steps:
       - name: Checkout (app)

--- a/CI_README.md
+++ b/CI_README.md
@@ -1,0 +1,101 @@
+# CI/CD Pipeline
+
+This document describes the CI/CD pipeline structure and security scanning setup for this React Native template.
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `ci.yml` | PR opened/updated | Linting, type checking, SonarQube |
+| `cd.yml` | PR opened/updated | Preview builds (Android → Firebase, iOS → TestFlight) |
+| `production.yml` | Push to `main` (version bump) | Production builds (Android → Play Store, iOS → App Store) |
+| `permanent_preview.yml` | Push to `main` (version bump) | Permanent preview APK/IPA published as GitHub Release |
+| `version-bump.yml` | PR merged to `main` | Bumps semver, rotates release notes |
+| `clean.yml` | PR closed | Cleans up Firebase and TestFlight preview builds |
+
+## Security Scanning
+
+Every deployment workflow runs a security scan **before** the build and upload steps. Deployment is blocked if any **HIGH** or **CRITICAL** vulnerability is found.
+
+### Composite Action: `mobile-scan`
+
+Location: `.github/actions/mobile-scan/action.yml`
+
+Inputs:
+
+| Input | Required | Description |
+|---|---|---|
+| `android-apk-path` | No | Glob path to a built APK for Ostorlab binary scan |
+| `ios-ipa-path` | No | Glob path to a built IPA for Ostorlab binary scan |
+
+Outputs:
+
+| Output | Description |
+|---|---|
+| `has-issues` | `"true"` if any scan found HIGH/CRITICAL issues |
+
+### Trivy (Source & Dependency Scan)
+
+- Tool: [`aquasecurity/trivy-action`](https://github.com/aquasecurity/trivy-action)
+- Scan type: `fs` (filesystem — source code and dependencies)
+- Severity threshold: `HIGH,CRITICAL`
+- Unfixed vulnerabilities: ignored (`ignore-unfixed: true`)
+- Runs on every deployment workflow, always
+
+**To suppress a false positive**, add the CVE ID to `.trivyignore` at the repo root with a comment explaining the reason and review date:
+
+```
+# CVE-2025-12345: Transitive dep via X, no fix available (reviewed 2026-01-15)
+CVE-2025-12345
+```
+
+### Ostorlab (Binary Scan)
+
+- Tool: [`ostorlab/github-action`](https://github.com/ostorlab/ostorlab-github-action)
+- Scan types: `android-apk`, `ios-ipa`
+- Required secret: `OSTORLAB_API_KEY`
+- Runs **only when `android-apk-path` or `ios-ipa-path` inputs are provided**
+
+**Current status:** Binary scanning is wired into the `mobile-scan` action but not yet active, because the current Fastlane lanes combine build and upload in a single command. To enable binary scanning, split each deploy Fastlane lane into a build-only step followed by a scan step, followed by an upload-only step. Then pass the artifact path to `mobile-scan`:
+
+```yaml
+- uses: ./.github/actions/mobile-scan
+  with:
+    android-apk-path: 'android/app/build/outputs/apk/release/*.apk'
+```
+
+### Scan Job Placement
+
+In each workflow the scan jobs run after `release_notes_check` and before the build/deploy jobs:
+
+```
+release_notes_check
+  ├── scan_android → build_android / deploy_android
+  └── scan_ios     → build_ios    / deploy_ios
+```
+
+### Interpreting Scan Failures
+
+If a scan job fails:
+
+1. Open the failed workflow run and expand the **Trivy source and dependency scan** step.
+2. Review the listed CVEs with their severity and affected package.
+3. Options to resolve:
+   - **Upgrade** the affected package to a fixed version.
+   - **Remove** the package if unused.
+   - **Suppress** with `.trivyignore` if it is a confirmed false positive or has no available fix (document the reason).
+4. Push a fix commit — the scan will re-run automatically.
+
+## Required Secrets
+
+| Secret | Used By | Description |
+|---|---|---|
+| `DOPPLER_PREVIEW_TOKEN` | cd.yml, permanent_preview.yml | Doppler token for preview environment |
+| `DOPPLER_PRODUCTION_TOKEN` | production.yml | Doppler token for production environment |
+| `ANDROID_GCP_JSON_BASE64` | deploy_android_preview | GCP service account for Firebase |
+| `ANDROID_FIREBASE_*` | deploy_android_preview | Firebase project credentials |
+| `GPLAY_SERVICE_ACCOUNT_KEY_JSON` | deploy_android_production | Google Play service account |
+| `ANDROID_KEYSTORE_*` | deploy_android_production, permanent_preview_android | Android signing keystore |
+| `IOS_MATCH_*` | deploy_ios_* | Fastlane Match certificates |
+| `IOS_APP_STORE_*` | deploy_ios_* | App Store Connect API credentials |
+| `OSTORLAB_API_KEY` | mobile-scan | Ostorlab API key for binary scanning |

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,1 @@
-<enter release notes for the next version here (max 500 chars)>
+Add mobile security scanning to CI/CD pipeline. Trivy now scans source and dependencies for HIGH/CRITICAL vulnerabilities before every Android and iOS deployment.


### PR DESCRIPTION
## Summary

- Adds a reusable `.github/actions/mobile-scan` composite action that runs Trivy filesystem scan (source/deps, HIGH/CRITICAL severity) and optionally Ostorlab binary scan (APK/IPA when paths are provided)
- Adds `scan_android` and `scan_ios` jobs to `cd.yml`, `production.yml`, and `permanent_preview.yml` that gate the build/deploy jobs — deployment is blocked if HIGH or CRITICAL vulnerabilities are found
- Creates `CI_README.md` documenting the pipeline structure, scan tools, required secrets, and how to suppress false positives

Closes #264

## Pre-Merge Checklist

- [x] Self-reviewed
- [x] Follows flask-react-app Trivy scan pattern as reference
- [x] Ostorlab binary scan wired into the action (optional inputs); documented in CI_README.md that activation requires Fastlane build/deploy lane separation

## Additional Context

**Job dependency graph after this change (`cd.yml`):**
```
changes → release_notes_check
              ├── scan_android → deploy_android → PR comment
              └── scan_ios     → deploy_ios     → PR comment
```

The `mobile-scan` action uses `continue-on-error: true` per scan step and a final explicit fail step — matching the flask-react-app pattern. Ostorlab inputs default to `''` so binary scanning is a no-op until binary paths are passed (which requires Fastlane lane separation as a follow-up).