### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/deploy_android_preview/action.yml
+++ b/.github/actions/deploy_android_preview/action.yml
@@ -35,7 +35,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'
@@ -50,7 +50,7 @@ runs:
       run: yarn install --immutable
 
     - name: Set up Java 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/actions/deploy_android_production/action.yml
+++ b/.github/actions/deploy_android_production/action.yml
@@ -29,18 +29,18 @@ runs:
   using: 'composite'
   steps:
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: 17
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: 22.13.1
 
     - name: Cache node modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: '**/node_modules'
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
@@ -48,13 +48,13 @@ runs:
           ${{ runner.os }}-node-modules-
 
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
     - name: Cache Gradle Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-caches-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/actions/deploy_ios_preview/action.yml
+++ b/.github/actions/deploy_ios_preview/action.yml
@@ -60,7 +60,7 @@ runs:
       shell: bash
 
     - name: Set Node Version
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
         cache: 'yarn'
@@ -76,7 +76,7 @@ runs:
 
     - name: Cache CocoaPods
       id: pods-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ios/Pods
@@ -88,7 +88,7 @@ runs:
 
     - name: Cache SwiftPM
       id: spm-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/Library/Caches/org.swift.swiftpm
@@ -98,7 +98,7 @@ runs:
           ${{ runner.os }}-spm-
 
     - name: Cache Xcode DerivedData
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/Library/Developer/Xcode/DerivedData
         key: ${{ runner.os }}-derived-${{ hashFiles('ios/Podfile.lock', 'yarn.lock') }}
@@ -114,7 +114,7 @@ runs:
         fi
 
     - name: Set up SSH for Match
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.IOS_MATCH_DEPLOY_KEY }}
 
@@ -172,7 +172,7 @@ runs:
         RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
     
     - name: Upload .ipa artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ios-preview-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
         path: ios/build/preview/Boilerplate.ipa
@@ -182,7 +182,7 @@ runs:
 
     - name: Upload Xcode build logs
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: xcode-build-logs
         path: /Users/runner/Library/Logs/gym/*.log

--- a/.github/actions/deploy_ios_production/action.yml
+++ b/.github/actions/deploy_ios_production/action.yml
@@ -57,12 +57,12 @@ runs:
       shell: bash
 
     - name: Set Node Version
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
 
     - name: Cache node modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           **/node_modules
@@ -80,7 +80,7 @@ runs:
 
     - name: Cache CocoaPods
       id: pods-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ios/Pods
@@ -92,7 +92,7 @@ runs:
 
     - name: Cache SwiftPM
       id: spm-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/Library/Caches/org.swift.swiftpm
@@ -110,7 +110,7 @@ runs:
         fi
 
     - name: Set up SSH for Match
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.IOS_MATCH_DEPLOY_KEY }}
 
@@ -163,7 +163,7 @@ runs:
 
     - name: Upload Xcode build logs
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: xcode-build-logs
         path: /Users/runner/Library/Logs/gym/*.log

--- a/.github/actions/inject_doppler_secrets/action.yml
+++ b/.github/actions/inject_doppler_secrets/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Doppler CLI
-      uses: dopplerhq/cli-action@v3
+      uses: dopplerhq/cli-action@v4
     
     - name: Inject Doppler secrets into environment
       shell: bash

--- a/.github/actions/permanent_preview_android/action.yml
+++ b/.github/actions/permanent_preview_android/action.yml
@@ -22,13 +22,13 @@ runs:
   using: 'composite'
   steps:
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: 17
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: 22.13.1
 
@@ -37,7 +37,7 @@ runs:
       shell: bash
 
     - name: Cache node modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: '**/node_modules'
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
@@ -45,13 +45,13 @@ runs:
           ${{ runner.os }}-node-modules-
 
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
     - name: Cache Gradle Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-caches-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/actions/permanent_preview_ios/action.yml
+++ b/.github/actions/permanent_preview_ios/action.yml
@@ -42,12 +42,12 @@ runs:
       shell: bash
 
     - name: Set Node Version
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
 
     - name: Cache node modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           **/node_modules
@@ -65,7 +65,7 @@ runs:
 
     - name: Cache CocoaPods
       id: pods-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ios/Pods
@@ -77,7 +77,7 @@ runs:
 
     - name: Cache SwiftPM
       id: spm-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/Library/Caches/org.swift.swiftpm
@@ -95,7 +95,7 @@ runs:
         fi
 
     - name: Set up SSH for Match
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.ios_match_deploy_key }}
 
@@ -136,7 +136,7 @@ runs:
 
     - name: Upload Xcode build logs
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: xcode-build-logs
         path: /Users/runner/Library/Logs/gym/*.log

--- a/.github/actions/update_preview_comment/action.yml
+++ b/.github/actions/update_preview_comment/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Upsert preview PR comment
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const marker = '<!-- preview-build-links -->';

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             code:
@@ -57,7 +57,7 @@ jobs:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
       - name: sonarqube-scan-pullrequest
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@v7
         if: ${{ github.base_ref == 'main' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -17,7 +17,7 @@ jobs:
       ANDROID_FIREBASE_APP_ID: ${{ secrets.ANDROID_FIREBASE_APP_ID }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Mask service account secret
         run: echo "::add-mask::${{ secrets.ANDROID_GCP_JSON_BASE64 }}"

--- a/.github/workflows/permanent_preview.yml
+++ b/.github/workflows/permanent_preview.yml
@@ -81,7 +81,7 @@ jobs:
           android_key_password: ${{ secrets.ANDROID_KEY_PASSWORD }}
 
       - name: Upload Android artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-preview-release
           path: preview-artifacts/react-native-template-preview.apk
@@ -130,7 +130,7 @@ jobs:
           ios_match_deploy_key: ${{ secrets.IOS_MATCH_DEPLOY_KEY }}
 
       - name: Upload iOS artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-preview-release
           path: preview-artifacts/react-native-template-preview.ipa
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: preview-artifacts
           merge-multiple: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR based on title prefix
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        uses: actions/github-script@v9
         with:
           script: |
             const title = context.payload.pull_request.title;

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload Android production artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-production-release
           path: production-artifacts/react-native-template.aab
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload iOS production artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-production-release
           path: production-artifacts/react-native-template.ipa
@@ -201,7 +201,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: production-artifacts
           merge-multiple: true

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.VERSION_BUMP_APP_ID }}
           private-key: ${{ secrets.VERSION_BUMP_PRIVATE_KEY }}
@@ -30,13 +30,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           
       - name: Determine version bump
         id: bump
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,1 @@
-<enter release notes for the next version here (max 500 chars)>
+Upgrade GitHub Actions to Node.js 24 compatible versions to prevent workflow failures after the June 2026 deprecation deadline.


### PR DESCRIPTION
## Summary

Resolves #344. GitHub is deprecating Node.js 20 on all hosted runners — from **June 2, 2026** actions on Node.js 20 will be forced to Node.js 24, and Node.js 20 will be fully removed on **September 16, 2026**.

This PR upgrades all affected action pinned versions across workflows and composite actions:

| Action | From | To |
|--------|------|----|
| `actions/setup-node` | `v3` / `v4` | `v6` |
| `actions/cache` | `v4` | `v5` |
| `actions/setup-java` | `v3` / `v4` | `v5` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `actions/github-script` | `v7` / commit SHA | `v9` |
| `actions/create-github-app-token` | `v1` | `v3` |
| `dopplerhq/cli-action` | `v3` | `v4` |
| `webfactory/ssh-agent` | `v0.7.0` | `v0.10.0` |
| `dorny/paths-filter` | `v3` | `v4` |
| `sonarsource/sonarqube-scan-action` | `master` | `v7` |
| `actions/checkout` (clean.yml) | `v3` | `v4` |

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

## Additional Context

All upgrades use the latest available major version tag confirmed via GitHub Releases API. `ruby/setup-ruby@v1`, `timheuer/base64-to-file@v1`, `gradle/actions/setup-gradle@v4`, docker actions, `aquasecurity/trivy-action`, and `Ostorlab/ostorlab_actions` are already at their latest versions and were left unchanged.