### PR TITLE
chore: point mobile API_BASE_URL to btr.group preview host

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 
 ENVIRONMENT=development
 # This is a permanent preview URL from: https://github.com/jalantechnologies/flask-react-template
-API_BASE_URL=https://preview.flask-react-template.platform.bettrhq.com/api
+API_BASE_URL=https://preview.flask-react-template.platform.btr.group/api
 
 DD_APPLICATION_ID=6755ccc7-0bf2-443e-bd4e-8df82d66f19d
 DD_CLIENT_TOKEN=pubad56f120eb0de2c58f2c976eac4d292c

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -1,1 +1,3 @@
-<enter release notes for the next version here (max 500 chars)>
+### Domain migration
+
+- Updated the default preview `API_BASE_URL` to the new `btr.group` domain (`preview.flask-react-template.platform.btr.group`), as part of moving our primary domain from bettrhq.com to btr.group. Runtime values are still injected via Doppler; this only changes the local/preview default.


### PR DESCRIPTION
# Pull Request

## Summary

Points the mobile app's default `API_BASE_URL` at the new `btr.group` flask preview backend (`https://preview.flask-react-template.platform.btr.group/api`) as part of moving our primary domain to **btr.group**.

This is the `.env` default for local/preview builds; production and preview runtime values are overwritten by Doppler secret injection, so this only affects local defaults and fresh builds.

> Depends on flask-react-template PR (permanent preview redeployed on `btr.group` with a valid cert). Merge this **after** the flask permanent-preview host is confirmed serving on `btr.group`. Note: builds already shipped have the old URL baked in — only future builds pick this up.

## Pre-Merge Checklist

- [ ] Tests pass
- [x] Self-reviewed
- [ ] AI code review completed (if applicable)
- [ ] flask `preview.flask-react-template.platform.btr.group` confirmed live

## Additional Context

Single-line `.env` default change; no application/TS code touched (eslint scope unaffected).