### PR TITLE
chore(ci): disable android and ios deployments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
 
   release_notes_check:
     needs: changes
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && (needs.changes.outputs.android == 'true' || needs.changes.outputs.ios == 'true')
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false'
     runs-on: ubuntu-latest
     outputs:
       release_notes: ${{ steps.check.outputs.release_notes }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
 
   release_notes_check:
     needs: changes
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false'
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && (needs.changes.outputs.android == 'true' || needs.changes.outputs.ios == 'true')
     runs-on: ubuntu-latest
     outputs:
       release_notes: ${{ steps.check.outputs.release_notes }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,7 +123,7 @@ jobs:
           echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
   deploy_android:
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && needs.changes.outputs.android == 'true'
+    if: false
     needs: [changes, release_notes_check, scan_android]
     runs-on: ubuntu-latest
     permissions:
@@ -178,7 +178,7 @@ jobs:
           echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
   deploy_ios:
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && needs.changes.outputs.doc_only == 'false' && needs.changes.outputs.ios == 'true'
+    if: false
     needs: [changes, release_notes_check, scan_ios]
     runs-on: macos-15-xlarge
     timeout-minutes: 60

--- a/.github/workflows/permanent_preview.yml
+++ b/.github/workflows/permanent_preview.yml
@@ -93,6 +93,7 @@ jobs:
           echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
   build_android_permanent_preview:
+    if: false
     runs-on: ubuntu-latest
     needs: [release_notes_check, scan_android]
     steps:
@@ -139,6 +140,7 @@ jobs:
           echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
   build_ios_permanent_preview:
+    if: false
     runs-on: macos-15-xlarge
     timeout-minutes: 60
     needs: [release_notes_check, scan_ios]

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -111,6 +111,7 @@ jobs:
           echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
   deploy_android:
+    if: false
     runs-on: ubuntu-latest
     needs: [release_notes_check, scan_android]
     steps:
@@ -171,6 +172,7 @@ jobs:
           echo "**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
 
   deploy_ios:
+    if: false
     runs-on: macos-15-xlarge
     needs: [release_notes_check, scan_ios]
     timeout-minutes: 30

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,1 @@
-<enter release notes for the next version here (max 500 chars)>
+Disabled Android and iOS deployments temporarily.


### PR DESCRIPTION
## Summary

- Adds `if: false` to all Android and iOS deploy/build jobs across `cd.yml`, `production.yml`, and `permanent_preview.yml`
- Security scans and release notes checks continue to run unaffected
- Dependent publish jobs (`publish_production_release`, `publish_preview_release`) auto-skip as a result

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [ ] AI code review completed (if applicable)

## Additional Context

Deployments are being paused temporarily. To re-enable, remove the `if: false` lines from the six affected jobs.